### PR TITLE
fix: restore Xcp_Pag.c to the coverage report

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -26,28 +26,48 @@ result=$?
 merged=gcov_merged
 rm -rf "$merged"
 
+# The seed matters, and not only as a starting value. gcov-tool merge emits .gcda profiles and no
+# notes, so the .gcno files copied in afterwards come from this same directory, and a .gcda only
+# pairs with the .gcno of the compile that produced it. Seeding from whichever directory sorts
+# first is therefore a coin toss: XCP_PAGING_SUPPORTED is derived per test configuration, so most
+# modules compile Xcp_Pag.c away to nothing and leave a 16-byte .gcno recording no functions. That
+# is what kept Xcp_Pag.c out of the coverage report entirely. Seed from a module that instrumented
+# the most translation units instead, so the notes describe every file the merged profile covers.
+seed=
+seed_profiles=-1
+
 for d in _cffi_xcp_*/usr/project/source; do
     [ -d "$d" ] || continue
-    if [ ! -d "$merged" ]; then
-        cp -r "$d" "$merged" || exit 1
-    else
-        # Failing quietly here would leave $merged holding the first module's profile, which then
-        # gets reported as though it were the union -- the exact defect this merge exists to fix.
-        if ! gcov-tool merge "$merged" "$d" -o "$merged.tmp"; then
-            echo "test.sh: gcov-tool merge failed for $d; coverage would be one module's, not the union" >&2
-            exit 1
-        fi
-        rm -rf "$merged" && mv "$merged.tmp" "$merged" || exit 1
+    profiles=$(ls "$d"/*.gcda 2>/dev/null | wc -l)
+    if [ "$profiles" -gt "$seed_profiles" ]; then
+        seed_profiles=$profiles
+        seed=$d
     fi
 done
 
-# gcov-tool merge emits only the .gcda profiles, so pair them with the notes from any one of the
-# merged directories: every module compiles the same sources with the same flags, so the notes
-# are interchangeable and gcov accepts the pairing.
+if [ -z "$seed" ]; then
+    echo 'test.sh: no profile directories found, so no coverage can be reported' >&2
+    exit 1
+fi
+
+cp -r "$seed" "$merged" || exit 1
+
+for d in _cffi_xcp_*/usr/project/source; do
+    [ -d "$d" ] || continue
+    [ "$d" = "$seed" ] && continue
+    # Failing quietly here would leave $merged holding the seed module's profile, which then
+    # gets reported as though it were the union -- the exact defect this merge exists to fix.
+    if ! gcov-tool merge "$merged" "$d" -o "$merged.tmp"; then
+        echo "test.sh: gcov-tool merge failed for $d; coverage would be one module's, not the union" >&2
+        exit 1
+    fi
+    rm -rf "$merged" && mv "$merged.tmp" "$merged" || exit 1
+done
+
+# gcov-tool merge emits only the .gcda profiles, so restore the notes from the seed -- the one
+# directory whose stamps the merged profiles carry.
 if [ -d "$merged" ]; then
-    for d in _cffi_xcp_*/usr/project/source; do
-        [ -d "$d" ] && cp "$d"/*.gcno "$merged/" 2>/dev/null && break
-    done
+    cp "$seed"/*.gcno "$merged/" 2>/dev/null || true
 
     # One entry per translation unit in the Xcp target, written by CMake's file(GENERATE) from
     # $<TARGET_PROPERTY:Xcp,SOURCES>. Adding a source to add_library is enough; nothing here needs


### PR DESCRIPTION
`Xcp_Pag.c` has never appeared in Codecov — [confirmed on the merge commit for #2](https://app.codecov.io/gh/Sauci/Xcp/commit/508023cfe2724b30f5818cf8a9a3db1f7b39789d/tree/source?dropdown=coverage). It is not untested; it was never reported.

### Cause

`gcov-tool merge` emits `.gcda` profiles and **no notes**, so `test.sh` copies the `.gcno` files back in afterwards. A `.gcda` only pairs with the `.gcno` of the compile that produced it, and both the seed of the merge and the notes were taken from whichever module directory sorted first. That is what made the pairing work at all — and it worked for five of the six sources by accident of them being compiled everywhere.

`Xcp_Pag.c` is the exception. It is wrapped entirely in `#if (XCP_PAGING_SUPPORTED == STD_ON)`, and that define is derived per test configuration, so only **5 of 24** modules instrument it. The other 19 leave a 16-byte `.gcno` recording no functions. Sorting first picked one of those 19, so the merged `Xcp_Pag` profile was paired with notes describing nothing, and gcov answered `stamp mismatch with notes file` and produced no report.

The comment justifying this — that the notes are interchangeable "because every module compiles the same sources with the same flags" — is the assumption that is wrong. It is dropped.

### Fix

Seed the merge from the module that instrumented the most translation units, and take the notes from that same directory.

### Evidence

The other five sources report **byte-identical** percentages before and after, so the new seed does not perturb the existing numbers — it only adds the missing file:

| source | before | after |
|:---|:---|:---|
| `Xcp.c` | 98.49% of 398 | 98.49% of 398 |
| `Xcp_Std.c` | 99.31% of 432 | 99.31% of 432 |
| `Xcp_Cal.c` | 100.00% of 100 | 100.00% of 100 |
| `Xcp_Pag.c` | **absent** | **98.93% of 187** |
| `Xcp_Daq.c` | 98.52% of 271 | 98.52% of 271 |
| `Xcp_DaqRuntime.c` | 100.00% of 102 | 100.00% of 102 |

Full clean run from an empty build directory: 12439 passed, 30 skipped, and `test.sh` now emits no "no coverage report for ..." warning. All six `.gcov` files reach the Codecov upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
