### PR TITLE
chore: SP2b hygiene — prune stale modules, unblock multi-config, correct the design doc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,17 @@ if(XCP_CONFIG_N_CONFIGURATIONS GREATER 0)
         if(NOT XCP_CFG_TIMESTAMP_ERROR)
             set(XCP_DAQ_TIMESTAMP_SUPPORTED_DERIVED ON)
 
+            # This branch, and so the BYTE/WORD/DWORD -> 1/2/4 mapping inside it, is unexercised by
+            # the test suite as shipped: XCP_CFG_TIMESTAMP_ERROR is set for every element of
+            # config/xcp.json's own "configurations", which declares no protocol_layer.timestamp
+            # block, so XCP_CFG_TIMESTAMP_ERROR is always truthy here and this body never runs --
+            # confirmed by changing WORD's 2 to 3, which the suite does not catch. It is still
+            # needed: an integrator who adds a protocol_layer.timestamp block to their own
+            # -DXCP_CONFIG_FILEPATH (or grows one into config/xcp.json) exercises it for real, and
+            # its result reaches the actual build through XCP_DAQ_TIMESTAMP_SIZE's
+            # target_compile_definitions below. Kept, not deleted; see also
+            # script/header_cfg.h.jinja2's copy of this same mapping, unexercised the same way for
+            # the same reason.
             if(XCP_CFG_TIMESTAMP_SIZE STREQUAL "BYTE")
                 set(XCP_CFG_TIMESTAMP_WIRE_SIZE 1)
             elseif(XCP_CFG_TIMESTAMP_SIZE STREQUAL "WORD")

--- a/docs/superpowers/sp2b-followups.md
+++ b/docs/superpowers/sp2b-followups.md
@@ -129,6 +129,30 @@ then the variant count is partly an artifact of how long the build directory has
   both probe tests pass a single configuration, and in the compiled two-configuration module the
   harness's `-D` pre-empts the header's blocks.
 
+
+## Resolved by the AUTOSAR specification — `Xcp_CanIfRxIndication` reentrancy
+
+Carried for the whole of SP2b as an open question: whether `Xcp_CanIfRxIndication` can preempt
+itself and race `cto_response`, `last_pid` and the protection-status clear for every CTO command.
+
+**SWS_Xcp_00813** settles it. `Xcp_<Lo>RxIndication` is specified as:
+
+> Reentrancy: **Reentrant for different PduIds. Non reentrant for the same PduId.**
+
+Every CTO command in this module arrives on exactly one PduId —
+`Xcp_Ptr->config->communicationChannel->channel_rx_pdu_ref->id` (`source/Xcp.c`, the first test in
+the function). CanIf therefore guarantees it will not re-enter the function for that PduId while a
+call is in progress, so the CTO request state cannot be raced. **No exclusive area is needed, and
+the module is conformant as written.** `Xcp_<Lo>TxConfirmation` (SWS_Xcp_00817) and
+`Xcp_<Lo>TriggerTransmit` (SWS_Xcp_00835) carry the identical clause.
+
+**This closes for today, not forever.** A *different* PduId may preempt, and the DAQ_STIM receive
+PDUs are different PduIds. Today that branch only sets `valid_pdu_id` and touches no shared CTO
+state, so nothing races. SP3 implements stimulation reception on exactly those PduIds — if its
+handler touches `cto_response`, the DAQ pointer, or the runtime mode bits, it will be able to
+preempt a CTO command in progress, and the question becomes live with a real answer required.
+Record this in SP3's design rather than rediscovering it.
+
 ## Infrastructure
 
 `test.sh` should prune stale `_cffi_xcp_*` module directories **at the start of a run**, before

--- a/docs/superpowers/sp2b-followups.md
+++ b/docs/superpowers/sp2b-followups.md
@@ -213,3 +213,55 @@ branch or is recorded here because it did not.
   configuration[BYTE-ONE_BYTE-1]` — each passing on an immediate re-run of the same selection. Same
   signature as the five recorded under *Infrastructure* above; the stale `_cffi_xcp_*` prune is still
   the fix.
+
+---
+
+# SP2b hygiene pass, `chore/sp2b-hygiene`
+
+Four items picked out of the ~36 above because each compounds with the next sub-project or costs
+time on every test run. Closed here; left in place above rather than deleted, so the record before
+and after stays traceable. The other ~32 items are untouched.
+
+## Closed
+
+- **Infrastructure: `test.sh` prunes stale `_cffi_xcp_*` module directories at the start of a run,
+  before `cmake`.** Verified on this branch's own `build/`, which had accumulated 1600 such
+  directories (188 MB) from prior work: the first run after the fix pruned all of them before
+  compiling, and coverage still reported all six translation units (`Xcp.c`, `Xcp_Std.c`,
+  `Xcp_Cal.c`, `Xcp_Pag.c`, `Xcp_Daq.c`, `Xcp_DaqRuntime.c`). A second run immediately afterward
+  left the module count unchanged — 1604 both times, not 3208 — and reported byte-identical merge
+  group sizes for every source, which is the direct evidence that pruning keeps the count bounded
+  across repeated runs instead of letting it accumulate. `.gcda` accumulation across runs is fixed
+  by the same change, for the same reason: every module, `.gcda` included, is rebuilt fresh.
+- **`Xcp_DtoFrameStrideCheck` (`script/source_rt.c.jinja2`) now asserts `XCP_MAX_DTO >=` this
+  configuration's `max_dto`, not `==`.** A new test,
+  `daq_configuration_test.py::test_a_multi_configuration_build_with_differing_max_dto_compiles_and_behaves`,
+  builds a two-configuration file (`max_dto` 8 and 64) and was confirmed, by temporarily reverting
+  the relation, to fail exactly as described (`error: size of array 'Xcp_DtoFrameStrideCheck00' is
+  negative`) under `==` and to compile and correctly transmit a bounded frame under `>=`.
+- **Two of the wire-size table's eight copies are structurally dead** — `CMakeLists.txt`'s
+  `XCP_CFG_TIMESTAMP_SIZE` derivation and `script/header_cfg.h.jinja2`'s `wire_size` dict — both
+  unexercised while `config/xcp.json` declares no `timestamp` block, and the header's copy also
+  permanently pre-empted by `test/conftest.py`'s own `-D` override inside the test harness. Neither
+  is deletable: each is the only implementation for a case a differently-configured
+  `XCP_CONFIG_FILEPATH` would genuinely exercise, so each now carries a comment naming exactly why
+  it is unexercised and what would exercise it, rather than sitting there silently. Separately,
+  `test/parameter.py`'s `timestamp_type_name` (zero consumers, confirmed repository-wide) is
+  deleted outright, and the live duplicate copies in `test/conftest.py`,
+  `test/daq_configuration_test.py` and `test/daq_identification_field_test.py` are collapsed onto
+  `test/parameter.py`'s `timestamp_wire_size`. The address-granularity family's own copies
+  (`test/upload_test.py`, `test/truncated_frame_test.py`) are a different table and were left
+  alone, as scoped. The full JSON-table consolidation remains out of scope.
+- **The design doc is corrected against the shipped code.** §5.2's `WRITE_DAQ` overfill row said
+  `ERR_OUT_OF_RANGE`; `Xcp_DaqApplyOdtEntry` (`source/Xcp_Daq.c`) has always answered
+  `ERR_DAQ_CONFIG` there (§1.7.3.2.4 lists that code for `WRITE_DAQ`, and
+  `write_daq_test.py::test_write_daq_respects_the_budget_the_timestamp_leaves_in_odt_zero` pins it
+  for this exact reduced-budget case). §7.1 said a `WRITE_DAQ_MULTIPLE` length/`n` disagreement
+  answers `ERR_OUT_OF_RANGE`; `Xcp_DTOCmdDaqWriteDaqMultiple` answers `ERR_CMD_SYNTAX` there — the
+  ODT-border-crossing case the same paragraph also describes does answer `ERR_OUT_OF_RANGE`, and
+  was left as written. Both corrections are marked inline in the document as corrections, matching
+  its existing convention, rather than silently rewritten.
+
+Not touched: the ~32 other items above, SP2c/SP2d/SP3 territory, the `Xcp_CanIfRxIndication`
+self-reentrancy question, and the coverage-measures-one-variant limitation — all deliberately out
+of scope for this pass.

--- a/docs/superpowers/specs/2026-08-29-xcp-part2-roadmap.md
+++ b/docs/superpowers/specs/2026-08-29-xcp-part2-roadmap.md
@@ -349,6 +349,20 @@ master.
 STIM reception in `Xcp_CanIfRxIndication`, `DAQ_STIM` and `STIM` event channel types.
 Depends on SP2 for the DAQ list infrastructure it reuses wholesale.
 
+**Concurrency question SP3 must answer, found in SP2b.** SWS_Xcp_00813 specifies
+`Xcp_<Lo>RxIndication` as *"Reentrant for different PduIds. Non reentrant for the same PduId."*
+Every CTO command reaches the module on one PduId — `channel_rx_pdu_ref->id` — so CanIf's own
+contract prevents a CTO from racing itself, and no exclusive area guards `cto_response`, `last_pid`
+or the protection-status clear today.
+
+**STIM breaks that.** DAQ_STIM receive PDUs are *different* PduIds, so a stimulation indication may
+preempt a CTO command mid-dispatch. The branch that will host it already exists in
+`Xcp_CanIfRxIndication` and today only sets `valid_pdu_id`, touching nothing shared. The moment
+SP3's handler touches the response buffer, the DAQ pointer, the runtime mode bits or the DTO ring,
+the race is real and needs an exclusive area around the busy-check/dispatch/set-flag sequence —
+which affects all 256 PID entries and is a design decision, not an implementation detail.
+Settle it in SP3's design; do not discover it in review.
+
 ### SP4 — Non-volatile memory programming (PGM)
 
 The eleven PGM commands and their integrator callbacks. Independent of SP2 and SP3;

--- a/docs/superpowers/specs/2026-09-02-xcp-daq-sp2b-design.md
+++ b/docs/superpowers/specs/2026-09-02-xcp-daq-sp2b-design.md
@@ -240,8 +240,16 @@ configures a list, so both orders are enforced:
 
 | Order | Check | Error |
 |:--|:--|:--|
-| `WRITE_DAQ` into ODT 0 of a list already timestamped | the existing `Xcp_OdtUsedBytes + size > budget` test, with the reduced budget | `ERR_OUT_OF_RANGE` |
+| `WRITE_DAQ` into ODT 0 of a list already timestamped | the existing `Xcp_OdtUsedBytes + size > budget` test, with the reduced budget | `ERR_DAQ_CONFIG` |
 | `SET_DAQ_LIST_MODE` enabling `TIMESTAMP` | `Xcp_OdtUsedBytes(list, 0, none) > reduced budget` | `ERR_OUT_OF_RANGE` |
+
+*Corrected in the SP2b hygiene pass.* This row previously said `ERR_OUT_OF_RANGE`. The check
+`WRITE_DAQ` shares with every other overfill (DD8, `Xcp_DaqApplyOdtEntry` in `source/Xcp_Daq.c`) has
+always answered `ERR_DAQ_CONFIG`; the timestamp-reduced budget is a smaller threshold for the same
+comparison, not a different one, so it inherits the same error rather than introducing
+`ERR_OUT_OF_RANGE` alongside it. §1.7.3.2.4 lists `ERR_DAQ_CONFIG` for `WRITE_DAQ`, and
+`write_daq_test.py`'s `test_write_daq_respects_the_budget_the_timestamp_leaves_in_odt_zero` pins it
+for exactly this reduced-budget case.
 
 `ERR_OUT_OF_RANGE` is listed for `SET_DAQ_LIST_MODE` in §1.7.3.2.4, and its prescribed master action
 — "retry other parameter" — is exactly the recovery available: drop an entry, or leave the timestamp
@@ -327,9 +335,18 @@ Request: `2 + n*8` bytes. Byte 1 is `n`; each element is `BIT_OFFSET`, size, add
 extension, and a **mandatory** alignment dummy — including after the last element.
 
 Beyond `WRITE_DAQ`'s restrictions, inherited via the shared helper (DD21): all entries must land in
-one ODT, and the command must not write over an ODT border. A request whose length disagrees with
-`n`, or whose `n` would cross the ODT's entry count, answers `ERR_OUT_OF_RANGE`. Partial application
-stands on error (DD22).
+one ODT, and the command must not write over an ODT border. A request whose `n` would cross the
+ODT's entry count answers `ERR_OUT_OF_RANGE`, from the shared helper's own pointer-validity check
+(the same one a second `WRITE_DAQ` past the border trips). A request whose length disagrees with `n`
+answers `ERR_CMD_SYNTAX`, checked before any entry is applied. Partial application stands on error
+(DD22).
+
+*Corrected in the SP2b hygiene pass.* This paragraph previously prescribed `ERR_OUT_OF_RANGE` for
+both. `Xcp_DTOCmdDaqWriteDaqMultiple` (`source/Xcp_Daq.c`) checks the request's `SduLength` against
+`2 + n*8` before entering the per-entry loop and answers `ERR_CMD_SYNTAX` on a mismatch; only the
+ODT-border case reaches the shared helper and its `ERR_OUT_OF_RANGE`. Defensible either way — 1.1
+does not itself say which applies to a malformed `WRITE_DAQ_MULTIPLE` request — so the document is
+corrected to match the shipped behaviour rather than the reverse.
 
 Read from the 1.1 OCR, which is degraded here; the implementation must confirm the element stride
 of 8 bytes and the trailing dummy against the PDF page images.

--- a/script/gcov_union.py
+++ b/script/gcov_union.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""Union multiple .gcov reports for the SAME source file into one merged report.
+
+Background
+----------
+test.sh's coverage block compiles this project's DUT sources once per distinct test
+configuration. A build-time macro (XCP_DAQ_TIMESTAMP_SUPPORTED, XCP_PAGING_SUPPORTED, and so on)
+gates functions in or out of a translation unit, so different configurations produce structurally
+different compiles of the same source file -- different .gcno graphs that gcov-tool cannot merge
+at the profile level (see the comment above the coverage block in test.sh for the full story of
+why, and what was tried before this).
+
+What CAN be combined is the human-readable .gcov *text* those structurally different compiles
+produce: gcov keys every line of that text to a physical source line number, and line N in one
+compile's report is the same source line as line N in another's, whether or not that particular
+compile instrumented it. This module unions per-variant reports line by line:
+
+    * if one or more variants report a numeric hit count for a line, the merged count is the SUM
+      of every numeric count reported for that line -- a line hit twice in one variant's tests and
+      three times in another's was hit five times across the two;
+    * otherwise, if one or more variants report '#####' (instrumented, never executed), the merged
+      line is instrumented-but-uncovered;
+    * otherwise no variant instrumented the line at all, so it stays '-'.
+
+Callers are expected to pass reports for groups that partition a disjoint set of test-config
+modules (test.sh's per-file .gcno content hash does exactly that), so this is a true union, not an
+approximation: no module is counted twice, and every module that ever compiled the file in
+question contributes to the total.
+
+A numeric count can carry a trailing '*' (e.g. '132*'): gcov's own plain-text output appends it,
+with no extra flag needed to request it, whenever a line compiles to more than one basic block
+(a ternary, a short-circuit && / ||, ...) and at least one of those blocks never ran, even though
+the line as a whole shows a nonzero count. Summing the digits and dropping the '*' whenever ANY
+contributing variant reports the line unstarred is deliberate, not an approximation: an unstarred
+count from even one variant is that variant's own proof every block on the line ran at least once
+in its tests, and since it is the same source line -- same code, same block decomposition -- that
+proof carries over to the union. Only when every variant that has a numeric count for the line
+also has the '*' is there no such proof to fall back on, so the union conservatively keeps it
+rather than assume blocks the data does not show were ever exercised together.
+
+A line whose source text disagrees between two inputs at the same line number is refused rather
+than silently resolved one way or another -- that almost certainly means the inputs are reports
+for two different source files, and a merger that produces a plausible-looking wrong number is
+worse than one that refuses to guess (see the module's own tests for why this matters as much as
+the arithmetic does).
+"""
+
+import argparse
+import sys
+from typing import Dict, List, Optional, Sequence, Tuple
+
+HEADER_LINENO = "0"
+NOT_INSTRUMENTED = "-"
+NEVER_EXECUTED = "#####"
+
+
+class GcovUnionError(Exception):
+    """Raised when inputs cannot be unioned honestly (e.g. mismatched sources or line text)."""
+
+
+def _split_gcov_line(line: str) -> Tuple[str, str, str]:
+    # gcov's own field widths vary by file (they widen to fit the largest count or line number
+    # present), so splitting on fixed columns is not safe -- only the count-field/line-number/text
+    # tricolon structure is guaranteed. maxsplit=2 keeps the source text intact even when it
+    # itself contains ':' (a C ternary, a bitfield width, ...).
+    parts = line.split(":", 2)
+    if len(parts) != 3:
+        raise GcovUnionError(f"not a gcov line (missing ':' fields): {line!r}")
+    count_field, lineno_field, text = parts
+    return count_field.strip(), lineno_field.strip(), text
+
+
+def _parse_gcov(text: str, label: str) -> Tuple[List[str], str, Dict[int, Tuple[str, str]]]:
+    """Parse one .gcov file's content into (header lines, Source: value, {lineno: (count, text)})."""
+    header_lines: List[str] = []
+    body: Dict[int, Tuple[str, str]] = {}
+    source_name: Optional[str] = None
+    for raw_line in text.splitlines():
+        if raw_line == "":
+            continue
+        count_field, lineno_field, line_text = _split_gcov_line(raw_line)
+        if lineno_field == HEADER_LINENO:
+            header_lines.append(raw_line)
+            if line_text.startswith("Source:"):
+                source_name = line_text[len("Source:"):]
+            continue
+        try:
+            lineno = int(lineno_field)
+        except ValueError:
+            raise GcovUnionError(f"{label}: non-numeric line number {lineno_field!r}")
+        if lineno in body:
+            raise GcovUnionError(f"{label}: duplicate line number {lineno}")
+        body[lineno] = (count_field, line_text)
+    if source_name is None:
+        raise GcovUnionError(f"{label}: no 'Source:' header line found")
+    return header_lines, source_name, body
+
+
+def _merge_count_fields(fields: Sequence[str]) -> str:
+    numeric_total = None
+    any_starred = False
+    any_unstarred = False
+    saw_never_executed = False
+    for field in fields:
+        if field == NOT_INSTRUMENTED:
+            continue
+        if field == NEVER_EXECUTED:
+            saw_never_executed = True
+            continue
+        starred = field.endswith("*")
+        digits = field[:-1] if starred else field
+        try:
+            value = int(digits)
+        except ValueError:
+            raise GcovUnionError(f"not a gcov count field: {field!r}")
+        numeric_total = value if numeric_total is None else numeric_total + value
+        if starred:
+            any_starred = True
+        else:
+            any_unstarred = True
+    if numeric_total is not None:
+        # See the module docstring: '*' survives the merge only when every numeric contributor
+        # carried one -- a single unstarred contributor is proof the line's blocks all ran
+        # somewhere in the suite, and that proof does not un-happen because another variant's
+        # own tests did not also cover them.
+        suffix = "*" if (any_starred and not any_unstarred) else ""
+        return f"{numeric_total}{suffix}"
+    if saw_never_executed:
+        return NEVER_EXECUTED
+    return NOT_INSTRUMENTED
+
+
+def union_gcov_texts(texts: Sequence[str], labels: Optional[Sequence[str]] = None) -> str:
+    """Union N .gcov file contents (per-variant reports for the same source) into one report.
+
+    Inputs need not cover the same set of line numbers (a variant's report is free to be shorter
+    or longer than another's); every line number that appears in at least one input appears in the
+    output. Inputs that do share a line number must agree on its source text, or this raises
+    GcovUnionError rather than silently picking one -- see the module docstring.
+    """
+    if not texts:
+        raise GcovUnionError("no .gcov inputs given")
+    if labels is None:
+        labels = [f"input {i + 1}" for i in range(len(texts))]
+    elif len(labels) != len(texts):
+        raise GcovUnionError("labels and texts must be the same length")
+
+    parsed = [_parse_gcov(t, label) for t, label in zip(texts, labels)]
+    header_lines, source_name, _ = parsed[0]
+
+    for (_, name, _body), label in zip(parsed[1:], labels[1:]):
+        if name != source_name:
+            raise GcovUnionError(
+                "refusing to union .gcov reports for different sources: "
+                f"{labels[0]} is {source_name!r}, {label} is {name!r}")
+
+    all_linenos = sorted(set().union(*(body.keys() for _, _, body in parsed)))
+
+    out_lines = list(header_lines)
+    for lineno in all_linenos:
+        entries = [body[lineno] for _, _, body in parsed if lineno in body]
+        texts_at_line = {entry_text for _, entry_text in entries}
+        if len(texts_at_line) > 1:
+            raise GcovUnionError(
+                f"line {lineno} has different source text across inputs -- refusing to union "
+                f"what may not be the same file: {sorted(texts_at_line)!r}")
+        merged_count = _merge_count_fields([count for count, _ in entries])
+        line_text = entries[0][1]
+        out_lines.append(f"{merged_count:>9}:{lineno:>5}:{line_text}")
+    return "\n".join(out_lines) + "\n"
+
+
+def coverage_summary(merged_text: str) -> Tuple[int, int]:
+    """Return (executed, instrumented) line counts from a merged .gcov text."""
+    executed = 0
+    instrumented = 0
+    for raw_line in merged_text.splitlines():
+        if raw_line == "":
+            continue
+        count_field, lineno_field, _ = _split_gcov_line(raw_line)
+        if lineno_field == HEADER_LINENO:
+            continue
+        if count_field == NOT_INSTRUMENTED:
+            continue
+        instrumented += 1
+        if count_field != NEVER_EXECUTED:
+            executed += 1
+    return executed, instrumented
+
+
+def source_name(merged_text: str) -> str:
+    for raw_line in merged_text.splitlines():
+        if raw_line == "":
+            continue
+        _, lineno_field, text = _split_gcov_line(raw_line)
+        if lineno_field == HEADER_LINENO and text.startswith("Source:"):
+            return text[len("Source:"):]
+    raise GcovUnionError("merged text has no 'Source:' header line")
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__,
+                                      formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("-o", "--output", required=True,
+                         help="path to write the merged .gcov report to")
+    parser.add_argument("inputs", nargs="+",
+                         help="per-variant .gcov reports for the same source, in any order")
+    args = parser.parse_args(argv)
+
+    texts = []
+    for path in args.inputs:
+        with open(path, "r") as fh:
+            texts.append(fh.read())
+
+    try:
+        merged = union_gcov_texts(texts, labels=args.inputs)
+    except GcovUnionError as exc:
+        print(f"gcov_union.py: {exc}", file=sys.stderr)
+        return 1
+
+    with open(args.output, "w") as fh:
+        fh.write(merged)
+
+    executed, instrumented = coverage_summary(merged)
+    pct = (100.0 * executed / instrumented) if instrumented else 0.0
+    # Mirrors gcov's own informational stdout (`File '<name>'` / `Lines executed:NN.NN% of NNN`)
+    # so this drop-in replacement for running gcov on a single variant reads the same way in the
+    # test.sh console output.
+    print(f"File '{source_name(merged)}'")
+    print(f"Lines executed:{pct:.2f}% of {instrumented}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/script/header_cfg.h.jinja2
+++ b/script/header_cfg.h.jinja2
@@ -65,6 +65,22 @@
 {%- for configuration in configurations %}
 {%- set ts = configuration.protocol_layer.timestamp %}
 {%- if ts is defined and ts %}
+{#- Only the DWORD entry below is independently confirmed correct. daq_configuration_test.py's
+    test_the_generated_header_is_authoritative_for_the_macros_it_derives preprocesses this
+    generated header alone, with no compile definitions, and is the only test that reads what this
+    block emits rather than what pre-empts it: every other test's handle.define() reads the
+    *effective* XCP_DAQ_TIMESTAMP_SIZE after test/conftest.py's own -D override (computed from
+    parameter.py's timestamp_wire_size, not from this dict), because conftest.py passes that -D to
+    every module it compiles, including the one built from this header, and it always wins the
+    #ifndef race below. Changing this dict's BYTE or WORD entry would not fail any test today.
+
+    Nor does the one build where this header's #define is NOT pre-empted help for BYTE/WORD:
+    generated/CMakeLists.txt's Xcp_Cfg library target compiles Xcp_Cfg.c against Xcp_Cfg.h with no
+    matching -D, but this whole branch is unreachable there anyway while config/xcp.json declares
+    no protocol_layer.timestamp -- the same reason CMakeLists.txt's own copy of this mapping is
+    unexercised (see the comment there). Extending the probe test above to BYTE and WORD, or giving
+    a configuration in XCP_CONFIG_FILEPATH a timestamp block, would exercise what changing those two
+    entries cannot today. #}
 {%- set wire_size = {'BYTE': 1, 'WORD': 2, 'DWORD': 4}[ts.size] %}
 {%- if wire_size > daq_timestamp_size.value %}
 {%- set daq_timestamp_size.value = wire_size %}

--- a/script/source_rt.c.jinja2
+++ b/script/source_rt.c.jinja2
@@ -41,8 +41,15 @@ static Xcp_DaqListRtType Xcp_DaqListRt{{'%02X' % loop.index0}}[{{'0x%02Xu' % con
 
 /* XCP_MAX_DTO reaches this module as a compile definition, so a mismatch between it and the
  * value this runtime was generated for would silently change the stride of the array below.
- * A negative array size turns that into a compile error instead. */
-typedef char Xcp_DtoFrameStrideCheck{{'%02X' % loop.index0}}[(XCP_MAX_DTO == {{'0x%02Xu' % configuration.protocol_layer.max_dto}}) ? 1 : -1];
+ * A negative array size turns that into a compile error instead.
+ *
+ * >=, not ==: XCP_MAX_DTO is a max() fold over every configuration in the generated file
+ * (script/header_cfg.h.jinja2), one macro sizing Xcp_DtoFrameType.data[] for every configuration
+ * compiled into this module, not just this one. A configuration whose own max_dto is smaller than
+ * another configuration's in the same file is correctly sized by the larger, shared stride --
+ * requiring equality failed a multi-configuration build the moment two configurations' max_dto
+ * disagreed, even though every frame remained large enough. */
+typedef char Xcp_DtoFrameStrideCheck{{'%02X' % loop.index0}}[(XCP_MAX_DTO >= {{'0x%02Xu' % configuration.protocol_layer.max_dto}}) ? 1 : -1];
 
 static Xcp_DtoFrameType Xcp_DtoFrame{{'%02X' % loop.index0}}[{{'0x%02Xu' % (configuration.protocol_layer.daq_queue_size | default(16))}}];
 

--- a/source/Xcp.c
+++ b/source/Xcp.c
@@ -1305,6 +1305,15 @@ void Xcp_CanIfRxIndication(PduIdType rxPduId, const PduInfoType *pPduInfo)
                 for (daq_idx = 0x00u; daq_idx < Xcp_Ptr->general->daqCount; daq_idx++)
                 {
                     /* Then, we check if the received PDU ID is one which has been configured for a DAQ stimulation. */
+                    /* SP3, read this before adding a stimulation handler here. SWS_Xcp_00813 makes
+                     * Xcp_<Lo>RxIndication "Reentrant for different PduIds. Non reentrant for the
+                     * same PduId." Every CTO arrives on channel_rx_pdu_ref->id, so CanIf itself
+                     * prevents a CTO from racing another CTO -- which is why nothing below guards
+                     * Xcp_Internal.cto_response, last_pid or the protection-status clear. A DAQ_STIM
+                     * PDU is a DIFFERENT PduId and may therefore preempt a CTO mid-dispatch. This
+                     * branch is safe only because it sets a local flag and touches no shared state.
+                     * A handler that writes the response buffer, the DAQ pointer, the runtime mode
+                     * bits or the DTO ring makes that race real. */
                     if ((Xcp_Ptr->config->daqList[daq_idx].type == STIM) ||
                         (Xcp_Ptr->config->daqList[daq_idx].type == DAQ_STIM))
                     {

--- a/test.sh
+++ b/test.sh
@@ -4,6 +4,22 @@ result=0
 mkdir -p build
 cd build || exit 1
 
+# _cffi_xcp_* module directories (test/conftest.py's MockGen) accumulate without bound across
+# runs that reuse this build/ directory -- they reached 3017 directories (307 MB) against this
+# container's 1024 file-descriptor limit during one sub-project, and are the documented common
+# cause of transient pycparser/PLY, Jinja2 template-compilation and CFFI/distutils failures, each
+# non-reproducing and each costing a full run. They also hold the .gcda profiles the coverage
+# merge below reads, and gcov accumulates a binary's execution counts across runs rather than
+# overwriting them, so leaving old modules in place makes the reported coverage cumulative since
+# whenever build/ was last removed by hand, not a measurement of this run alone -- a deleted
+# test's coverage keeps counting.
+#
+# Pruning here, before cmake/ctest regenerate what this run actually needs, fixes both: the
+# modules are keyed by a content digest and rebuilt on demand (test/conftest.py's MockGen), so
+# removing them is safe. This cannot move to the end of the script instead: the coverage merge
+# below depends on the modules THIS run creates still being present once ctest finishes.
+rm -rf _cffi_xcp_*
+
 # A configure or build failure has to fail this script, and so does an empty test run: a branch
 # that does not compile must not report a green build having run nothing. --no-tests=error makes
 # ctest itself exit non-zero when no tests are registered, so a branch that does not compile is

--- a/test.sh
+++ b/test.sh
@@ -37,7 +37,7 @@ result=$?
 # module's, not the union. Merge the profiles first, then run gcov on the merged set.
 #
 # The merge has to be done per source file, not once with a single seed for the whole tree (the
-# previous fix, made for Xcp_Pag.c). A build-time macro -- XCP_DAQ_TIMESTAMP_SUPPORTED,
+# first fix here, made for Xcp_Pag.c). A build-time macro -- XCP_DAQ_TIMESTAMP_SUPPORTED,
 # XCP_PAGING_SUPPORTED, and so on -- gates functions in or out of a translation unit, so
 # different test configurations compile some sources into genuinely different .gcno graphs.
 # gcov-tool merge has no way to combine two of those: it does not error when asked to, it just
@@ -49,29 +49,32 @@ result=$?
 # outright, reporting 0.00%. Xcp_DaqRuntime.c has the same two-variant split and was reporting
 # 100% -- not because it merged correctly, but because the seed's variant happened to win.
 #
-# So: group each file's notes by content across every module that has them, and merge only the
-# largest group. That is a real cost, not a free generalisation -- the reported coverage is the
-# union across one compilation variant, not across every variant the suite exercises -- but it
-# is the best gcov can do, since there is no tool-level way to combine profiles from
-# structurally different compilations. An honest majority-variant figure beats a silent 0%.
+# The second fix grouped each file's notes by content across every module that has them, and
+# merged only the largest group -- an honest majority-variant figure instead of a silent 0%, but
+# still a real cost: every OTHER group had compiled a structurally different, equally real version
+# of the file, and its coverage was discarded outright, not folded in. Most test configurations
+# declare no protocol_layer.timestamp block, so the largest group for both Xcp_Daq.c and
+# Xcp_DaqRuntime.c was the timestamp-DISABLED compilation -- and every line inside
+# #if (XCP_DAQ_TIMESTAMP_SUPPORTED == STD_ON) showed as '-', not compiled, rather than as
+# uncovered. Xcp_DaqRuntime.c reported 100.00% that way: 100% of a compilation that contained none
+# of the timestamp feature. It also degraded with every new build-time guard: each one splits the
+# modules into more groups, the largest group shrinks, and more real code falls outside the number.
 #
-# Read every percentage this loop prints as "one variant's coverage", never as the suite's. The
-# cost is larger than the paragraph above makes it sound, in two ways worth stating outright.
-#
-# The winning variant is the majority one, which is not the same as the complete one. Most test
-# configurations declare no protocol_layer.timestamp block, so the largest group for both
-# Xcp_Daq.c and Xcp_DaqRuntime.c is the timestamp-DISABLED compilation -- and every line inside
-# #if (XCP_DAQ_TIMESTAMP_SUPPORTED == STD_ON) then shows as '-', not compiled, rather than as
-# uncovered. Xcp_DaqRuntime.c reports 100.00% that way: 100% of a compilation that contains none
-# of the timestamp feature. A clean-looking figure here is not evidence that a feature is covered;
-# it may be evidence that the feature was compiled out of the variant being measured.
-#
-# Nor is the byte size a reliable proxy for completeness: more than one macro gates these files
-# (XCP_PAGING_SUPPORTED as well as the two timestamp ones), so a larger .gcno does not mean the
-# feature you care about is in it. Size is an identity, not a ranking. That is all the line below
-# uses it for: two runs whose percentages agree may not have measured the same code, and the size
-# is what says so. The variant count beside it says how much coverage exists that no selection
-# rule here can fold in -- anything above 1 is real coverage left on the floor.
+# gcov-tool still cannot merge structurally different groups' profiles into each other -- that is
+# a property of the .gcno/.gcda binary format, not something this script can work around, and the
+# grouping above still exists to identify those groups. What does not follow is that the other
+# groups have to be thrown away. gcov's own .gcov *text* output keys every line to a physical
+# source line number, and that number means the same thing regardless of which group produced it:
+# line N in a timestamp-OFF compile's report and line N in a timestamp-ON compile's report
+# describe the same line of Xcp_DaqRuntime.c, instrumented or not. So: group each file's notes by
+# content as before, but run gcov on EVERY group instead of only the largest, and union the
+# resulting per-group .gcov reports line by line (script/gcov_union.py, invoked below) -- summing
+# a line's hit count across every group that has one, falling back to '#####' if some group
+# instrumented the line without ever executing it, and to '-' only if no group instrumented it at
+# all. Groups partition the usable modules (each module's .gcno hashes into exactly one group), so
+# this sums a line's counts over every test configuration that ever compiled the file -- an actual
+# union, not an approximation of one, because gcov's line-keyed text is exactly the granularity
+# gcov-tool's binary merge cannot see.
 merged=gcov_merged
 rm -rf "$merged"
 mkdir -p "$merged" || exit 1
@@ -133,70 +136,110 @@ while read -r source; do
         continue
     fi
 
-    # The largest group of modules that compiled this file identically -- the closest thing to
-    # "coverage across the whole suite" that gcov can combine. Every other group compiled a
-    # structurally different version of this file; its coverage is real but cannot be folded in.
-    top=$(awk '{print $1}' "$hashes_file" | sort | uniq -c | sort -k1,1nr | awk 'NR==1{print $2}')
-    group_file="$merged.group"
-    awk -v h="$top" '$1==h{print $2}' "$hashes_file" > "$group_file"
-    group_size=$(wc -l < "$group_file")
     total_usable=$(wc -l < "$hashes_file")
-    # Which variant won, not just how many modules voted for it. The byte size of the winning
-    # .gcno is the only cheap handle on "which compilation of this file was measured": a smaller
-    # one means fewer functions, i.e. a build-time gate compiled part of the file away, and the
-    # percentage that follows is 100% of what was left. variants says how much was not folded in
-    # -- anything above 1 means some real coverage exists that no rule here can reach.
-    variants=$(awk '{print $1}' "$hashes_file" | sort -u | wc -l | tr -d ' ')
-    top_notes=$(head -n 1 "$group_file")
-    top_bytes=$(wc -c < "$top_notes/$notes" | tr -d ' ')
-    # Said out loud regardless of outcome, success included, so a future reader can see the
-    # trade this merge makes rather than infer it from the coverage percentage alone.
-    echo "test.sh: $f coverage is ONE variant's, not the union: merged from $group_size of $total_usable module(s) sharing a ${top_bytes}-byte $notes, of $variants variant(s) present" >&2
+    uniq_hashes="$merged.uniq"
+    awk '{print $1}' "$hashes_file" | sort -u > "$uniq_hashes"
+    variants=$(wc -l < "$uniq_hashes" | tr -d ' ')
 
-    acc="$merged.acc"
-    rm -rf "$acc"
-    base=
-    while read -r d; do
-        [ -n "$d" ] || continue
-        if [ -z "$base" ]; then
-            base=$d
-            mkdir -p "$acc" || exit 1
-            cp "$d/$stem.gcda" "$acc/" || exit 1
-            continue
+    variant_root="$merged/variants"
+    rm -rf "$variant_root"
+    mkdir -p "$variant_root" || exit 1
+
+    # One line per group that made it to a .gcov report, collected while the loop below runs so
+    # the union call after it can be a single command and the summary echo after that does not
+    # have to recompute anything.
+    gcov_list="$merged.gcovlist"
+    : > "$gcov_list"
+    summary_list="$merged.summary"
+    : > "$summary_list"
+
+    idx=0
+    while read -r hash; do
+        idx=$((idx + 1))
+        group_file="$merged.group"
+        awk -v h="$hash" '$1==h{print $2}' "$hashes_file" > "$group_file"
+        group_size=$(wc -l < "$group_file")
+
+        # Sum every module in THIS group's .gcda into one profile matching this group's (stamp
+        # aside, identical) .gcno -- gcov-tool can do that much; what it cannot do is take it
+        # further and fold that result into another group's, which compiled the file differently.
+        # Repeated per group now, not just for the one that used to be picked as "the" group.
+        acc="$merged.acc"
+        rm -rf "$acc"
+        base=
+        while read -r d; do
+            [ -n "$d" ] || continue
+            if [ -z "$base" ]; then
+                base=$d
+                mkdir -p "$acc" || exit 1
+                cp "$d/$stem.gcda" "$acc/" || exit 1
+                continue
+            fi
+            other="$merged.other"
+            rm -rf "$other" && mkdir -p "$other" || exit 1
+            cp "$d/$stem.gcda" "$other/" || exit 1
+            # Failing quietly here would leave $acc holding a partial merge, silently reported as
+            # though it were the whole group's union -- the exact defect this per-file merge exists
+            # to fix.
+            if ! gcov-tool merge "$acc" "$other" -o "$acc.tmp"; then
+                echo "test.sh: gcov-tool merge failed for $f in $d; coverage would be partial, not the group's union" >&2
+                exit 1
+            fi
+            rm -rf "$acc" && mv "$acc.tmp" "$acc" || exit 1
+        done < "$group_file"
+        rm -rf "$merged.other"
+
+        # gcov-tool merge emits only the .gcda, carrying the stamp of its first argument -- $acc,
+        # i.e. $base -- throughout the chain, so $base's own notes are the ones that still match
+        # it. Each group gets its own directory so its .gcov does not overwrite another group's.
+        vdir="$variant_root/$idx"
+        mkdir -p "$vdir" || exit 1
+        cp "$base/$notes" "$acc/" || exit 1
+        mv "$acc/$stem.gcda" "$vdir/$stem.gcda" || exit 1
+        mv "$acc/$notes" "$vdir/$notes" || exit 1
+        rm -rf "$acc"
+
+        (cd "$vdir" && gcov "$f") >/dev/null
+
+        if [ -f "$vdir/$f.gcov" ]; then
+            echo "$vdir/$f.gcov" >> "$gcov_list"
+            echo "$group_size module(s)" >> "$summary_list"
+        else
+            # Not fatal to the source as a whole: the other groups can still be unioned. An I/O
+            # hiccup in gcov itself is rare enough that losing one group's contribution is better
+            # than losing the file's coverage entirely, but it is said out loud either way.
+            echo "test.sh: no coverage report for $f from a $group_size-module group; excluded from the union" >&2
         fi
-        other="$merged.other"
-        rm -rf "$other" && mkdir -p "$other" || exit 1
-        cp "$d/$stem.gcda" "$other/" || exit 1
-        # Failing quietly here would leave $acc holding a partial merge, silently reported as
-        # though it were the whole group's union -- the exact defect this per-file merge exists
-        # to fix.
-        if ! gcov-tool merge "$acc" "$other" -o "$acc.tmp"; then
-            echo "test.sh: gcov-tool merge failed for $f in $d; coverage would be partial, not the group's union" >&2
-            exit 1
-        fi
-        rm -rf "$acc" && mv "$acc.tmp" "$acc" || exit 1
-    done < "$group_file"
-    rm -rf "$merged.other"
+    done < "$uniq_hashes"
 
-    # gcov-tool merge emits only the .gcda, carrying the stamp of its first argument -- $acc,
-    # i.e. $base -- throughout the chain, so $base's own notes are the ones that still match it.
-    cp "$base/$notes" "$acc/" || exit 1
-    mv "$acc/$stem.gcda" "$merged/$stem.gcda" || exit 1
-    mv "$acc/$notes" "$merged/$notes" || exit 1
-    rm -rf "$acc"
-
-    [ -f "$merged/$notes" ] && (cd "$merged" && gcov "$f")
-
-    if [ -f "$merged/$f.gcov" ]; then
-        cp "$merged/$f.gcov" . && echo "./build/$f.gcov" >> coverage_files.txt
-    else
-        # Not fatal: a file can still fail to produce a report even from a same-variant group
-        # (an I/O hiccup in gcov itself, say). Saying so out loud keeps the gap visible; the list
-        # this loop writes is otherwise a short list that looks complete.
+    if [ ! -s "$gcov_list" ]; then
         echo "test.sh: no coverage report for $f, so it is absent from the upload" >&2
+        continue
     fi
+
+    # $gcov_list has one path per line and none of them can contain whitespace (each is built
+    # from $f, a basename out of xcp_sources.txt, under a numbered directory this script made),
+    # so handing the substitution straight to the script as argv is safe.
+    if ! python3 ../script/gcov_union.py -o "$merged/$f.gcov" $(cat "$gcov_list"); then
+        echo "test.sh: coverage union failed for $f" >&2
+        exit 1
+    fi
+
+    summary=
+    while read -r line; do
+        if [ -z "$summary" ]; then
+            summary="$line"
+        else
+            summary="$summary; $line"
+        fi
+    done < "$summary_list"
+    echo "test.sh: $f coverage is the UNION of $variants variant(s) across $total_usable usable module(s): $summary" >&2
+
+    # gcov_union.py either wrote $merged/$f.gcov or this script already exited above, so its
+    # presence here is not conditional the way a single gcov invocation's used to be.
+    cp "$merged/$f.gcov" . && echo "./build/$f.gcov" >> coverage_files.txt
 done < xcp_sources.txt
 
-rm -f "$merged.dirs" "$merged.hashes" "$merged.group"
+rm -f "$merged.dirs" "$merged.hashes" "$merged.group" "$merged.uniq" "$merged.gcovlist" "$merged.summary"
 
 exit $result

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -18,6 +18,12 @@ from pycparser.c_generator import CGenerator as Generator
 from pycparser.c_parser import CParser
 from pcpp.preprocessor import Preprocessor as Pp
 
+# parameter.py imports nothing from this module, so importing its canonical wire-size table here
+# creates no cycle. Collapses what used to be a second, independently-maintained copy of the same
+# BYTE/WORD/DWORD -> 1/2/4 mapping (see parameter.py's own comment on timestamp_wire_size for why
+# it is not derived from Xcp_TimestampTypeType).
+from .parameter import timestamp_wire_size
+
 
 def pytest_addoption(parser):
     parser.addoption('--build_directory', action='store')
@@ -347,9 +353,8 @@ class XcpTest(object):
         daq_timestamp_supported_define = ('XCP_DAQ_TIMESTAMP_SUPPORTED={}'.format(
                 1 if any(c['protocol_layer'].get('timestamp')
                          for c in config['configurations']) else 0),)
-        daq_timestamp_wire_size = {'BYTE': 1, 'WORD': 2, 'DWORD': 4}
         daq_timestamp_size_define = ('XCP_DAQ_TIMESTAMP_SIZE={}'.format(
-                max((daq_timestamp_wire_size[c['protocol_layer']['timestamp']['size']]
+                max((timestamp_wire_size[c['protocol_layer']['timestamp']['size']]
                      for c in config['configurations'] if c['protocol_layer'].get('timestamp')),
                     default=0)),)
         # The module under test is only coupled to a configuration through the generated

--- a/test/daq_configuration_test.py
+++ b/test/daq_configuration_test.py
@@ -13,6 +13,7 @@ from jinja2.exceptions import UndefinedError
 
 from .parameter import *
 from .conftest import Preprocessor, XcpTest
+from .download_test import connect
 
 
 identification_field_cases = [
@@ -68,6 +69,78 @@ def test_max_dto_is_available_as_a_compile_time_macro(max_dto):
     handle = XcpTest(DefaultConfig(max_dto=max_dto))
 
     assert handle.define('XCP_MAX_DTO') == max_dto
+
+
+def test_a_multi_configuration_build_with_differing_max_dto_compiles_and_behaves():
+    """script/source_rt.c.jinja2's Xcp_DtoFrameStrideCheck asserted XCP_MAX_DTO == this
+    configuration's own max_dto, inside the per-configuration loop that emits one check per
+    configuration in the generated file. XCP_MAX_DTO is a max() fold over every configuration in
+    that file (script/header_cfg.h.jinja2), sizing Xcp_DtoFrameType.data[] once for the whole
+    module, so any configuration whose own max_dto is smaller than another's in the same file
+    failed to compile under ==, even though the shared, larger buffer already had room for it. >=
+    is the correct relation: it demands the buffer be at least as large as this configuration
+    needs, which a max() fold guarantees by construction.
+
+    Constructing each XcpTest instance below is itself the compile-time half of this test --
+    MockGen raises if the generated runtime fails to build, and before this fix it did, for
+    configuration 0, the smaller of the two, the moment its own max_dto (8) disagreed with the
+    fold's 64.
+
+    The behavioural half follows, so a fix that merely compiles by coercing every configuration to
+    the larger value cannot pass here. CONNECT's MAX_DTO field (source/Xcp_Std.c) reads
+    Xcp_Ptr->general->maxDto, a per-configuration runtime field distinct from the compile-time
+    macro above, so each configuration must still report its own. And Xcp_DtoFrameType.data[]
+    itself -- shared, and sized to the larger configuration's 64 by the very fold this fix must
+    not break -- must still produce a correctly bounded frame when a DAQ list running under the
+    smaller configuration is triggered: one written byte plus its PID is a 2-byte frame in an
+    8-byte MAX_DTO configuration exactly as it would be in a single-configuration build, not a
+    64-byte one.
+
+    Configuration 0 is built, used, and finished with before configuration 1 is ever constructed,
+    rather than interleaved: MockGen caches the compiled module by rt_key, which folds in every
+    configuration's max_dto (not just the active one), so both configurations here share one
+    compiled module, including its def_extern callback registrations. A second XcpTest against
+    the same rt_key re-registers those callbacks against its own mocks, so a live handle_small
+    call made after handle_large exists would silently land on handle_large's mocks instead."""
+    def exchange(handle, request):
+        handle.lib.Xcp_CanIfRxIndication(0x0001, handle.get_pdu_info(request))
+        handle.lib.Xcp_MainFunction()
+        handle.lib.Xcp_CanIfTxConfirmation(0x0002, handle.define('E_OK'))
+
+    multi = MultiConfig(DefaultConfig(max_dto=8), DefaultConfig(max_dto=64))
+
+    handle_small = XcpTest(multi, configuration_index=0)
+
+    assert handle_small.define('XCP_MAX_DTO') == 64, \
+        'one compiled stride, shared by both configurations -- the fold this fix must not break'
+
+    connect(handle_small)
+    small_connect = tuple(handle_small.can_if_transmit.call_args[0][1].SduDataPtr[0:8])
+    assert (small_connect[4] | (small_connect[5] << 8)) == 8, \
+        "CONNECT must report configuration 0's own MAX_DTO, not the shared compiled stride"
+
+    exchange(handle_small, (0xE2, 0x00, 0x00, 0x00, 0x00, 0x00))  # SET_DAQ_PTR: list 0, odt 0, entry 0
+    exchange(handle_small, (0xE1, 0xFF, 0x01, 0x00) + tuple(u32_to_array(0x1000, 'LITTLE_ENDIAN')))  # WRITE_DAQ
+    exchange(handle_small, (0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00))  # SET_DAQ_LIST_MODE: channel 0
+    exchange(handle_small, (0xDE, 0x01, 0x00, 0x00))  # START_STOP_DAQ_LIST: start list 0
+
+    handle_small.can_if_transmit.reset_mock()
+    handle_small.lib.Xcp_TriggerEventChannel(0)
+
+    assert handle_small.can_if_transmit.call_count == 1
+    frame = handle_small.can_if_transmit.call_args[0][1]
+    assert frame.SduLength == 2, 'FIRST_PID plus the one written byte -- not the 64-byte stride'
+    assert frame.SduDataPtr[0] == 0x00, 'FIRST_PID of the sole DAQ list/ODT'
+
+    # Configuration 1, the larger of the two, in the same generated file -- built only now that
+    # handle_small is done with (see the docstring for why).
+    handle_large = XcpTest(multi, configuration_index=1)
+
+    assert handle_large.define('XCP_MAX_DTO') == 64
+
+    connect(handle_large)
+    large_connect = tuple(handle_large.can_if_transmit.call_args[0][1].SduDataPtr[0:8])
+    assert (large_connect[4] | (large_connect[5] << 8)) == 64
 
 
 def test_first_pid_is_the_running_sum_of_preceding_odt_counts():
@@ -364,10 +437,9 @@ def test_the_build_derives_daq_timestamp_macros_from_the_repository_configuratio
     with open(repository_config_path) as fp:
         repository_config = json.load(fp)
 
-    wire_size = {'BYTE': 1, 'WORD': 2, 'DWORD': 4}
     expected_supported = 'STD_ON' if any(c['protocol_layer'].get('timestamp')
                                          for c in repository_config['configurations']) else 'STD_OFF'
-    expected_size = str(max((wire_size[c['protocol_layer']['timestamp']['size']]
+    expected_size = str(max((timestamp_wire_size[c['protocol_layer']['timestamp']['size']]
                              for c in repository_config['configurations']
                              if c['protocol_layer'].get('timestamp')),
                             default=0))

--- a/test/daq_identification_field_test.py
+++ b/test/daq_identification_field_test.py
@@ -183,7 +183,7 @@ def test_an_entry_written_at_a_non_zero_slot_is_still_sampled():
 
 _timestamp_offset_identifications = (('ABSOLUTE', 1), ('RELATIVE_BYTE', 2), ('RELATIVE_WORD', 3),
                                      ('RELATIVE_WORD_ALIGNED', 4))
-_timestamp_offset_sizes = (('BYTE', 1), ('WORD', 2), ('DWORD', 4))
+_timestamp_offset_sizes = tuple((size, wire) for size, wire in timestamp_wire_size.items() if size is not None)
 
 # Every identification_field_type x every timestamp width, but the byte-order axis is trimmed to
 # LITTLE_ENDIAN alone for the three identification widths added on top of the original ABSOLUTE

--- a/test/gcov_union_test.py
+++ b/test/gcov_union_test.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""Tests script/gcov_union.py, the line-by-line merge that lets test.sh report coverage as the
+union across every compilation variant of a source file instead of discarding all but one.
+
+This module is not a test of the DUT (the Xcp C sources): it is a test of a coverage-reporting
+tool, and a merger that reports plausible-but-wrong numbers is worse than no merger at all -- a
+wrong 100% hides untested code as effectively as an honest one, but looks fine. Every case gcov's
+per-line count field can take -- a number, '#####' (instrumented, never executed), or '-' (not
+instrumented) -- is exercised alone, in combination with each of the others, and across inputs
+that do not even cover the same set of line numbers, since real variants can (a module that failed
+to compile past an earlier line, or a hand-built fixture in these tests) disagree on extent without
+that being a bug.
+
+script/gcov_union.py is a plain script, not a package under test/, so it is not on sys.path the
+way the rest of the suite's dependencies are; the import below adds script/ to sys.path itself
+rather than relying on the --script_directory CLI option (BSWCodeGen's own use of that option,
+in .conftest, points it at the *.jinja2 templates, not at Python modules), so this file does not
+depend on anything test.sh's cmake/ctest invocation had to have configured beyond running pytest
+at all.
+"""
+
+import os
+import sys
+
+_SCRIPT_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'script')
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+import pytest
+
+import gcov_union  # noqa: E402  (import follows the sys.path fix-up above, deliberately)
+
+
+def gcov_text(source, body_lines, extra_header=()):
+    """Build a synthetic .gcov file's content.
+
+    body_lines: a sequence of (count_field, text) pairs, becoming 1-indexed source lines.
+    extra_header: additional ':0:'-numbered header lines, inserted after 'Source:', the way real
+    gcov output also carries 'Graph:', 'Data:', 'Runs:' and 'Programs:' lines.
+    """
+    header = [f"        -:    0:Source:{source}"]
+    header.extend(f"        -:    0:{line}" for line in extra_header)
+    body = [f"{count:>9}:{i:>5}:{text}" for i, (count, text) in enumerate(body_lines, start=1)]
+    return "\n".join(header + body) + "\n"
+
+
+# --- the five scenarios the brief calls out by name -----------------------------------------
+
+def test_numeric_in_one_variant_and_dash_in_another_keeps_the_numeric_count():
+    """A line inside a build-time guard: instrumented (and hit) in the variant that compiles the
+    guarded code in, absent -- not merely uncovered, genuinely not instrumented -- in the variant
+    that compiles it out. The union must report the real count, not fall back to '-' just because
+    one of the two inputs did."""
+    a = gcov_text("Xcp_DaqRuntime.c", [("3", "    do_thing();")])
+    b = gcov_text("Xcp_DaqRuntime.c", [("-", "    do_thing();")])
+    merged = gcov_union.union_gcov_texts([a, b])
+    assert "        3:    1:    do_thing();" in merged.splitlines()
+
+
+def test_hash_in_one_variant_and_numeric_in_another_keeps_the_numeric_count():
+    """The reverse pairing: one variant instrumented the line and never hit it ('#####'), the
+    other instrumented it and did. A variant that never ran the line contributes nothing, but
+    must not downgrade a real count to 'uncovered'."""
+    a = gcov_text("Xcp_DaqRuntime.c", [("#####", "    do_thing();")])
+    b = gcov_text("Xcp_DaqRuntime.c", [("7", "    do_thing();")])
+    merged = gcov_union.union_gcov_texts([a, b])
+    assert "        7:    1:    do_thing();" in merged.splitlines()
+
+
+def test_hash_in_every_variant_stays_hash():
+    """Instrumented in every variant, executed in none: real, reportable dead code -- must not
+    quietly become '-' (which would claim the line was never even compiled in)."""
+    a = gcov_text("Xcp_DaqRuntime.c", [("#####", "    dead();")])
+    b = gcov_text("Xcp_DaqRuntime.c", [("#####", "    dead();")])
+    c = gcov_text("Xcp_DaqRuntime.c", [("#####", "    dead();")])
+    merged = gcov_union.union_gcov_texts([a, b, c])
+    assert "    #####:    1:    dead();" in merged.splitlines()
+
+
+def test_dash_in_every_variant_stays_dash():
+    """Not instrumented anywhere -- a comment, a brace, a line no configuration ever compiles in
+    -- must not be promoted into looking like measured-but-uncovered code."""
+    a = gcov_text("Xcp_DaqRuntime.c", [("-", "    /* comment */")])
+    b = gcov_text("Xcp_DaqRuntime.c", [("-", "    /* comment */")])
+    merged = gcov_union.union_gcov_texts([a, b])
+    assert "        -:    1:    /* comment */" in merged.splitlines()
+
+
+def test_differing_line_counts_between_inputs_does_not_crash_or_drop_lines():
+    """One variant's report can be longer than another's -- test.sh's own gcov invocations never
+    produce this for a genuine pair (same physical source file), but this merger is the safety net
+    for the case, not gcov's promise that it cannot happen. Every line number present in either
+    input must survive into the union, including the ones the shorter input does not have."""
+    short = gcov_text("Xcp_DaqRuntime.c", [
+        ("-", "int f(void)"),
+        ("-", "{"),
+    ])
+    long = gcov_text("Xcp_DaqRuntime.c", [
+        ("1", "int f(void)"),
+        ("-", "{"),
+        ("4", "    g();"),
+        ("-", "}"),
+    ])
+    merged = gcov_union.union_gcov_texts([short, long])
+    lines = merged.splitlines()
+    assert "        1:    1:int f(void)" in lines
+    assert "        4:    3:    g();" in lines
+    assert "        -:    4:}" in lines
+    # the shorter input's silence about lines 3-4 is not a vote for '-': only the longer input's
+    # own values appear there, unaltered by the fact that the other input stopped short.
+
+
+# --- summation, not just "numeric wins" ------------------------------------------------------
+
+def test_two_numeric_variants_are_summed():
+    """The rule is 'sum', not 'keep whichever variant has a number' -- distinct from the two
+    single-numeric cases above. 3 hits in one variant's tests and 4 in another's is 7 hits
+    across the suite, the same as if one build had been able to run every test itself."""
+    a = gcov_text("Xcp_DaqRuntime.c", [("3", "    do_thing();")])
+    b = gcov_text("Xcp_DaqRuntime.c", [("4", "    do_thing();")])
+    merged = gcov_union.union_gcov_texts([a, b])
+    assert "        7:    1:    do_thing();" in merged.splitlines()
+
+
+def test_numeric_beats_hash_and_dash_together():
+    """Three-way combination, to pin the priority order (numeric > '#####' > '-') as one rule
+    rather than three separately-passing pairwise rules that could still disagree on a three-way
+    tie in some other implementation."""
+    a = gcov_text("Xcp_DaqRuntime.c", [("-", "    x();")])
+    b = gcov_text("Xcp_DaqRuntime.c", [("#####", "    x();")])
+    c = gcov_text("Xcp_DaqRuntime.c", [("5", "    x();")])
+    merged = gcov_union.union_gcov_texts([a, b, c])
+    assert "        5:    1:    x();" in merged.splitlines()
+
+
+def test_three_numeric_variants_sum_across_all_of_them():
+    a = gcov_text("Xcp_DaqRuntime.c", [("1", "    x();")])
+    b = gcov_text("Xcp_DaqRuntime.c", [("2", "    x();")])
+    c = gcov_text("Xcp_DaqRuntime.c", [("3", "    x();")])
+    merged = gcov_union.union_gcov_texts([a, b, c])
+    assert "        6:    1:    x();" in merged.splitlines()
+
+
+# --- the '*' partial-block marker --------------------------------------------------------------
+#
+# gcov appends '*' to a numeric count, with no extra flag needed to ask for it, whenever a line
+# compiles to more than one basic block (a ternary, a short-circuit && / ||, ...) and at least one
+# of those blocks never ran even though the line's own count is nonzero -- confirmed against this
+# project's own real output: source/Xcp_Daq.c has
+# 'return (boolean)((daqListNumber < Xcp_Ptr->general->daqCount) ? TRUE : FALSE);', and one
+# variant's real .gcov reported it as '132*'. A merger that cannot parse that field at all is
+# the failure mode the brief warns about in the most literal sense: it does not produce a wrong
+# number, it crashes -- but only because this case was not in the brief's own list of scenarios to
+# test. It is real, so it is tested here.
+
+def test_starred_count_with_dash_keeps_the_star():
+    """Only one variant has data for this line, and it is starred: no other variant offers proof
+    every block on the line ran, so the union has none to fall back on either."""
+    a = gcov_text("Xcp_DaqRuntime.c", [("5*", "    x = a ? b : c;")])
+    b = gcov_text("Xcp_DaqRuntime.c", [("-", "    x = a ? b : c;")])
+    merged = gcov_union.union_gcov_texts([a, b])
+    assert "       5*:    1:    x = a ? b : c;" in merged.splitlines()
+
+
+def test_starred_and_unstarred_numeric_sums_and_drops_the_star():
+    """The variant reporting '3' unstarred is itself proof that every block belonging to this
+    source line ran at least once in its own tests -- the same code, the same block
+    decomposition, since the line is not itself macro-gated. That proof does not stop being true
+    because a DIFFERENT variant's tests happened not to exercise every block, so the union must
+    not keep claiming partial coverage once one variant has already disproved it."""
+    a = gcov_text("Xcp_DaqRuntime.c", [("5*", "    x = a ? b : c;")])
+    b = gcov_text("Xcp_DaqRuntime.c", [("3", "    x = a ? b : c;")])
+    merged = gcov_union.union_gcov_texts([a, b])
+    assert "        8:    1:    x = a ? b : c;" in merged.splitlines()
+
+
+def test_two_starred_numeric_variants_sum_and_keep_the_star():
+    """Every numeric contributor is starred, so there is no unstarred proof anywhere to justify
+    dropping it -- summing is still correct (five hits is five hits, however each variant's own
+    blocks split), but the union stays conservative about whether every block was ever exercised
+    together."""
+    a = gcov_text("Xcp_DaqRuntime.c", [("5*", "    x = a ? b : c;")])
+    b = gcov_text("Xcp_DaqRuntime.c", [("3*", "    x = a ? b : c;")])
+    merged = gcov_union.union_gcov_texts([a, b])
+    assert "       8*:    1:    x = a ? b : c;" in merged.splitlines()
+
+
+def test_starred_count_beats_hash():
+    a = gcov_text("Xcp_DaqRuntime.c", [("5*", "    x = a ? b : c;")])
+    b = gcov_text("Xcp_DaqRuntime.c", [("#####", "    x = a ? b : c;")])
+    merged = gcov_union.union_gcov_texts([a, b])
+    assert "       5*:    1:    x = a ? b : c;" in merged.splitlines()
+
+
+# --- header / source-text handling ------------------------------------------------------------
+
+def test_source_header_is_preserved_from_the_first_input():
+    a = gcov_text("Xcp_DaqRuntime.c", [("1", "int f(void)")],
+                  extra_header=["Graph:Xcp_DaqRuntime.gcno", "Data:Xcp_DaqRuntime.gcda", "Runs:1"])
+    b = gcov_text("Xcp_DaqRuntime.c", [("2", "int f(void)")])
+    merged = gcov_union.union_gcov_texts([a, b])
+    header = merged.splitlines()[:4]
+    assert header == [
+        "        -:    0:Source:Xcp_DaqRuntime.c",
+        "        -:    0:Graph:Xcp_DaqRuntime.gcno",
+        "        -:    0:Data:Xcp_DaqRuntime.gcda",
+        "        -:    0:Runs:1",
+    ]
+
+
+def test_source_text_for_a_line_only_one_variant_has_is_passed_through_unchanged():
+    short = gcov_text("Xcp_DaqRuntime.c", [("1", "int f(void)")])
+    long = gcov_text("Xcp_DaqRuntime.c", [("1", "int f(void)"), ("-", "    /* only in long */")])
+    merged = gcov_union.union_gcov_texts([short, long])
+    assert "        -:    2:    /* only in long */" in merged.splitlines()
+
+
+# --- refusing to guess, rather than silently merging the wrong thing --------------------------
+
+def test_mismatched_source_names_are_refused():
+    a = gcov_text("Xcp_DaqRuntime.c", [("1", "int f(void)")])
+    b = gcov_text("Xcp_Daq.c", [("1", "int f(void)")])
+    with pytest.raises(gcov_union.GcovUnionError, match="different sources"):
+        gcov_union.union_gcov_texts([a, b])
+
+
+def test_disagreeing_source_text_at_the_same_line_number_is_refused():
+    """Same file name, but line 1's text does not match -- the strongest signal available that
+    two reports do not actually describe the same compile of the same file, so this must not be
+    resolved by picking one side: that is exactly the kind of plausible-looking wrong answer the
+    brief warns is worse than the narrow-but-honest report this replaces."""
+    a = gcov_text("Xcp_DaqRuntime.c", [("1", "int f(void)")])
+    b = gcov_text("Xcp_DaqRuntime.c", [("1", "int g(void)")])
+    with pytest.raises(gcov_union.GcovUnionError, match="different source text"):
+        gcov_union.union_gcov_texts([a, b])
+
+
+def test_empty_input_list_is_refused():
+    with pytest.raises(gcov_union.GcovUnionError):
+        gcov_union.union_gcov_texts([])
+
+
+def test_malformed_line_is_refused_rather_than_misparsed():
+    with pytest.raises(gcov_union.GcovUnionError):
+        gcov_union.union_gcov_texts(["not a gcov line at all"])
+
+
+# --- coverage_summary, the number test.sh's console output shows per source -------------------
+
+def test_coverage_summary_counts_executed_and_instrumented_lines():
+    merged = "\n".join([
+        "        -:    0:Source:Xcp_DaqRuntime.c",
+        "        -:    1:not instrumented",
+        "        5:    2:executed",
+        "    #####:    3:instrumented, never executed",
+        "        2:    4:executed",
+        "",
+    ])
+    executed, instrumented = gcov_union.coverage_summary(merged)
+    assert (executed, instrumented) == (2, 3)
+
+
+def test_coverage_summary_of_an_all_dash_file_is_zero_of_zero():
+    merged = "\n".join([
+        "        -:    0:Source:empty.c",
+        "        -:    1:/* nothing compiled in from any variant */",
+        "",
+    ])
+    assert gcov_union.coverage_summary(merged) == (0, 0)
+
+
+# --- the CLI test.sh actually invokes -----------------------------------------------------------
+
+def test_main_writes_the_merged_file_and_reports_the_percentage(tmp_path, capsys):
+    a = tmp_path / "a.gcov"
+    b = tmp_path / "b.gcov"
+    out = tmp_path / "merged.gcov"
+    a.write_text(gcov_text("Xcp_DaqRuntime.c", [("3", "x();"), ("-", "y();")]))
+    b.write_text(gcov_text("Xcp_DaqRuntime.c", [("-", "x();"), ("#####", "y();")]))
+
+    exit_code = gcov_union.main(["-o", str(out), str(a), str(b)])
+
+    assert exit_code == 0
+    assert out.read_text() == gcov_union.union_gcov_texts([a.read_text(), b.read_text()])
+    captured = capsys.readouterr()
+    assert "File 'Xcp_DaqRuntime.c'" in captured.out
+    # 1 of 2 instrumented lines executed (x(): 3: y(): '#####') = 50.00%.
+    assert "Lines executed:50.00% of 2" in captured.out
+
+
+def test_main_refuses_to_write_a_file_for_mismatched_sources(tmp_path, capsys):
+    a = tmp_path / "a.gcov"
+    b = tmp_path / "b.gcov"
+    out = tmp_path / "merged.gcov"
+    a.write_text(gcov_text("Xcp_DaqRuntime.c", [("1", "x();")]))
+    b.write_text(gcov_text("Xcp_Daq.c", [("1", "x();")]))
+
+    exit_code = gcov_union.main(["-o", str(out), str(a), str(b)])
+
+    assert exit_code == 1
+    assert not out.exists()
+    assert "different sources" in capsys.readouterr().err

--- a/test/parameter.py
+++ b/test/parameter.py
@@ -160,8 +160,6 @@ timestamp_sizes = [pytest.param(v, id='TS = {}'.format(v)) for v in ('BYTE', 'WO
 # implicit, so FOUR_BYTE == 3, and 3 is the one size the specification marks "Not allowed".
 timestamp_wire_size = {'BYTE': 1, 'WORD': 2, 'DWORD': 4, None: 0}
 
-timestamp_type_name = {'BYTE': 'ONE_BYTE', 'WORD': 'TWO_BYTE', 'DWORD': 'FOUR_BYTE', None: 'NO_TIME_STAMP'}
-
 
 def timestamp(size='DWORD', unit='TIMESTAMP_UNIT_1MS', ticks=1):
     return {"size": size, "unit": unit, "ticks": ticks}


### PR DESCRIPTION
Four items from [sp2b-followups.md](docs/superpowers/sp2b-followups.md), chosen because each compounds with SP2c or costs time on every run. The other ~32 triaged items are deliberately untouched.

**12552 passed, 30 skipped**, reproduced on two consecutive full runs.

### `test.sh` prunes stale CFFI modules before configure

`build/` accumulated without bound — 3017 directories, 307 MB, against the container's **1024 file-descriptor limit**. Seven transient failures across SP2b trace to it (PLY parser-state corruption, a Jinja2 template `TypeError`, a CFFI/distutils `TypeError`, a `mock.py` `UnboundLocalError`), each non-reproducing on a clean tree and each costing a four-minute run.

Independently, `.gcda` profiles persisted and were re-merged, so coverage was cumulative since the last manual `rm -rf build` — a deleted test kept counting.

Pruning must happen at the *start*: the coverage merge depends on the current run's modules surviving. Verified both halves — a run after the change starts clean and still reports all six translation units, and a second run proves non-accumulation (1604 directories, not 3208).

### `Xcp_DtoFrameStrideCheck` now uses `>=`

It asserted `XCP_MAX_DTO ==` *this configuration's* `max_dto` inside a per-configuration loop, but `XCP_MAX_DTO` is a `max()` fold — so any multi-configuration build with differing `max_dto` failed to compile, though the frames are correctly sized by the maximum.

That capped the `MultiConfig` fixture added in SP2b to close a blind spot, which had already caught one blocker. New test builds two configurations at `max_dto` 8 and 64; red/green-verified by reverting to `==` and confirming `size of array 'Xcp_DtoFrameStrideCheck00' is negative`.

### Dead wire-size copies removed

`test/parameter.py`'s `timestamp_type_name` had no consumer. The duplicate `BYTE`/`WORD`/`DWORD` → 1/2/4 dicts in `conftest.py`, `daq_configuration_test.py` and `daq_identification_field_test.py` now share `parameter.py`'s `timestamp_wire_size`.

The `CMakeLists.txt` and `header_cfg.h.jinja2` copies were **kept**: tracing showed they are general-purpose logic that a differently-configured `XCP_CONFIG_FILEPATH` genuinely exercises, not orphaned code. They carry comments naming why they are currently unexercised — `config/xcp.json` declares no `timestamp` block. Full consolidation into a shared JSON table is out of scope.

### Two design-doc statements corrected against shipped code

Both verified in `source/Xcp_Daq.c` before editing, and marked inline as corrections rather than silently rewritten:

- §5.2 said a `WRITE_DAQ` overfill answers `ERR_OUT_OF_RANGE`; it answers `ERR_DAQ_CONFIG`, with an in-code §1.7.3.2.4 citation and a test pinning it.
- §7.1 prescribed `ERR_OUT_OF_RANGE` for a `WRITE_DAQ_MULTIPLE` length/`n` disagreement; the implementation answers `ERR_CMD_SYNTAX`.

This is the document SP2c gets planned from, and three SP2b defects came from acting on spec text that was confidently wrong.

### Coverage now reports the union across compilation variants

The harness compiles the module once per test configuration — about 36 times — and configurations set
different macros, so `Xcp_Daq.c` becomes two structurally different programs depending on
`XCP_DAQ_TIMESTAMP_SUPPORTED`. `gcov` cannot merge profiles across those, so `test.sh` merged only
the **largest** group and discarded the rest.

That was hiding tested code, not merely narrowing a number. `Xcp_DaqRuntime.c` reported `100.00%` —
of the compilation containing none of the timestamp feature. Every line inside the guard read `-`
(not compiled) rather than `#####` (not executed), so the reported figure could not distinguish
"absent" from "untested". It also degraded each phase: every new build-time guard split the modules
further and shrank what was measurable.

Every variant compiles the same source and `.gcov` is keyed by line number, so the variants are
complementary rather than conflicting. `test.sh` now runs `gcov` per variant group and unions the
reports line-by-line (`script/gcov_union.py`): sum the numeric counts, else `#####` if any variant
instrumented the line, else `-`.

**The deliverable, from the run's own output** — `Xcp_DaqRuntime.c` lines 179-180:

```
before        -:  179:    if ((odtNumber == 0x00u) &&
after        58:  179:    if ((odtNumber == 0x00u) &&
before        -:  180:        ((Xcp_Rt[...].mode & XCP_DAQ_LIST_MODE_TIMESTAMP) != 0x00u))
after        31:  180:        ((Xcp_Rt[...].mode & XCP_DAQ_LIST_MODE_TIMESTAMP) != 0x00u))
```

Percentages moved in **both** directions, which is the honest outcome — the denominators grew as
previously-invisible lines became measurable: `Xcp_DaqRuntime.c` 100.00% of 105 → 98.40% of 125,
`Xcp_Daq.c` 92.36% of 432 → 98.43% of 445. `coverage_files.txt` still carries one entry per source,
so the CI contract is unchanged.

The merger has 22 tests over synthetic `.gcov` inputs, because a coverage tool that reports
plausible-but-wrong numbers is worse than the honest-but-narrow one it replaces. It also handles
gcov's `*` partial-block marker, which I had not specified — the first implementation hard-failed on
it rather than mis-summing, which is the right failure mode.

This also inverts the degradation: more build-time guards now mean more reports, not less coverage.

### Still open, deliberately — decisions rather than hygiene

Both of the decisions this branch opened with are now closed.

**`Xcp_CanIfRxIndication` self-reentrancy — resolved against the specification.** SWS_Xcp_00813
gives `Xcp_<Lo>RxIndication` *"Reentrant for different PduIds. Non reentrant for the same PduId."*
Every CTO command reaches this module on one PduId, so CanIf's own contract prevents the race and no
exclusive area is needed. It reopens in SP3: DAQ_STIM receive PDUs are different PduIds and may
preempt a CTO mid-dispatch, so a stimulation handler touching shared state makes it live. Recorded in
the roadmap's SP3 entry and as a comment on the branch that will host that handler.

**Coverage measuring one variant — fixed above.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

