### PR TITLE
fix: put DIRECTION and ALTERNATING at the bits the specification gives them

### DIFF
--- a/source/Xcp_Internal.h
+++ b/source/Xcp_Internal.h
@@ -126,8 +126,16 @@ extern "C" {
 #define XCP_SESSION_STATUS_MASK_CLEAR_DAQ_REQ (0x01u << 0x03u)
 #define XCP_SESSION_STATUS_MASK_DAQ_RUNNING (0x01u << 0x06u)
 
-/* SET_DAQ_LIST_MODE mode byte, XCP part 2 - Protocol Layer Specification 1.1/1.6.4.1.1.3. */
-#define XCP_DAQ_LIST_MODE_REQ_DIRECTION (0x01u << 0x00u)
+/* SET_DAQ_LIST_MODE mode byte, XCP part 2 - Protocol Layer Specification 1.1/1.6.4.1.1.3.
+ * Read off the specification's own bit table, which is identical in 1.0 and 1.1 except that 1.1
+ * fills bit 0, which 1.0 left don't-care:
+ *
+ *   bit    7   6   5        4          3   2   1          0
+ *   1.0    x   x   PID_OFF  TIMESTAMP  x   x   DIRECTION  x
+ *   1.1    x   x   PID_OFF  TIMESTAMP  x   x   DIRECTION  ALTERNATING
+ */
+#define XCP_DAQ_LIST_MODE_REQ_ALTERNATING (0x01u << 0x00u)
+#define XCP_DAQ_LIST_MODE_REQ_DIRECTION (0x01u << 0x01u)
 #define XCP_DAQ_LIST_MODE_REQ_TIMESTAMP (0x01u << 0x04u)
 #define XCP_DAQ_LIST_MODE_REQ_PID_OFF (0x01u << 0x05u)
 
@@ -139,12 +147,16 @@ extern "C" {
  * this mask either, for the same reason: Xcp_DTOCmdDaqSetDaqListMode decides it itself, depending
  * on whether the identification field type is absolute and the targeted DAQ list has exactly one
  * ODT (1.1/1.1.2.1). What remains here is refused unconditionally: DIRECTION selects STIM, out of
- * scope until SP3; and 1.1 places ALTERNATING somewhere in bits 6..7 -- refusing the whole class
- * is conformant whichever bit it turns out to occupy.
+ * scope until SP3, and ALTERNATING pairs a DAQ list with a display event channel declared only in
+ * the A2L file (DAQ_ALTERNATING_SUPPORTED), which this module does not emit -- and which 1.1
+ * forbids combining with TIMESTAMP in any case.
+ *
+ * Bits 2, 3, 6 and 7 are don't-care in both versions and are tolerated. An earlier revision of
+ * this mask refused 6 and 7 believing ALTERNATING lived there; it does not, and refusing bits the
+ * specification marks don't-care is over-strict.
  */
 #define XCP_DAQ_LIST_MODE_REQ_UNSUPPORTED \
-    (XCP_DAQ_LIST_MODE_REQ_DIRECTION | \
-     (0x01u << 0x06u) | (0x01u << 0x07u)) /* bits 6-7 reserved: 1.1 places ALTERNATING somewhere in them */
+    (XCP_DAQ_LIST_MODE_REQ_DIRECTION | XCP_DAQ_LIST_MODE_REQ_ALTERNATING)
 
 /* GET_DAQ_LIST_MODE mode byte, 1.1/1.6.4.1.2.6. This is the layout Xcp_DaqListRtType stores. */
 #define XCP_DAQ_LIST_MODE_SELECTED (0x01u << 0x00u)

--- a/test/set_daq_list_mode_test.py
+++ b/test/set_daq_list_mode_test.py
@@ -72,9 +72,8 @@ def test_set_daq_list_mode_stores_channel_prescaler_and_priority():
 # test_pid_off_is_refused_when_another_list_shares_this_list_s_tx_pdu cover the three refusal paths
 # precisely and by name. Keeping a same-outcome entry here would only assert the same thing twice
 # for three different reasons.
-@pytest.mark.parametrize('mode, name', ((0x01, 'DIRECTION = STIM'),
-                                        (0x40, 'bit 6, ALTERNATING in 1.1'),
-                                        (0x80, 'bit 7')))
+@pytest.mark.parametrize('mode, name', ((0x02, 'DIRECTION = STIM, bit 1'),
+                                        (0x01, 'ALTERNATING, bit 0 in 1.1')))
 def test_set_daq_list_mode_rejects_every_unimplemented_mode_bit(mode, name):
     """DD9: 1.7.3.2.4 lists ERR_MODE_NOT_VALID for this command and that is what these are."""
     handle = daq_handle()
@@ -82,11 +81,36 @@ def test_set_daq_list_mode_rejects_every_unimplemented_mode_bit(mode, name):
     assert set_mode(handle, mode=mode) == (0xFE, 0x27), name
 
 
-@pytest.mark.parametrize('mode', (0x02, 0x04, 0x08))
-def test_set_daq_list_mode_tolerates_the_bits_1_0_marks_dont_care(mode):
+@pytest.mark.parametrize('mode', (0x04, 0x08, 0x40, 0x80))
+def test_set_daq_list_mode_tolerates_the_bits_the_specification_marks_dont_care(mode):
+    """Bits 2, 3, 6 and 7 carry an 'x' in the mode bit table of both 1.0 and 1.1, so a master may
+    set them to anything and the slave ignores them. Bits 6 and 7 were previously refused, on the
+    belief that 1.1 placed ALTERNATING in them -- it places it at bit 0."""
     handle = daq_handle()
 
     assert set_mode(handle, mode=mode)[0] == 0xFF
+
+
+def test_set_daq_list_mode_refuses_a_stimulation_direction_rather_than_ignoring_it():
+    """Regression. DIRECTION is bit 1 in both 1.0 and 1.1, but this module declared it at bit 0
+    until the mode-bit positions were corrected. Bit 1 was covered by nothing, and the mask's own
+    comment called bits 1-3 tolerated don't-cares -- so a master asking for STIM got a positive
+    response, believed it had configured stimulation, and the slave went on sampling in the DAQ
+    direction with no error anywhere. Silence was the whole defect, so this test asserts the error
+    code rather than merely that the request did not succeed."""
+    handle = daq_handle()
+
+    assert set_mode(handle, mode=0x02) == (0xFE, 0x27)
+
+
+def test_set_daq_list_mode_refuses_alternating_at_the_bit_the_specification_gives_it():
+    """ALTERNATING is bit 0, read off 1.1's own bit table. It is refused rather than implemented:
+    the capability is declared through DAQ_ALTERNATING_SUPPORTED in the A2L file, which this module
+    does not emit, it pairs the list with a display event channel the protocol layer never gives
+    slave-side semantics for, and 1.1 forbids combining it with TIMESTAMP."""
+    handle = daq_handle()
+
+    assert set_mode(handle, mode=0x01) == (0xFE, 0x27)
 
 
 def test_set_daq_list_mode_rejects_an_unknown_daq_list():


### PR DESCRIPTION
Found while investigating `ALTERNATING` for SP2c. Rendering the 1.1 scanned page settled where that flag lives — and showed `DIRECTION` has been at the wrong bit since SP2a.

**12576 passed, 30 skipped.**

## The bit table, read off the specification

| bit | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |
|:--|:--|:--|:--|:--|:--|:--|:--|:--|
| **1.0** | x | x | `PID_OFF` | `TIMESTAMP` | x | x | **`DIRECTION`** | x |
| **1.1** | x | x | `PID_OFF` | `TIMESTAMP` | x | x | **`DIRECTION`** | **`ALTERNATING`** |

Identical in both, except 1.1 fills bit 0 where 1.0 had don't-care.

## What was wrong

**`DIRECTION` was declared at bit 0.** Nothing tested bit 1 — the refusal mask didn't cover it, and the mask's own comment described bits 1–3 as tolerated don't-cares. `test_set_daq_list_mode_tolerates_the_bits_1_0_marks_dont_care` even asserted `0x02` was *accepted*, pinning the defect in place.

So a master requesting `DIRECTION = STIM` got a **positive response**. It believed it had configured stimulation; the slave carried on sampling in the DAQ direction; no error was reported anywhere. Silence was the entire failure mode, which is why the new regression test asserts the error *code* rather than merely that the request didn't succeed. This lands directly on SP3.

**`ALTERNATING` is bit 0**, not "somewhere in bits 6..7" as the mask assumed. It remains refused — now at the correct bit — and the reasoning is recorded rather than left to be re-derived:

- the capability is declared through `DAQ_ALTERNATING_SUPPORTED` in the **A2L file**, which this module does not emit, and it takes a *display event channel number*;
- the protocol layer gives it no slave-side transmission semantics;
- 1.1 **forbids** combining it with `TIMESTAMP`, which SP2b just shipped.

**Bits 6 and 7 are no longer refused.** They are don't-care in both versions, and refusing them rested on the same wrong belief about where `ALTERNATING` lives.

## Verification

Mutation-verified: reverting `DIRECTION` to bit 0 fails exactly the sweep case and the named regression test, and nothing else. Restored cleanly, confirmed by diff.

## Why this keeps happening

Third time this pattern has produced a defect on this codebase: a confident claim in a comment (*"Bits 1, 2 and 3 are marked don't-care in 1.0"*, *"1.1 places ALTERNATING somewhere in bits 6..7"*) that nobody checked against the primary source. Every review since SP2a checked the constant against the comment. The 1.1 spec is a scan whose OCR is unusable for bit tables — rendering the page image is what settled it, and is what earlier work should have done rather than reasoning from degraded text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
