### PR TITLE
fix: refuse the non-volatile DAQ modes instead of latching a request nothing fulfils

### DIFF
--- a/docs/superpowers/specs/2026-08-29-xcp-part2-roadmap.md
+++ b/docs/superpowers/specs/2026-08-29-xcp-part2-roadmap.md
@@ -67,11 +67,11 @@ positive response without doing anything, which was defect D2, fixed in SP1.
 |:--|:--|:--|
 | 0xFF | CONNECT | done |
 | 0xFE | DISCONNECT | done |
-| 0xFD | GET_STATUS | partial — bytes 4,5 (session configuration id) are hard-coded to 0xABCD at `source/Xcp.c:3193`; see defect D9 |
+| 0xFD | GET_STATUS | yes | reports session configuration id 0, which is truthful while no DAQ configuration is stored; see defect D9 |
 | 0xFC | SYNCH | done |
 | 0xFB | GET_COMM_MODE_INFO | done |
 | 0xFA | GET_ID | partial — identification type 0 (ASCII) only; §1.6.1.2.2 defines 0–4 plus 128–255 user-defined, all implementation-specific |
-| 0xF9 | SET_REQUEST | partial — accepts the session configuration id in bytes 2,3 but does not store it; see defect D9 |
+| 0xF9 | SET_REQUEST | yes | STORE_CAL_REQ implemented; STORE_DAQ_REQ and CLEAR_DAQ_REQ refused with ERR_OUT_OF_RANGE as unsupported modes; see defect D9 |
 | 0xF8 | GET_SEED | done |
 | 0xF7 | UNLOCK | done |
 | 0xF6 | SET_MTA | done |
@@ -178,8 +178,10 @@ into SP1; it belongs with D6.
 
 ## 3. Known defects in existing code
 
-**Status as of 2026-09-02:** D1, D2, D3, D4, D5 and D8 were fixed in SP1; D7 fell out of the
-same dispatch rework. D6 and D9 remain open — D9 is scheduled into SP5, D6 travels with the
+**Status as of 2026-09-03:** D1, D2, D3, D4, D5 and D8 were fixed in SP1; D7 fell out of the
+same dispatch rework. D9 was resolved by refusing the two modes it could not fulfil, which also
+closed a session-wide denial of service found while investigating it; the non-volatile storage
+that would let those modes be accepted is tracked as SP5-NV. D6 remains open and travels with the
 per-segment checksum reconciliation noted at the end of §2.6. The entries below are kept as
 written, each with its outcome, because the reasoning is what makes the fix reviewable.
 
@@ -276,7 +278,27 @@ reset it to 0 on `CLEAR_DAQ_REQ`. `Xcp_CTOCmdStdGetStatus` returns the constant 
 `test/get_status_test.py` is the marker left for it — note its name misstates the byte
 offsets. Because persistence is defined in terms of DAQ list storage, this belongs with SP2.
 
-> **Open.** Scheduled into SP5.
+> **Resolved 2026-09-03, by refusal rather than by implementation.** Investigating this found the
+> defect was not the cosmetic one described above. `SET_REQUEST` accepted `STORE_DAQ_REQ` and
+> `CLEAR_DAQ_REQ` and OR-ed them into `Xcp_Internal.session_status`; no code fulfils either
+> request, so nothing ever cleared the bit, and the `ERR_PGM_ACTIVE` gate in
+> `Xcp_CanIfRxIndication` (`source/Xcp.c`) refuses **every command carrying that flag — 42 of
+> them — for as long as one of the three request bits is set**. A single conformant `SET_REQUEST`
+> therefore disabled most of the command set until the next `CONNECT`. `STORE_CAL_REQ` was never
+> affected: `Xcp_MainFunction` fulfils it and clears its bit.
+>
+> The nonzero-session-id rejection was also inert. It ran after the success branch had been
+> entered, so it set the local `result` and then finalized a positive response regardless — the
+> error never reached the master, and the check only read as validation.
+>
+> §1.6.1.2.3's own escape hatch — *"If the slave device does not support the requested mode, an
+> ERR_OUT_OF_RANGE will be returned"* — makes refusing both modes fully conformant, and it agrees
+> with what the module already advertises, since `GET_DAQ_PROCESSOR_INFO` reports RESUME
+> unsupported and non-volatile DAQ storage exists to serve RESUME. `GET_STATUS` now reports
+> session configuration id 0, the value the specification itself resets it to.
+>
+> **This closes the misreporting, not the feature.** Accepting the two modes needs non-volatile
+> storage, tracked as SP5-NV below.
 
 **D7 — `Xcp_PIDTable` misroutes the entire command space above 0xE3.** §1.1.5.1 fixes the
 master-to-slave identifier space at `0xC0..0xFF` for commands and `0x00..0xBF` for STIM ODT
@@ -383,14 +405,43 @@ schedulable whenever flash programming becomes a requirement.
 
 The residue: the interleaved communication model (§1.7.2.3), `EV_CMD_PENDING` (§1.7.2.4.2),
 RESUME mode, `GET_ID` identification types 1–4 and 128–255 (§1.6.1.2.2),
-`SET_DAQ_LIST_CAN_ID`, defect D9, the remaining `EV_*` event codes and the `SERV_*` service
-request codes.
+`SET_DAQ_LIST_CAN_ID`, the remaining `EV_*` event codes and the `SERV_*` service request codes.
 
 Note that time-out handling itself is *not* here: §1.7.2 places the t1…t6 timers entirely on
 the master. `EV_CMD_PENDING` and the interleaved request queue are the slave's whole share
 of that chapter.
 
-**Dependencies.** `SET_DAQ_LIST_CAN_ID`, RESUME mode and D9 all depend on SP2 — RESUME is a
+#### SP5-NV — non-volatile DAQ storage
+
+Everything the module currently refuses because it keeps no non-volatile DAQ configuration:
+`SET_REQUEST`'s `STORE_DAQ_REQ` and `CLEAR_DAQ_REQ` modes, the session configuration id that is
+stored and cleared alongside them (§1.6.1.2.3), the `GET_STATUS` byte pair that reports it, and
+RESUME mode itself, which is what the whole mechanism exists to serve. D9 closed the
+*misreporting* by refusing these modes outright; this item is what would let them be accepted.
+
+**Intended shape** (agreed 2026-09-03, not yet designed): an integrator-provided callback pair
+for storing and reading the configuration, **asynchronous**, following the pattern already
+established by `Xcp_StoreCalibrationDataToNonVolatileMemory` — which `Xcp_MainFunction` polls
+until it reports completion, then clears the request bit and raises `EV_STORE_CAL`. The DAQ side
+needs the same treatment for `EV_STORE_DAQ` and `EV_CLEAR_DAQ`, plus a read path at
+initialisation that RESUME depends on and that calibration has no equivalent of.
+
+Three things this must get right, all of them discovered by D9:
+
+- **A request bit that is never cleared is a denial of service, not a cosmetic flaw.** The
+  `ERR_PGM_ACTIVE` gate in `Xcp_CanIfRxIndication` refuses the 42 commands that carry it while
+  any of the three request bits is set. Any asynchronous store must guarantee the bit is
+  cleared on *every* exit path, including callback failure, or it reintroduces exactly what D9
+  removed.
+- **Storing has an ordering requirement.** §1.6.1.2.3: the slave must first clear any DAQ list
+  configuration already in non-volatile memory, then store the new one — so a store interrupted
+  midway must not leave a configuration the master would take for complete.
+- **`GET_DAQ_PROCESSOR_INFO` must stop reporting RESUME unsupported at the same time**, and the
+  refusals in `SET_REQUEST` and `SET_DAQ_LIST_MODE` must be lifted together with it. The
+  module's advertisement and its refusals are currently consistent; changing one without the
+  others is what would make it incoherent.
+
+**Dependencies.** `SET_DAQ_LIST_CAN_ID` and SP5-NV both depend on SP2 — RESUME is a
 `SET_DAQ_LIST_MODE` bit backed by `STORE_DAQ_REQ` persistence, and the session configuration
 id is persisted and cleared through the same DAQ storage mechanism. Only the interleaved
 model, `EV_CMD_PENDING`, `GET_ID` types and the `SERV_*` codes are genuinely independent and

--- a/source/Xcp_Std.c
+++ b/source/Xcp_Std.c
@@ -921,33 +921,46 @@ uint8 Xcp_DTOCmdStdGetSeed(boolean *responseExpected, const PduInfoType *pPduInf
 
 uint8 Xcp_DTOCmdStdSetRequest(boolean *responseExpected, const PduInfoType *pPduInfo)
 {
-    uint8 mode;
-    uint16 session_configuration_id;
-
     Std_ReturnType result = E_OK;
 
     *responseExpected = TRUE;
 
-    if ((pPduInfo->SduDataPtr[0x01u] & 0b11110010u) != 0x00u)
+    /* XCP part 2 - Protocol Layer Specification 1.0/1.6.1.2.3, mode byte:
+     *
+     *   bit    7   6   5   4   3              2              1   0
+     *          x   x   x   x   CLEAR_DAQ_REQ  STORE_DAQ_REQ  x   STORE_CAL_REQ
+     *
+     * Only STORE_CAL_REQ is implemented: Xcp_MainFunction fulfils it through the integrator's
+     * store-calibration callback, then clears the bit and raises EV_STORE_CAL. STORE_DAQ_REQ and
+     * CLEAR_DAQ_REQ both act on a non-volatile DAQ list configuration this module does not keep,
+     * so they are refused under this same section's "If the slave device does not support the
+     * requested mode, an ERR_OUT_OF_RANGE will be returned". That agrees with what the module
+     * already advertises: GET_DAQ_PROCESSOR_INFO reports RESUME unsupported, and non-volatile DAQ
+     * storage exists to serve RESUME.
+     *
+     * Accepting them instead is not merely inaccurate, it is a session-wide denial of service.
+     * Nothing clears a request bit that no code fulfils, and Xcp_CanIfRxIndication refuses every
+     * command carrying ERR_PGM_ACTIVE -- 42 of them -- for as long as one is set, so a single
+     * conformant SET_REQUEST would disable most of the command set until the next CONNECT.
+     * Defect D9 in docs/superpowers/specs/2026-08-29-xcp-part2-roadmap.md tracks the non-volatile
+     * storage work that would let these two modes be accepted rather than refused.
+     *
+     * These bit positions coincide with the GET_STATUS session status bits of 1.0/1.6.1.1.3,
+     * which is what makes the assignment below sound; both bit tables were read to confirm it. */
+    if ((pPduInfo->SduDataPtr[0x01u] & (uint8)(~XCP_SESSION_STATUS_MASK_STORE_CAL_REQ)) != 0x00u)
     {
         result = XCP_E_ASAM_OUT_OF_RANGE;
-    }
-    else
-    {
-        mode = pPduInfo->SduDataPtr[0x01u];
     }
 
     if (result == E_OK)
     {
-        Xcp_CopyToU16WithOrder(&pPduInfo->SduDataPtr[0x02u], &session_configuration_id, Xcp_Ptr->general->byteOrder);
-
-        /* TODO: this is most likely not the correct way to handle the session id, this must be implemented... */
-        if (session_configuration_id != 0x00u)
-        {
-            result = XCP_E_ASAM_OUT_OF_RANGE;
-        }
-
-        Xcp_Internal.session_status |= mode;
+        /* The session configuration id in bytes 2,3 belongs to STORE_DAQ_REQ: 1.0/1.6.1.2.3 has the
+         * slave store it in non-volatile memory alongside the DAQ lists, and CLEAR_DAQ_REQ reset it
+         * to 0. With both modes refused above, there is nowhere to store it and nothing to validate
+         * it against, so it is ignored rather than examined. The check that stood here rejected a
+         * non-zero id, but did so after this branch had already been entered: it set `result` and
+         * then finalized a positive response regardless, so it never reached the master. */
+        Xcp_Internal.session_status |= pPduInfo->SduDataPtr[0x01u];
 
         Xcp_Internal.cto_response.pdu_info.SduDataPtr[0x00u] = XCP_PID_RESPONSE;
 
@@ -1060,8 +1073,16 @@ uint8 Xcp_CTOCmdStdGetStatus(boolean *responseExpected, const PduInfoType *pPduI
     Xcp_Internal.cto_response.pdu_info.SduDataPtr[0x01u] = Xcp_Internal.session_status;
     Xcp_Internal.cto_response.pdu_info.SduDataPtr[0x02u] = Xcp_GetProtectionStatus();
     Xcp_Internal.cto_response.pdu_info.SduDataPtr[0x03u] = 0x00u;
-    Xcp_Internal.cto_response.pdu_info.SduDataPtr[0x04u] = 0xABu; /* TODO: implement me... */
-    Xcp_Internal.cto_response.pdu_info.SduDataPtr[0x05u] = 0xCDu; /* TODO: implement me... */
+    /* XCP part 2 - Protocol Layer Specification 1.0/1.6.1.1.3, bytes 4,5: session configuration id.
+     * 1.6.1.2.3 has it set by a prior SET_REQUEST carrying STORE_DAQ_REQ, held in non-volatile
+     * memory alongside the stored DAQ lists and reset to 0 by CLEAR_DAQ_REQ, so that a master can
+     * check that automatically started (RESUME) DAQ lists carry the configuration it expects.
+     * SET_REQUEST refuses STORE_DAQ_REQ and GET_DAQ_PROCESSOR_INFO reports RESUME unsupported, so
+     * no configuration is ever stored and 0 -- the value the specification itself resets the id to
+     * -- is the truthful answer here, not a placeholder. This reported 0xABCD until defect D9 was
+     * closed; see the roadmap for the non-volatile storage work that would give it a real value. */
+    Xcp_Internal.cto_response.pdu_info.SduDataPtr[0x04u] = 0x00u;
+    Xcp_Internal.cto_response.pdu_info.SduDataPtr[0x05u] = 0x00u;
 
     Xcp_FinalizeResPacket(0x06u, &Xcp_Internal.cto_response.pdu_info);
 

--- a/test/asam_error_matrix_test.py
+++ b/test/asam_error_matrix_test.py
@@ -9,6 +9,22 @@ from .parameter import *
 from .conftest import XcpTest
 
 
+# The SET_REQUEST mode bits that can put the session into the ERR_PGM_ACTIVE state, which is what
+# every test_returns_err_pgm_active below needs to provoke.
+#
+# STORE_DAQ_REQ (0b100) and CLEAR_DAQ_REQ (0b1000) were listed here as well until defect D9 was
+# closed. That was asserting the defect: SET_REQUEST accepted both, no code fulfils either, so
+# nothing ever cleared the bit -- and because these very tests show the bit gates ERR_PGM_ACTIVE,
+# one SET_REQUEST left all 42 commands carrying that flag refused for the rest of the session.
+# SET_REQUEST now refuses both as unsupported modes (1.0/1.6.1.2.3), so neither can reach the gate.
+#
+# STORE_CAL_REQ remains, because it is genuinely implemented: Xcp_MainFunction fulfils it through
+# the integrator's store callback and then clears the bit. Each test below stubs that callback to
+# fail, which is what holds the bit set across the command under test. When SP5-NV adds
+# non-volatile DAQ storage, the other two modes belong back in this tuple.
+PGM_ACTIVE_MODE_BITS = (0b00000001,)
+
+
 class TestConnectErrorHandling:
     """
     Command               Error               Pre-Action Action
@@ -59,7 +75,7 @@ class TestDisconnectErrorHandling:
         handle.lib.Xcp_MainFunction()
         assert tuple(handle.can_if_transmit.call_args[0][1].SduDataPtr[0:2]) == (0xFE, 0x10)
 
-    @pytest.mark.parametrize('mode_bit', (0b00000001, 0b00000100, 0b00001000))
+    @pytest.mark.parametrize('mode_bit', PGM_ACTIVE_MODE_BITS)
     def test_returns_err_pgm_active(self, mode_bit):
         handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001))
         handle.xcp_store_calibration_data_to_non_volatile_memory.return_value = handle.define('E_NOT_OK')
@@ -228,7 +244,7 @@ class TestSetRequestErrorHandling:
         handle.lib.Xcp_MainFunction()
         assert tuple(handle.can_if_transmit.call_args[0][1].SduDataPtr[0:2]) == (0xFE, 0x10)
 
-    @pytest.mark.parametrize('mode_bit', (0b00000001, 0b00000100, 0b00001000))
+    @pytest.mark.parametrize('mode_bit', PGM_ACTIVE_MODE_BITS)
     def test_returns_err_pgm_active(self, mode_bit):
         handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001))
         handle.xcp_store_calibration_data_to_non_volatile_memory.return_value = handle.define('E_NOT_OK')
@@ -308,7 +324,7 @@ class TestGetSeedErrorHandling:
         handle.lib.Xcp_MainFunction()
         assert tuple(handle.can_if_transmit.call_args[0][1].SduDataPtr[0:2]) == (0xFE, 0x10)
 
-    @pytest.mark.parametrize('mode_bit', (0b00000001, 0b00000100, 0b00001000))
+    @pytest.mark.parametrize('mode_bit', PGM_ACTIVE_MODE_BITS)
     def test_returns_err_pgm_active(self, mode_bit):
         handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001))
         handle.xcp_store_calibration_data_to_non_volatile_memory.return_value = handle.define('E_NOT_OK')
@@ -451,7 +467,7 @@ class TestUnlockErrorHandling:
         handle.lib.Xcp_MainFunction()
         assert tuple(handle.can_if_transmit.call_args[0][1].SduDataPtr[0:2]) == (0xFE, 0x10)
 
-    @pytest.mark.parametrize('mode_bit', (0b00000001, 0b00000100, 0b00001000))
+    @pytest.mark.parametrize('mode_bit', PGM_ACTIVE_MODE_BITS)
     def test_returns_err_pgm_active(self, mode_bit):
         handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001))
         handle.xcp_store_calibration_data_to_non_volatile_memory.return_value = handle.define('E_NOT_OK')
@@ -613,7 +629,7 @@ class TestSetMtaErrorHandling:
         handle.lib.Xcp_MainFunction()
         assert tuple(handle.can_if_transmit.call_args[0][1].SduDataPtr[0:2]) == (0xFE, 0x10)
 
-    @pytest.mark.parametrize('mode_bit', (0b00000001, 0b00000100, 0b00001000))
+    @pytest.mark.parametrize('mode_bit', PGM_ACTIVE_MODE_BITS)
     def test_returns_err_pgm_active(self, mode_bit):
         handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001))
         handle.xcp_store_calibration_data_to_non_volatile_memory.return_value = handle.define('E_NOT_OK')
@@ -679,7 +695,7 @@ class TestUploadErrorHandling:
         handle.lib.Xcp_MainFunction()
         assert tuple(handle.can_if_transmit.call_args[0][1].SduDataPtr[0:2]) == (0xFE, 0x10)
 
-    @pytest.mark.parametrize('mode_bit', (0b00000001, 0b00000100, 0b00001000))
+    @pytest.mark.parametrize('mode_bit', PGM_ACTIVE_MODE_BITS)
     def test_returns_err_pgm_active(self, mode_bit):
         handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001))
         handle.xcp_store_calibration_data_to_non_volatile_memory.return_value = handle.define('E_NOT_OK')
@@ -755,7 +771,7 @@ class TestShortUploadErrorHandling:
         handle.lib.Xcp_MainFunction()
         assert tuple(handle.can_if_transmit.call_args[0][1].SduDataPtr[0:2]) == (0xFE, 0x10)
 
-    @pytest.mark.parametrize('mode_bit', (0b00000001, 0b00000100, 0b00001000))
+    @pytest.mark.parametrize('mode_bit', PGM_ACTIVE_MODE_BITS)
     def test_returns_err_pgm_active(self, mode_bit):
         handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001))
         handle.xcp_store_calibration_data_to_non_volatile_memory.return_value = handle.define('E_NOT_OK')
@@ -843,7 +859,7 @@ class TestBuildChecksumErrorHandling:
         handle.lib.Xcp_MainFunction()
         assert tuple(handle.can_if_transmit.call_args[0][1].SduDataPtr[0:2]) == (0xFE, 0x10)
 
-    @pytest.mark.parametrize('mode_bit', (0b00000001, 0b00000100, 0b00001000))
+    @pytest.mark.parametrize('mode_bit', PGM_ACTIVE_MODE_BITS)
     def test_returns_err_pgm_active(self, mode_bit):
         handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001))
         handle.xcp_store_calibration_data_to_non_volatile_memory.return_value = handle.define('E_NOT_OK')
@@ -928,7 +944,7 @@ class TestTransportLayerCmdErrorHandling:
         handle.lib.Xcp_MainFunction()
         assert tuple(handle.can_if_transmit.call_args[0][1].SduDataPtr[0:2]) == (0xFE, 0x10)
 
-    @pytest.mark.parametrize('mode_bit', (0b00000001, 0b00000100, 0b00001000))
+    @pytest.mark.parametrize('mode_bit', PGM_ACTIVE_MODE_BITS)
     def test_returns_err_pgm_active(self, mode_bit):
         handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001))
         handle.xcp_store_calibration_data_to_non_volatile_memory.return_value = handle.define('E_NOT_OK')
@@ -1000,7 +1016,7 @@ class TestUserCmdErrorHandling:
         handle.lib.Xcp_MainFunction()
         assert tuple(handle.can_if_transmit.call_args[0][1].SduDataPtr[0:2]) == (0xFE, 0x10)
 
-    @pytest.mark.parametrize('mode_bit', (0b00000001, 0b00000100, 0b00001000))
+    @pytest.mark.parametrize('mode_bit', PGM_ACTIVE_MODE_BITS)
     def test_returns_err_pgm_active(self, mode_bit):
         handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001))
         handle.xcp_store_calibration_data_to_non_volatile_memory.return_value = handle.define('E_NOT_OK')
@@ -1069,7 +1085,7 @@ class TestDownloadErrorHandling:
         handle.lib.Xcp_MainFunction()
         assert tuple(handle.can_if_transmit.call_args[0][1].SduDataPtr[0:2]) == (0xFE, 0x10)
 
-    @pytest.mark.parametrize('mode_bit', (0b00000001, 0b00000100, 0b00001000))
+    @pytest.mark.parametrize('mode_bit', PGM_ACTIVE_MODE_BITS)
     def test_returns_err_pgm_active(self, mode_bit):
         handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001))
         handle.xcp_store_calibration_data_to_non_volatile_memory.return_value = handle.define('E_NOT_OK')
@@ -1181,7 +1197,7 @@ class TestDownloadNextErrorHandling:
         # matrix row lost the bit, the command would have run and left its own response here.
         assert tuple(handle.can_if_transmit.call_args[0][1].SduDataPtr[0:2]) == (0xFE, 0x10)
 
-    @pytest.mark.parametrize('mode_bit', (0b00000001, 0b00000100, 0b00001000))
+    @pytest.mark.parametrize('mode_bit', PGM_ACTIVE_MODE_BITS)
     def test_returns_err_pgm_active(self, mode_bit):
         """XCP part 2 - Protocol Layer Specification 1.0/1.7.3.2.2"""
         handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001))
@@ -1317,7 +1333,7 @@ class TestDownloadMaxErrorHandling:
         # matrix row lost the bit, the command would have run and left its own response here.
         assert tuple(handle.can_if_transmit.call_args[0][1].SduDataPtr[0:2]) == (0xFE, 0x10)
 
-    @pytest.mark.parametrize('mode_bit', (0b00000001, 0b00000100, 0b00001000))
+    @pytest.mark.parametrize('mode_bit', PGM_ACTIVE_MODE_BITS)
     def test_returns_err_pgm_active(self, mode_bit):
         """XCP part 2 - Protocol Layer Specification 1.0/1.7.3.2.2"""
         handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001))
@@ -1435,7 +1451,7 @@ class TestShortDownloadErrorHandling:
         # matrix row lost the bit, the command would have run and left its own response here.
         assert tuple(handle.can_if_transmit.call_args[0][1].SduDataPtr[0:2]) == (0xFE, 0x10)
 
-    @pytest.mark.parametrize('mode_bit', (0b00000001, 0b00000100, 0b00001000))
+    @pytest.mark.parametrize('mode_bit', PGM_ACTIVE_MODE_BITS)
     def test_returns_err_pgm_active(self, mode_bit):
         """XCP part 2 - Protocol Layer Specification 1.0/1.7.3.2.2"""
         handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001))
@@ -1561,7 +1577,7 @@ class TestModifyBitsErrorHandling:
         # matrix row lost the bit, the command would have run and left its own response here.
         assert tuple(handle.can_if_transmit.call_args[0][1].SduDataPtr[0:2]) == (0xFE, 0x10)
 
-    @pytest.mark.parametrize('mode_bit', (0b00000001, 0b00000100, 0b00001000))
+    @pytest.mark.parametrize('mode_bit', PGM_ACTIVE_MODE_BITS)
     def test_returns_err_pgm_active(self, mode_bit):
         """XCP part 2 - Protocol Layer Specification 1.0/1.7.3.2.2"""
         handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001))
@@ -1690,7 +1706,7 @@ class TestSetCalPageErrorHandling:
         # matrix row lost the bit, the command would have run and left its own response here.
         assert tuple(handle.can_if_transmit.call_args[0][1].SduDataPtr[0:2]) == (0xFE, 0x10)
 
-    @pytest.mark.parametrize('mode_bit', (0b00000001, 0b00000100, 0b00001000))
+    @pytest.mark.parametrize('mode_bit', PGM_ACTIVE_MODE_BITS)
     def test_returns_err_pgm_active(self, mode_bit):
         """XCP part 2 - Protocol Layer Specification 1.0/1.7.3.2.2"""
         handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001,
@@ -1841,7 +1857,7 @@ class TestGetCalPageErrorHandling:
         # matrix row lost the bit, the command would have run and left its own response here.
         assert tuple(handle.can_if_transmit.call_args[0][1].SduDataPtr[0:2]) == (0xFE, 0x10)
 
-    @pytest.mark.parametrize('mode_bit', (0b00000001, 0b00000100, 0b00001000))
+    @pytest.mark.parametrize('mode_bit', PGM_ACTIVE_MODE_BITS)
     def test_returns_err_pgm_active(self, mode_bit):
         """XCP part 2 - Protocol Layer Specification 1.0/1.7.3.2.2"""
         handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001,
@@ -1956,7 +1972,7 @@ class TestGetPagProcessorInfoErrorHandling:
         # matrix row lost the bit, the command would have run and left its own response here.
         assert tuple(handle.can_if_transmit.call_args[0][1].SduDataPtr[0:2]) == (0xFE, 0x10)
 
-    @pytest.mark.parametrize('mode_bit', (0b00000001, 0b00000100, 0b00001000))
+    @pytest.mark.parametrize('mode_bit', PGM_ACTIVE_MODE_BITS)
     def test_returns_err_pgm_active(self, mode_bit):
         """XCP part 2 - Protocol Layer Specification 1.0/1.7.3.2.2"""
         handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001,
@@ -2026,7 +2042,7 @@ class TestGetSegmentInfoErrorHandling:
         # matrix row lost the bit, the command would have run and left its own response here.
         assert tuple(handle.can_if_transmit.call_args[0][1].SduDataPtr[0:2]) == (0xFE, 0x10)
 
-    @pytest.mark.parametrize('mode_bit', (0b00000001, 0b00000100, 0b00001000))
+    @pytest.mark.parametrize('mode_bit', PGM_ACTIVE_MODE_BITS)
     def test_returns_err_pgm_active(self, mode_bit):
         """XCP part 2 - Protocol Layer Specification 1.0/1.7.3.2.2"""
         handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001,
@@ -2151,7 +2167,7 @@ class TestGetPageInfoErrorHandling:
         # matrix row lost the bit, the command would have run and left its own response here.
         assert tuple(handle.can_if_transmit.call_args[0][1].SduDataPtr[0:2]) == (0xFE, 0x10)
 
-    @pytest.mark.parametrize('mode_bit', (0b00000001, 0b00000100, 0b00001000))
+    @pytest.mark.parametrize('mode_bit', PGM_ACTIVE_MODE_BITS)
     def test_returns_err_pgm_active(self, mode_bit):
         """XCP part 2 - Protocol Layer Specification 1.0/1.7.3.2.2"""
         handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001,
@@ -2279,7 +2295,7 @@ class TestSetSegmentModeErrorHandling:
         # matrix row lost the bit, the command would have run and left its own response here.
         assert tuple(handle.can_if_transmit.call_args[0][1].SduDataPtr[0:2]) == (0xFE, 0x10)
 
-    @pytest.mark.parametrize('mode_bit', (0b00000001, 0b00000100, 0b00001000))
+    @pytest.mark.parametrize('mode_bit', PGM_ACTIVE_MODE_BITS)
     def test_returns_err_pgm_active(self, mode_bit):
         """XCP part 2 - Protocol Layer Specification 1.0/1.7.3.2.2"""
         handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001,
@@ -2414,7 +2430,7 @@ class TestGetSegmentModeErrorHandling:
         # matrix row lost the bit, the command would have run and left its own response here.
         assert tuple(handle.can_if_transmit.call_args[0][1].SduDataPtr[0:2]) == (0xFE, 0x10)
 
-    @pytest.mark.parametrize('mode_bit', (0b00000001, 0b00000100, 0b00001000))
+    @pytest.mark.parametrize('mode_bit', PGM_ACTIVE_MODE_BITS)
     def test_returns_err_pgm_active(self, mode_bit):
         """XCP part 2 - Protocol Layer Specification 1.0/1.7.3.2.2"""
         handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001,
@@ -2505,7 +2521,7 @@ class TestCopyCalPageErrorHandling:
         # matrix row lost the bit, the command would have run and left its own response here.
         assert tuple(handle.can_if_transmit.call_args[0][1].SduDataPtr[0:2]) == (0xFE, 0x10)
 
-    @pytest.mark.parametrize('mode_bit', (0b00000001, 0b00000100, 0b00001000))
+    @pytest.mark.parametrize('mode_bit', PGM_ACTIVE_MODE_BITS)
     def test_returns_err_pgm_active(self, mode_bit):
         """XCP part 2 - Protocol Layer Specification 1.0/1.7.3.2.2"""
         handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001,

--- a/test/get_status_test.py
+++ b/test/get_status_test.py
@@ -6,13 +6,13 @@ from .conftest import XcpTest
 from .download_test import connect
 
 
+# Only STORE_CAL_REQ survives here. The cases that once drove STORE_DAQ_REQ (0b100) and
+# CLEAR_DAQ_REQ (0b1000) through SET_REQUEST and asserted they appeared in the session status were
+# asserting the defect: neither mode is fulfilled by any code, so the bit latched forever and, via
+# the ERR_PGM_ACTIVE gate in Xcp_CanIfRxIndication, disabled most of the command set for the rest
+# of the session. SET_REQUEST now refuses both; the tests below cover that.
 @pytest.mark.parametrize('current_session_status_byte, set_request_mode_byte', ((0b00000000, 0b00000000),
-                                                                                (0b00000001, 0b00000001),
-                                                                                (0b00000100, 0b00000100),
-                                                                                (0b00001000, 0b00001000),
-                                                                                (0b00001001, 0b00001001),
-                                                                                (0b00001100, 0b00001100),
-                                                                                (0b00001101, 0b00001101)))
+                                                                                (0b00000001, 0b00000001)))
 def test_get_status_returns_the_current_session_status_for_bytes_0_2_3(current_session_status_byte,
                                                                        set_request_mode_byte):
     handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001))
@@ -39,9 +39,42 @@ def test_get_status_returns_the_current_session_status_for_bytes_0_2_3(current_s
     assert handle.can_if_transmit.call_args[0][1].SduDataPtr[1] == current_session_status_byte
 
 
-@pytest.mark.skip(reason='not implemented yet, implement me...')
-def test_get_status_returns_the_current_session_status_for_bytes_6_7():
-    pass
+def test_get_status_reports_a_session_configuration_id_of_zero_rather_than_a_placeholder():
+    """XCP part 2 - Protocol Layer Specification 1.0/1.6.1.1.3, bytes 4,5.
+
+    This replaces a skipped placeholder that had stood as defect D9's marker (and misnamed the
+    offsets as bytes 6,7). The id is written by SET_REQUEST with STORE_DAQ_REQ and held in
+    non-volatile memory beside the stored DAQ lists; this module refuses STORE_DAQ_REQ and reports
+    RESUME unsupported, so nothing is ever stored and 0 -- what the specification itself resets the
+    id to on CLEAR_DAQ_REQ -- is the honest answer. It reported the fabricated constant 0xABCD
+    until D9 was closed, which a master could not distinguish from a real stored id."""
+    handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001))
+    connect(handle)
+
+    handle.lib.Xcp_CanIfRxIndication(0x0001, handle.get_pdu_info((0xFD,)))
+    handle.lib.Xcp_MainFunction()
+
+    assert tuple(handle.can_if_transmit.call_args[0][1].SduDataPtr[0x04:0x06]) == (0x00, 0x00)
+
+
+@pytest.mark.parametrize('mode, name', ((0b00000100, 'STORE_DAQ_REQ'),
+                                        (0b00001000, 'CLEAR_DAQ_REQ')))
+def test_get_status_never_reports_a_request_no_code_can_fulfil(mode, name):
+    """A request bit is cleared by the slave once the request is fulfilled (1.0/1.6.1.1.3). Nothing
+    in this module fulfils the two non-volatile DAQ requests, so a bit that reached the session
+    status would stay set for the rest of the session and GET_STATUS would report a store that was
+    never going to complete. SET_REQUEST refuses them instead, which is what keeps this clear."""
+    handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001))
+    connect(handle)
+
+    handle.lib.Xcp_CanIfRxIndication(0x0001, handle.get_pdu_info((0xF9, mode, 0x00, 0x00)))
+    handle.lib.Xcp_MainFunction()
+    handle.lib.Xcp_CanIfTxConfirmation(0x0001, handle.define('E_OK'))
+
+    handle.lib.Xcp_CanIfRxIndication(0x0001, handle.get_pdu_info((0xFD,)))
+    handle.lib.Xcp_MainFunction()
+
+    assert handle.can_if_transmit.call_args[0][1].SduDataPtr[1] == 0x00
 
 
 @pytest.mark.parametrize('trailing_value', trailing_values)

--- a/test/set_request_test.py
+++ b/test/set_request_test.py
@@ -3,6 +3,7 @@
 
 from .parameter import *
 from .conftest import XcpTest
+from .download_test import connect
 
 
 def test_set_request_activates_the_callback_function_call_until_finished():
@@ -124,3 +125,75 @@ def test_set_request_sets_all_remaining_bytes_to_trailing_value(trailing_value, 
     handle.lib.Xcp_MainFunction()
     remaining_zeros = tuple(trailing_value for _ in range(max_cto - 0x08))
     assert tuple(handle.can_if_transmit.call_args[0][1].SduDataPtr[0x08:max_cto]) == remaining_zeros
+
+
+def exchange(handle, request, tx_pdu_ref=0x0001, length=8):
+    handle.lib.Xcp_CanIfRxIndication(0x0001, handle.get_pdu_info(request))
+    handle.lib.Xcp_MainFunction()
+    handle.lib.Xcp_CanIfTxConfirmation(tx_pdu_ref, handle.define('E_OK'))
+    return tuple(handle.can_if_transmit.call_args[0][1].SduDataPtr[0:length])
+
+
+@pytest.mark.parametrize('mode, name', ((0b00000100, 'STORE_DAQ_REQ'),
+                                        (0b00001000, 'CLEAR_DAQ_REQ')))
+def test_set_request_refuses_the_non_volatile_daq_modes_it_cannot_fulfil(mode, name):
+    """XCP part 2 - Protocol Layer Specification 1.0/1.6.1.2.3: "If the slave device does not
+    support the requested mode, an ERR_OUT_OF_RANGE will be returned."
+
+    STORE_DAQ_REQ saves the selected DAQ lists to non-volatile memory and CLEAR_DAQ_REQ clears
+    what is stored there. This module keeps no non-volatile DAQ configuration -- consistent with
+    GET_DAQ_PROCESSOR_INFO, which reports RESUME unsupported -- so both are refused rather than
+    accepted and quietly dropped. STORE_CAL_REQ is unaffected; it is implemented end to end."""
+    handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001))
+    connect(handle)
+
+    assert exchange(handle, (0xF9, mode, 0x00, 0x00))[0:2] == (0xFE, 0x22)
+
+
+def test_a_refused_store_daq_request_leaves_the_rest_of_the_command_set_usable():
+    """Regression, defect D9. SET_REQUEST used to accept STORE_DAQ_REQ and OR it into
+    Xcp_Internal.session_status. No code fulfils that request, so nothing ever cleared the bit --
+    and Xcp_CanIfRxIndication refuses every command carrying ERR_PGM_ACTIVE, 42 of them, for as
+    long as one of the three request bits is set. A single conformant SET_REQUEST therefore
+    disabled most of the command set until the next CONNECT.
+
+    The assertion is that the following command *succeeds*: a permanent, silent refusal was the
+    whole defect, so asserting merely that SET_REQUEST failed would not catch its return. This
+    holds for any correct implementation -- refusing the mode, or accepting and fulfilling it."""
+    handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001, daqs=(daq(name='DAQ1'),)))
+    connect(handle)
+
+    exchange(handle, (0xF9, 0b00000100, 0x00, 0x00), tx_pdu_ref=0x0002)
+
+    # GET_DAQ_LIST_MODE (0xDF) carries ERR_PGM_ACTIVE in Xcp_CTOErrorMatrix.
+    assert exchange(handle, (0xDF, 0x00, 0x00, 0x00), tx_pdu_ref=0x0002)[0] == 0xFF
+
+
+def test_set_request_stores_calibration_even_when_the_session_configuration_id_is_not_zero():
+    """The session configuration id in bytes 2,3 belongs to STORE_DAQ_REQ, not to STORE_CAL_REQ.
+    A check on it used to sit in this handler, but it ran after the success branch had been
+    entered: it set the local result and then finalized a positive response anyway, so it never
+    reached the master and only read as validation. It is gone; a calibration store is decided by
+    the mode byte alone."""
+    handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001))
+
+    def store_calibration_data_to_non_volatile_memory(p_success):
+        p_success[0] = handle.define('E_OK')
+        return handle.define('E_OK')
+
+    handle.xcp_store_calibration_data_to_non_volatile_memory.side_effect = \
+        store_calibration_data_to_non_volatile_memory
+
+    connect(handle)
+
+    handle.lib.Xcp_CanIfRxIndication(0x0001, handle.get_pdu_info((0xF9, 0b00000001, 0xAB, 0xCD)))
+    handle.lib.Xcp_MainFunction()
+
+    # Read the response before the confirmation: confirming chains the queued EV_STORE_CAL onto the
+    # same in-flight slot, so the last CanIf_Transmit call would be the event, not the response.
+    assert handle.can_if_transmit.call_args[0][1].SduDataPtr[0] == 0xFF
+
+    handle.lib.Xcp_CanIfTxConfirmation(0x0001, handle.define('E_OK'))
+    handle.lib.Xcp_MainFunction()
+
+    assert handle.xcp_store_calibration_data_to_non_volatile_memory.called


### PR DESCRIPTION
Closes defect **D9**. The defect was not the cosmetic one the `TODO`s described.

**12532 passed, 29 skipped.** `Xcp_Std.c` coverage 99.31% → **99.53%**.

## A single conformant SET_REQUEST disabled most of the command set

`SET_REQUEST` accepted `STORE_DAQ_REQ` and `CLEAR_DAQ_REQ` and OR-ed them into `Xcp_Internal.session_status`. No code fulfils either request — this module keeps no non-volatile DAQ configuration — so nothing ever cleared the bit.

Those bits gate `ERR_PGM_ACTIVE` in `Xcp_CanIfRxIndication`, which refuses **every command carrying that flag — 42 of them — for as long as one is set**. So one conformant request from a master left most of the command set refused **until the next CONNECT**. That is a session-wide denial of service, not a misreported byte.

`STORE_CAL_REQ` was never affected: `Xcp_MainFunction` fulfils it through the integrator's store callback and clears its bit. It is untouched here.

## The session-id check never ran

```c
if (result == E_OK)
{
    ...
    if (session_configuration_id != 0x00u)
    {
        result = XCP_E_ASAM_OUT_OF_RANGE;   /* set after the branch was entered */
    }
    ...
    Xcp_FinalizeResPacket(0x01u, ...);      /* positive response goes out anyway */
}
```

It set `result` *after* the success branch had been entered, then finalized a positive response regardless — and the caller discards the return value. The error never reached the master; the check only read as validation. Removed rather than repaired: the id belongs to `STORE_DAQ_REQ`, which is now refused, so there is nothing to validate it against.

## Why refusal is the right fix, not a workaround

§1.6.1.2.3 provides it directly: *"If the slave device does not support the requested mode, an ERR_OUT_OF_RANGE will be returned."*

It also matches what the module already advertises — `GET_DAQ_PROCESSOR_INFO` reports RESUME unsupported, and non-volatile DAQ storage exists to serve RESUME. Accepting `CLEAR_DAQ_REQ` as a vacuous no-op (its postcondition does hold) was considered and rejected: accepting one while refusing the other would signal partial NV support that does not exist.

`GET_STATUS` now reports session configuration id `0` — the value the specification itself resets it to — instead of `0xABCD`, which a master could not distinguish from a real stored id.

## Three existing tests asserted the defect

- the `GET_STATUS` session-status sweep, parametrised over `0b100`/`0b1000`, asserting those bits latched;
- **23 copies** of `test_returns_err_pgm_active`, all reaching the gate through the two modes that can no longer latch.

Those now provoke `ERR_PGM_ACTIVE` through `STORE_CAL_REQ`, which is genuinely implemented. The shared `PGM_ACTIVE_MODE_BITS` constant records why the other two left and when they come back. Note the irony: those 23 tests demonstrated the gate's reach, which is exactly the mechanism that made the defect severe.

## Verification

Mutation-verified both halves. Restoring the old mask fails exactly the five refusal and denial-of-service tests; restoring `0xABCD` fails exactly the session-id test. Test-count arithmetic reconciles exactly: −46 (23 × 2 dropped params) −5 (sweep) +7 new, and the skipped D9 placeholder became a real test.

The denial-of-service regression asserts the following command **succeeds**, not merely that `SET_REQUEST` failed — a permanent silent refusal was the whole defect, and the assertion holds for any correct implementation, including a future one that accepts and fulfils the mode.

## Follow-up

This closes the misreporting, not the feature. Accepting these modes needs non-volatile storage, recorded as **SP5-NV** in the roadmap with the intended shape: an asynchronous integrator callback pair following the `Xcp_StoreCalibrationDataToNonVolatileMemory` pattern, plus the three constraints this investigation surfaced — clear the request bit on every exit path, clear-before-store ordering per §1.6.1.2.3, and lift the `RESUME` advertisement and the `SET_REQUEST`/`SET_DAQ_LIST_MODE` refusals together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
