### PR TITLE
docs: correct two notes left stale by the bit fix and by the SP2c finding

### DIFF
--- a/docs/superpowers/specs/2026-08-29-xcp-part2-roadmap.md
+++ b/docs/superpowers/specs/2026-08-29-xcp-part2-roadmap.md
@@ -337,8 +337,20 @@ not:
   transmission chain SP2a built — the one guarded by the `SchM` exclusive area and shaped by
   D16. Scope them deliberately, and consider splitting them out, rather than treating the
   bullet as one homogeneous list.
-- **SP2c** — **next.** DAQ list prioritisation, more than one outstanding DTO frame, and
-  `ALTERNATING`.
+- **SP2c** — DAQ list prioritisation and more than one outstanding DTO frame. **Deferred, and it
+  buys no conformance.** §1.6.4.1.1.3 states outright that *"If the ECU doesn't support the
+  prioritization of DAQ lists, a DAQ list priority > 0 is not allowed and will be indicated by
+  returning ERR_OUT_OF_RANGE"*, which is exactly what the module does today; and "more than one
+  outstanding DTO frame" is not a protocol concept at all, only throughput. SP2b made a full ring
+  a *reported* condition through `EV_DAQ_OVERLOAD`, so the current single-frame chain is slow
+  under load, never silent. Schedule this against a measured throughput requirement, not against
+  the specification.
+
+  `ALTERNATING` was removed from this entry on 2026-09-02 and needs no further work. It is
+  declared through `DAQ_ALTERNATING_SUPPORTED` in the **A2L file**, which this module does not
+  emit, and it takes a display event channel number; the protocol layer gives it no slave-side
+  transmission semantics, and 1.1 forbids combining it with `TIMESTAMP`, which SP2b shipped. It is
+  refused at bit 0 of the `SET_DAQ_LIST_MODE` mode byte, where 1.1 puts it.
 
   Unlike SP2a and SP2b, this is not additive. Those extended a dispatch surface that already
   worked; SP2c reworks the confirmation-driven transmission chain that DD3 built and the `SchM`
@@ -346,9 +358,11 @@ not:
   also differ in risk: prioritisation reorders what the ring already holds, while multiple
   outstanding frames changes the ring's own invariants. Consider splitting them.
 
-- **SP2d** — dynamic DAQ list configuration (§1.6.4.3), the `DAQ_CONFIG_TYPE` = dynamic branch, and
-  the four remaining commands: `FREE_DAQ` (0xD6), `ALLOC_DAQ` (0xD5), `ALLOC_ODT` (0xD4) and
-  `ALLOC_ODT_ENTRY` (0xD3).
+- **SP2d** — **next.** Dynamic DAQ list configuration (§1.6.4.2 in 1.0, renumbered in 1.1), the
+  `DAQ_CONFIG_TYPE` = dynamic branch, and the four remaining commands: `FREE_DAQ` (0xD6),
+  `ALLOC_DAQ` (0xD5), `ALLOC_ODT` (0xD4) and `ALLOC_ODT_ENTRY` (0xD3). Chosen ahead of SP2c
+  because it is additive to the dispatch surface, and because a master that cannot allocate its
+  own lists is confined to whatever the generated static configuration happens to contain.
 
 An earlier revision of this section proposed decomposing by layer — configuration model,
 then command surface, then runtime. That was rejected when the design was written: no layer

--- a/interface/Xcp_Types.h
+++ b/interface/Xcp_Types.h
@@ -638,8 +638,12 @@ typedef struct {
 
     /**
      * @brief current mode, in the GET_DAQ_LIST_MODE layout of 1.1/1.6.4.1.2.6.
-     * @details Stored in the layout the slave reports rather than the one it receives:
-     * SET_DAQ_LIST_MODE puts DIRECTION at bit 0, while this byte puts SELECTED there.
+     * @details Stored in the layout the slave reports rather than the one it receives. The two
+     * layouts differ only at bit 0, where SET_DAQ_LIST_MODE has ALTERNATING (refused) and this
+     * byte has SELECTED, and at bits 6 and 7, which carry RUNNING and RESUME here and are
+     * don't-care in the request. DIRECTION is bit 1 in both. This previously read "SET_DAQ_LIST_MODE
+     * puts DIRECTION at bit 0", which was true of the module's own constants but not of the
+     * specification; the constants were corrected to bit 1 and this note was left behind.
      */
     uint8 mode;
 


### PR DESCRIPTION
Two documentation corrections found while gathering context for SP2d. No behaviour change; the header comment is the reason this isn't purely cosmetic.

## A false claim about bit positions, left by #9

`Xcp_Types.h` described the stored DAQ list mode byte by contrasting it with the request layout:

> SET_DAQ_LIST_MODE puts DIRECTION at bit 0, while this byte puts SELECTED there.

That was true of the module's own constants but never of the specification. #9 corrected the constants to bit 1 and did not revisit this note, so the codebase now carried a comment contradicting the constants it describes.

`DIRECTION` is bit 1 in **both** layouts. They differ only at bit 0 — `ALTERNATING` in the request (refused) against `SELECTED` here — and at bits 6 and 7, which carry `RUNNING` and `RESUME` here and are don't-care in the request.

A confident, unchecked claim in a comment about bit positions is the exact failure mode that produced the defect #9 fixed. The replacement records what the note used to say and why it was wrong, so the correction doesn't read as arbitrary to whoever reads it next.

## Roadmap: SP2c and ALTERNATING

The roadmap still listed SP2c as next and still carried `ALTERNATING` inside it.

`ALTERNATING` is resolved and needs no further work: declared through `DAQ_ALTERNATING_SUPPORTED` in the **A2L file** (which this module does not emit), given no slave-side transmission semantics by the protocol layer, and forbidden by 1.1 in combination with `TIMESTAMP`, which SP2b shipped.

SP2c is now recorded as buying **no conformance**: §1.6.4.1.1.3 permits refusing priority > 0 with `ERR_OUT_OF_RANGE`, which is what the module does, and "more than one outstanding DTO frame" is a throughput property rather than a protocol one — SP2b already made a full ring reported through `EV_DAQ_OVERLOAD` rather than silent. It should be scheduled against a measured throughput requirement, not against the specification. SP2d is marked next in its place.

Verified the header still compiles and its tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
