### PR TITLE
feat: dynamic DAQ list configuration (SP2d)

### DIFF
--- a/config/xcp.json
+++ b/config/xcp.json
@@ -172,19 +172,19 @@
           "protected": false
         },
         "xcp_free_daq_api_enable": {
-          "enabled": true,
+          "enabled": false,
           "protected": false
         },
         "xcp_alloc_daq_api_enable": {
-          "enabled": true,
+          "enabled": false,
           "protected": false
         },
         "xcp_alloc_odt_api_enable": {
-          "enabled": true,
+          "enabled": false,
           "protected": false
         },
         "xcp_alloc_odt_entry_api_enable": {
-          "enabled": true,
+          "enabled": false,
           "protected": false
         },
         "xcp_program_clear_api_enable": {

--- a/config/xcp.schema.json
+++ b/config/xcp.schema.json
@@ -94,7 +94,7 @@
                   "default": "DAQ"
                 },
                 "triggered_daq_list_ref": {
-                  "description": "References all DAQ lists that are trigged by this event channel (see ECUC_Xcp_00151)",
+                  "description": "References all DAQ lists that are trigged by this event channel (see ECUC_Xcp_00151). Required by a DAQ_STATIC configuration and refused by a DAQ_DYNAMIC one -- see the $comment beside the if/then/else at the end of this configuration item -- because a dynamic configuration declares no DAQ lists for a reference to name. Every list the master allocates out of the pool may bind to any event channel, so a dynamic configuration reports the whole pool as each channel's MAX_DAQ_LIST instead",
                   "type": "array",
                   "items": {
                     "type": "string"
@@ -104,8 +104,7 @@
               "required": [
                 "priority",
                 "time_cycle",
-                "time_unit",
-                "triggered_daq_list_ref"
+                "time_unit"
               ]
             },
             "minItems": 1,
@@ -175,6 +174,42 @@
               ]
             },
             "minItems": 1
+          },
+          "daq_dynamic": {
+            "description": "Dimensions of the DAQ pool a DAQ_DYNAMIC configuration reserves at build time, and which the master hands out at runtime through FREE_DAQ, ALLOC_DAQ, ALLOC_ODT and ALLOC_ODT_ENTRY. Required when protocol_layer.daq_config_type is DYNAMIC, and rejected otherwise: a pool nothing can ever allocate from would silently go nowhere. AUTOSAR's capacity model is rectangular, so the reservation is daq_count x odt_count x odt_entries_count in full, and every DAQ list gets the same caps",
+            "type": "object",
+            "properties": {
+              "daq_count": {
+                "description": "DAQ_COUNT indicates the number of DAQ lists the master may allocate (DYNAMIC configuration) (see ECUC_Xcp_00012). Generation refuses a value above 255: GET_DAQ_EVENT_INFO transmits MAX_DAQ_LIST as one byte (XCP part 2 - Protocol Layer Specification 1.1/1.6.4.1.2.7), and a dynamic configuration reports the pool size there because any allocated list may bind to any event channel",
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 65535
+              },
+              "odt_count": {
+                "description": "This parameter indicates the maximum amount of ODTs in a DAQ list (DYNAMIC configuration) (see ECUC_Xcp_00054)",
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 252
+              },
+              "odt_entries_count": {
+                "description": "This parameter indicates the maximum amount of entries in an ODT (DYNAMIC configuration) (see ECUC_Xcp_00059)",
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 255
+              },
+              "pdu_mapping": {
+                "description": "This reference specifies the mapping of the DTO to the PDU from the lower-layer interface every list in the pool transmits on. A dynamic configuration declares no DAQ lists of its own, so there is no per-list pdu_mapping to take this from (see ECUC_Xcp_00067)",
+                "type": "string",
+                "pattern": "[A-Z_][A-Z0-9_]*"
+              }
+            },
+            "required": [
+              "daq_count",
+              "odt_count",
+              "odt_entries_count",
+              "pdu_mapping"
+            ],
+            "additionalProperties": false
           },
           "segments": {"type": "array", "maxItems": 255, "items": {"$ref": "#/definitions/segment"}},
           "paging": {"$ref": "#/definitions/paging"},
@@ -390,6 +425,15 @@
             "description": "This container allows the user to specify protocol layer specific parameters. This is not part of the specification",
             "type": "object",
             "properties": {
+              "daq_config_type": {
+                "description": "Sets the DAQ_CONFIG_TYPE bit within DAQ_PROPERTIES to static or dynamic (see ECUC_Xcp_00164). DAQ_STATIC generates the DAQ lists declared under daqs; DAQ_DYNAMIC generates an empty pool the master fills through FREE_DAQ, ALLOC_DAQ, ALLOC_ODT and ALLOC_ODT_ENTRY",
+                "type": "string",
+                "enum": [
+                  "STATIC",
+                  "DYNAMIC"
+                ],
+                "default": "STATIC"
+              },
               "byte_order": {
                 "type": "string",
                 "enum": [
@@ -579,10 +623,67 @@
         "required": [
           "communication",
           "events",
-          "daqs",
           "apis",
           "protocol_layer"
         ],
+        "$comment": "daqs is deliberately absent from the required list above and pinned by the if/then/else below instead: it is required by a DAQ_STATIC configuration, which is what declares DAQ lists, and refused outright by a DAQ_DYNAMIC one, which declares a pool for the master to allocate out of. daq_dynamic is the exact mirror. The two directions are also guarded in script/source_cfg.c.jinja2, because a configuration reaches the generator through BSWCodeGen's Python API without passing this schema at all",
+        "if": {
+          "required": [
+            "protocol_layer"
+          ],
+          "properties": {
+            "protocol_layer": {
+              "required": [
+                "daq_config_type"
+              ],
+              "properties": {
+                "daq_config_type": {
+                  "const": "DYNAMIC"
+                }
+              }
+            }
+          }
+        },
+        "then": {
+          "required": [
+            "daq_dynamic"
+          ],
+          "not": {
+            "required": [
+              "daqs"
+            ]
+          },
+          "properties": {
+            "events": {
+              "items": {
+                "not": {
+                  "required": [
+                    "triggered_daq_list_ref"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "else": {
+          "required": [
+            "daqs"
+          ],
+          "not": {
+            "required": [
+              "daq_dynamic"
+            ]
+          },
+          "properties": {
+            "events": {
+              "items": {
+                "required": [
+                  "triggered_daq_list_ref"
+                ]
+              }
+            }
+          }
+        },
         "additionalProperties": false
       },
       "minItems": 1

--- a/docs/superpowers/plans/2026-09-03-xcp-daq-sp2d.md
+++ b/docs/superpowers/plans/2026-09-03-xcp-daq-sp2d.md
@@ -139,7 +139,7 @@ Each moves from `Xcp_Ptr->config->daqList[N].maxOdtEntries` to that ODT's `entry
 
 - [ ] **Step 6: Run the new test and the full suite**
 
-Expected: the new test passes, and **12532 passed, 29 skipped** — the count before this task, unchanged. Any other difference means the relocation changed behaviour and must be investigated, not accepted.
+Expected: the new test passes, and every other count is unchanged — **measure the baseline on this branch before changing anything** rather than trusting a number written here, then require exactly `+1 passed`, skips and failures identical. Any other difference means a relocated bound changed behaviour and must be investigated, not accepted.
 
 - [ ] **Step 7: Mutation-verify**
 

--- a/docs/superpowers/plans/2026-09-03-xcp-daq-sp2d.md
+++ b/docs/superpowers/plans/2026-09-03-xcp-daq-sp2d.md
@@ -1,0 +1,1049 @@
+# SP2d — Dynamic DAQ List Configuration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let an XCP master allocate DAQ lists, ODTs and ODT entries at runtime through `FREE_DAQ`, `ALLOC_DAQ`, `ALLOC_ODT` and `ALLOC_ODT_ENTRY`, selected by a build-time configuration switch.
+
+**Architecture:** A `daq_config_type` key picks STATIC (today's generated lists, unchanged) or DYNAMIC (an empty pool the master fills). Capacity is AUTOSAR's rectangle — `daq_count` lists × `odt_count` ODTs × `odt_entries_count` entries — reserved in full. The allocator writes the DAQ list descriptor in place, so the existing bounds checks keep working against values that now change at runtime.
+
+**Tech Stack:** C (AUTOSAR-style BSW), Jinja2 code generation via `bsw_code_gen`, pytest + CFFI compiling the real sources, CMake 3.19+, Docker image `xcp-test:local`.
+
+**Spec:** `docs/superpowers/specs/2026-09-03-xcp-daq-sp2d-design.md`
+
+## Global Constraints
+
+- Specification citations use **1.1 numbering** (`XCP part 2 - Protocol Layer Specification 1.1/...`). Dynamic configuration is §1.6.4.3; SP2a's design §0 carries the 1.0↔1.1 mapping table.
+- **A STATIC build must stay behaviourally identical.** `test/cmd_unknown_test.py` must keep passing unchanged, and it asserts `0xD3`–`0xD6` answer `ERR_CMD_UNKNOWN`.
+- **SP2d adds no new bounds check.** Unallocated lists have `maxOdt == 0` and fail the checks that already exist. Task 1 *relocates* 6 entry bounds; it adds none.
+- **Do not add a list-validity check to the sampler.** `Xcp_TriggerEventChannel` iterates `daq_idx < Xcp_Ptr->general->daqCount` deliberately; see spec §6.
+- Error identifiers: `XCP_E_ASAM_CMD_UNKNOWN` `0x20`, `XCP_E_ASAM_OUT_OF_RANGE` `0x22`, `XCP_E_ASAM_SEQUENCE` `0x29`, `XCP_E_ASAM_MEMORY_OVERFLOW` `0x30`.
+- `raise(...)` is **not** a registered Jinja global. Referencing it aborts rendering with `UndefinedError`, which is the intended effect, but the message never reaches the caller. Write the message for the human reading the template; test that generation *fails*, never that a message matches.
+- **Mutation-verify every new test**: break the line it targets, confirm that test fails and nothing else does, restore, confirm clean via `git diff`.
+- `XCP_PYTEST_ARGS` is a **CMake cache variable**. A stale filter makes a "full" run silently execute a subset and report green. Reset it with `-DXCP_PYTEST_ARGS=` before any run you will quote as full.
+- The DAQ list runtime reset values are `mode = 0x00u`, `eventChannelNumber = 0x0000u`, **`prescaler = 0x01u`**, `prescalerCounter = 0x00u`, `priority = 0x00u`. Prescaler is one, not zero.
+
+**Test commands.**
+
+Filtered:
+```bash
+docker run --rm --user $(id -u):$(id -g) -v $(pwd):/usr/project xcp-test:local sh -c "cd /usr/project/build && cmake .. -DXCP_ENABLE_TEST=ON -DXCP_PYTEST_ARGS='-k;FILTER;--maxfail=99' >/dev/null && make all >/dev/null 2>&1 && LD_LIBRARY_PATH=\$LD_LIBRARY_PATH:/usr/project/build ctest -V --no-tests=error 2>&1 | grep -E '^1: FAILED|passed|failed'"
+```
+
+Full (takes about 4m20s):
+```bash
+docker run --rm --user $(id -u):$(id -g) -v $(pwd):/usr/project xcp-test:local sh -c "cd /usr/project/build && cmake .. -DXCP_ENABLE_TEST=ON -DXCP_PYTEST_ARGS= >/dev/null" && docker run --rm --user $(id -u):$(id -g) -v $(pwd):/usr/project xcp-test:local sh -c "cd /usr/project && ./test.sh"
+```
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|:--|:--|
+| `interface/Xcp_Types.h` | Descriptor members lose `const`; `Xcp_OdtType` gains `entryCount` |
+| `source/Xcp_Internal.h` | Allocation state enum; `daq_alloc_state` and `allocated_daq_count` in `Xcp_InternalType` |
+| `source/Xcp_Daq.c` | The four handlers, the state machine, the `firstPid` prefix sum, the shared per-list reset |
+| `source/Xcp.c` | `Xcp_PIDTable` entries for `0xD3`–`0xD6`; allocation state reset in `Xcp_Init` |
+| `source/Xcp_DaqRuntime.c` | One relocated entry bound (Task 1) |
+| `script/source_cfg.c.jinja2` | `daq_config_type` derivation, pool emission, MemMap sections, new guards |
+| `script/source_rt.c.jinja2` | Runtime DAQ list array sized from the pool under DYNAMIC |
+| `config/xcp.schema.json` | `daq_config_type`, `daq_dynamic`, the `if/then` pairing |
+| `test/parameter.py` | `daq_config_type` / `daq_dynamic` kwargs; the four ALLOC flags default `False` |
+| `test/free_daq_test.py`, `alloc_daq_test.py`, `alloc_odt_test.py`, `alloc_odt_entry_test.py` | One per command |
+| `test/daq_dynamic_acceptance_test.py` | Full round trip and the 16-cell state sweep |
+
+---
+
+## Task 1: Per-ODT entry count and mutable descriptor members
+
+Implements **DD27** (mutable descriptor) and the field half of **DD34**. Pure refactor. **Zero behaviour change** — its whole proof is that the existing suite passes untouched.
+
+**Files:**
+- Modify: `interface/Xcp_Types.h`
+- Modify: `script/source_cfg.c.jinja2:41-100` (ODT emission)
+- Modify: `source/Xcp_Daq.c` (5 bounds), `source/Xcp_DaqRuntime.c` (1 bound)
+- Test: `test/daq_configuration_test.py`
+
+**Interfaces:**
+- Produces: `Xcp_OdtType.entryCount` (`uint8`) — entries allocated to this ODT. `Xcp_DaqListType.maxOdt`, `.maxOdtEntries`, `.number`, `.firstPid` and `Xcp_OdtType.odtNumber` become non-`const`.
+
+- [ ] **Step 1: Write the failing test**
+
+In `test/daq_configuration_test.py`:
+
+```python
+def test_each_odt_carries_its_own_entry_count_seeded_from_the_list_cap():
+    """DD34. ALLOC_ODT_ENTRY assigns entries to one ODT, so a per-ODT count is needed; the
+    per-list maxOdtEntries cannot express one ODT holding four entries and another two. Under
+    STATIC every ODT is seeded with the list's max_odt_entries, which is what keeps the six
+    relocated bound checks comparing against the value they compared against before."""
+    handle = XcpTest(DefaultConfig(daqs=(daq(name='DAQ1', max_odt=3, max_odt_entries=9),)))
+    daq_list = handle.config.lib.Xcp[0].config.daqList[0]
+    assert daq_list.maxOdtEntries == 9
+    for odt in range(3):
+        assert daq_list.odt[odt].entryCount == 9
+```
+
+- [ ] **Step 2: Run it and verify it fails**
+
+Filter: `each_odt_carries_its_own_entry_count`
+Expected: FAIL — `entryCount` is not a field of `Xcp_OdtType`.
+
+- [ ] **Step 3: Add the field and drop `const` from the members the allocator writes**
+
+In `interface/Xcp_Types.h`, `Xcp_OdtType` gains, after `odtNumber`:
+
+```c
+    /**
+     * @brief number of ODT entries allocated to this ODT.
+     * @details Under a STATIC configuration the generator seeds this with the DAQ list's
+     * max_odt_entries for every ODT, so it equals maxOdtEntries throughout. Under DYNAMIC it
+     * starts at zero and ALLOC_ODT_ENTRY raises it, which is what lets two ODTs of one list hold
+     * different numbers of entries.
+     * @note XCP part 2 - Protocol Layer Specification 1.1/1.6.4.3.1.4.
+     */
+    uint8 entryCount;
+```
+
+Drop `const` from `Xcp_OdtType.odtNumber`, and from `Xcp_DaqListType.number`, `.firstPid`, `.maxOdt` and `.maxOdtEntries`. Add above `Xcp_DaqListType`:
+
+```c
+/**
+ * @note The members below are not const because a DAQ_DYNAMIC configuration assigns them at
+ * runtime from ALLOC_DAQ, ALLOC_ODT and ALLOC_ODT_ENTRY (1.1/1.6.4.3.1). A struct definition
+ * cannot differ between builds without an #if here, which would give the CFFI test harness a
+ * second type to compile, so they are non-const in both. Flash placement is unaffected: it comes
+ * from the Xcp_START_SEC_CONST_UNSPECIFIED MemMap section the generator emits around these
+ * arrays, which a STATIC configuration keeps. Only the allocator writes them.
+ */
+```
+
+- [ ] **Step 4: Emit `entryCount` from the generator**
+
+In `script/source_cfg.c.jinja2`, the `Xcp_OdtType` initialiser (around line 73) gains `entryCount` in the member order used by the struct — `{{'0x%02Xu' % daq.max_odt_entries}}, /* entryCount */`.
+
+- [ ] **Step 5: Relocate the six entry bounds**
+
+Each moves from `Xcp_Ptr->config->daqList[N].maxOdtEntries` to that ODT's `entryCount`:
+
+| File:line | ODT index in scope |
+|:--|:--|
+| `source/Xcp_DaqRuntime.c:152` | `odtNumber` (parameter of `Xcp_DaqSampleOdt`) |
+| `source/Xcp_Daq.c:60` | `odt_idx` (enclosing loop in `Xcp_DaqListClearEntries`) |
+| `source/Xcp_Daq.c:125` | `p_odt` already computed in `Xcp_OdtUsedBytes` — use `p_odt->entryCount` |
+| `source/Xcp_Daq.c:173` | `Xcp_Internal.daq_pointer.odtNumber` in `Xcp_DaqPointerAdvance` |
+| `source/Xcp_Daq.c:288` | `odt_idx` (enclosing loop) |
+| `source/Xcp_Daq.c:369` | `odt_number`, validated against `maxOdt` immediately above |
+
+**`source/Xcp_Daq.c:969` does not move.** It reports `MAX_ODT_ENTRIES` for the list in `GET_DAQ_LIST_INFO`, which is the per-list cap, not a bound.
+
+- [ ] **Step 6: Run the new test and the full suite**
+
+Expected: the new test passes, and **12532 passed, 29 skipped** — the count before this task, unchanged. Any other difference means the relocation changed behaviour and must be investigated, not accepted.
+
+- [ ] **Step 7: Mutation-verify**
+
+Change one relocated site's `entryCount` to `entryCount + 1` and confirm an existing DAQ test fails; restore and confirm `git diff` is clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add interface/Xcp_Types.h script/source_cfg.c.jinja2 source/Xcp_Daq.c source/Xcp_DaqRuntime.c test/daq_configuration_test.py
+git commit -m "refactor: give each ODT its own entry count, ahead of dynamic allocation"
+```
+
+---
+
+## Task 2: Configuration model — schema, generator, test harness
+
+Implements **DD25** (build-time choice) and **DD26** (AUTOSAR rectangular caps).
+
+**Files:**
+- Modify: `config/xcp.schema.json`, `script/source_cfg.c.jinja2`, `script/source_rt.c.jinja2`, `test/parameter.py`
+- Test: `test/daq_configuration_test.py`
+
+**Interfaces:**
+- Consumes: `Xcp_OdtType.entryCount` from Task 1.
+- Produces: `DefaultConfig(daq_config_type='DYNAMIC', daq_count=N, odt_count=N, odt_entries_count=N)`; `Xcp_GeneralType.daqConfigType` carrying `DAQ_DYNAMIC`; `.daqCount`, `.odtCount`, `.odtEntriesCount` carrying the pool dimensions.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+def test_a_dynamic_configuration_reports_its_pool_through_the_autosar_parameters():
+    """DD26. XcpDaqCount (ECUC_Xcp_00012) is the number of allocatable lists, XcpOdtCount
+    (ECUC_Xcp_00054) the ODTs of a DAQ list, XcpOdtEntriesCount (ECUC_Xcp_00059) the entries into
+    an ODT. All three are defined only for DAQ_DYNAMIC."""
+    handle = XcpTest(DefaultConfig(daq_config_type='DYNAMIC', daq_count=4, odt_count=8,
+                                   odt_entries_count=16))
+    general = handle.config.lib.Xcp[0].general
+    assert general.daqConfigType == handle.define('DAQ_DYNAMIC')
+    assert general.daqCount == 4
+    assert general.odtCount == 8
+    assert general.odtEntriesCount == 16
+
+
+def test_a_static_configuration_leaves_the_dynamic_only_parameters_at_zero():
+    """AUTOSAR defines XcpOdtCount and XcpOdtEntriesCount only for DAQ_DYNAMIC. The generator
+    previously emitted aggregate sums here -- the total ODTs across all lists, and the grand total
+    of entries -- which is neither field's meaning. No .c file read either one, so this corrects a
+    latent wrong value rather than changing behaviour."""
+    handle = XcpTest(DefaultConfig(daqs=(daq(name='DAQ1', max_odt=3, max_odt_entries=9),)))
+    general = handle.config.lib.Xcp[0].general
+    assert general.daqConfigType == handle.define('DAQ_STATIC')
+    assert general.daqCount == 1
+    assert general.odtCount == 0
+    assert general.odtEntriesCount == 0
+```
+
+- [ ] **Step 2: Run and verify they fail**
+
+Filter: `reports_its_pool_through_the_autosar or leaves_the_dynamic_only`
+Expected: FAIL — `daq_config_type` is not a `DefaultConfig` keyword.
+
+- [ ] **Step 3: Extend the schema**
+
+`daq_config_type` joins `configurations[].properties.protocol_layer.properties`:
+
+```json
+"daq_config_type": {
+  "description": "Sets the DAQ_CONFIG_TYPE bit within DAQ_PROPERTIES to static or dynamic (see ECUC_Xcp_00164). DAQ_STATIC generates the DAQ lists declared under daqs; DAQ_DYNAMIC generates an empty pool the master fills through FREE_DAQ, ALLOC_DAQ, ALLOC_ODT and ALLOC_ODT_ENTRY",
+  "type": "string",
+  "enum": ["STATIC", "DYNAMIC"],
+  "default": "STATIC"
+}
+```
+
+`daq_dynamic` joins `configurations[].properties`, with `daq_count` (0..65535), `odt_count` (0..252), `odt_entries_count` (0..255) and `pdu_mapping` (pattern `[A-Z_][A-Z0-9_]*`), all required, `additionalProperties: false`. Add an `if/then` on `configurations[].items` requiring `daq_dynamic` when `protocol_layer.daq_config_type` is `DYNAMIC`.
+
+- [ ] **Step 4: Extend `DefaultConfig`**
+
+Add `daq_config_type='STATIC'`, `daq_count=4`, `odt_count=8`, `odt_entries_count=16` keyword arguments. Put `"daq_config_type": daq_config_type` in the `protocol_layer` dict at line 292. When `daq_config_type == 'DYNAMIC'`, add a `daq_dynamic` key to the configuration dict and **omit `daqs` and every event's `triggered_daq_list_ref`**.
+
+Change the four ALLOC flags' defaults from `True` to `False`, with this comment, following the `xcp_write_daq_multiple_api_enable` precedent already in the file:
+
+```python
+                 # False, not True, for the same reason as xcp_write_daq_multiple_api_enable
+                 # above: the generation guard added with SP2d rejects these four being enabled
+                 # under a STATIC configuration, and this class's own daq_config_type default is
+                 # STATIC. Defaulting them True would make DefaultConfig() itself fail to
+                 # generate. A DYNAMIC configuration must enable all four, and the guard rejects
+                 # that direction too.
+                 xcp_free_daq_api_enable=False,
+                 xcp_alloc_daq_api_enable=False,
+                 xcp_alloc_odt_api_enable=False,
+                 xcp_alloc_odt_entry_api_enable=False,
+```
+
+- [ ] **Step 5: Extend the generator**
+
+In `script/source_cfg.c.jinja2`, near the top of the configuration loop:
+
+```jinja
+{%- set daq_dynamic = configuration.protocol_layer.daq_config_type | default('STATIC') == 'DYNAMIC' %}
+```
+
+Then:
+
+- `Xcp_GeneralType`: emit `{% if daq_dynamic %}DAQ_DYNAMIC{% else %}DAQ_STATIC{% endif %}` for `XcpDaqConfigType`, replacing the hard-coded `DAQ_STATIC` and its stale "arrives in SP2c" comment; `XcpDaqCount` from `configuration.daq_dynamic.daq_count` when dynamic, else `configuration.daqs|length`; `XcpOdtCount` and `XcpOdtEntriesCount` from `odt_count` / `odt_entries_count` when dynamic, else `0x00u` each — replacing `counters.odt` and `counters.odt_entries`.
+- Under DYNAMIC, emit the pool: `daq_count` `Xcp_DaqListType` elements, `daq_count × odt_count` `Xcp_OdtType` elements, `daq_count × odt_count × odt_entries_count` `Xcp_OdtEntryType` elements, all zero-initialised except each list's `type` (`DAQ`), `dto` (the `pdu_mapping`), `maxOdtEntries` (`odt_entries_count`) and `odt` (its slice of the ODT array), and each ODT's `odtEntry` (its slice of the entry array) and `odtEntryMaxSize` (`odt_entry_size_daq`).
+- Under DYNAMIC, the `Xcp_DaqListType` and `Xcp_OdtType` arrays go in `Xcp_START_SEC_VAR_FAST_POWER_ON_INIT_UNSPECIFIED` instead of `Xcp_START_SEC_CONST_UNSPECIFIED`; the allocator writes them. STATIC keeps `Xcp_START_SEC_CONST_UNSPECIFIED` exactly as today.
+- Keep the `pid.next > 252` guard for STATIC only. DYNAMIC gets no generation-time PID guard (DD31).
+
+In `script/source_rt.c.jinja2:40`, size `Xcp_DaqListRtNN` from `daq_count` under DYNAMIC.
+
+- [ ] **Step 6: Add the four guards**
+
+```jinja
+{%- if daq_dynamic and configuration.daq_dynamic.daq_count > 255 %}
+{{ raise('daq_count {} exceeds the uint8 maxDaqList field of Xcp_EventChannelType; GET_DAQ_EVENT_INFO transmits MAX_DAQ_LIST as one byte (XCP part 2 1.1/1.6.4.1.2.7), and a DAQ_DYNAMIC configuration reports daq_count there because any allocated list may bind to any event channel'.format(configuration.daq_dynamic.daq_count)) }}
+{%- endif %}
+```
+
+Plus: any of the four ALLOC APIs enabled under STATIC; any disabled under DYNAMIC ("a dynamic configuration with no way to allocate"); and `daqs` non-empty under DYNAMIC or `daq_dynamic` present under STATIC.
+
+- [ ] **Step 7: Test the guards**
+
+```python
+@pytest.mark.parametrize('kwargs, why', (
+    (dict(daq_config_type='DYNAMIC', daq_count=256), 'daq_count above the uint8 MAX_DAQ_LIST field'),
+    (dict(xcp_free_daq_api_enable=True), 'FREE_DAQ enabled under a STATIC configuration'),
+    (dict(daq_config_type='DYNAMIC', xcp_alloc_daq_api_enable=False), 'ALLOC_DAQ disabled under DYNAMIC'),
+))
+def test_generation_refuses_incoherent_dynamic_configurations(kwargs, why):
+    """The guard messages are documentation, not output: raise() is not a registered Jinja global
+    in bsw_code_gen, so referencing it aborts rendering with UndefinedError and the string never
+    reaches the caller. These assert that generation fails, never that a message matches."""
+    with pytest.raises(Exception):
+        XcpTest(DefaultConfig(**kwargs))
+```
+
+- [ ] **Step 7b: Add the shared `dynamic_config` helper**
+
+A DYNAMIC configuration must enable all four ALLOC APIs, or the Step 6 guard refuses it. Put this in `test/parameter.py` so no test repeats it:
+
+```python
+def dynamic_config(daq_count=4, odt_count=8, odt_entries_count=16, **kwargs):
+    """A DefaultConfig with a dynamic DAQ pool. The four ALLOC APIs must all be enabled: the
+    generator refuses a DAQ_DYNAMIC configuration with any of them disabled, since that is a
+    dynamic build with no way to allocate. `daqs` is left empty because a dynamic configuration
+    declares no lists -- the master allocates them."""
+    return DefaultConfig(daq_config_type='DYNAMIC',
+                         daq_count=daq_count,
+                         odt_count=odt_count,
+                         odt_entries_count=odt_entries_count,
+                         daqs=(),
+                         xcp_free_daq_api_enable=True,
+                         xcp_alloc_daq_api_enable=True,
+                         xcp_alloc_odt_api_enable=True,
+                         xcp_alloc_odt_entry_api_enable=True,
+                         **kwargs)
+```
+
+- [ ] **Step 8: Run the new tests, then the full suite**
+
+Expected: new tests pass; the pre-existing count is unchanged apart from the additions.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add config/xcp.schema.json script/source_cfg.c.jinja2 script/source_rt.c.jinja2 test/parameter.py test/daq_configuration_test.py
+git commit -m "feat: generate a dynamic DAQ pool from the AUTOSAR configuration parameters"
+```
+
+---
+
+## Task 3: Allocation state and the runtime list count
+
+**Files:**
+- Modify: `source/Xcp_Internal.h`, `source/Xcp.c`, `source/Xcp_Daq.c:18-21`
+- Test: `test/daq_dynamic_acceptance_test.py` (create)
+
+**Interfaces:**
+- Consumes: `dynamic_config(...)` from `test/parameter.py` (Task 2).
+- Produces: the per-file test boilerplate below, which **every** test file created by Tasks 3–9 repeats verbatim. This follows the existing house pattern — `get_daq_list_mode_test.py`, `write_daq_test.py` and `set_daq_ptr_test.py` each define their own `exchange`/`response` rather than sharing one:
+
+```python
+from .parameter import *
+from .conftest import XcpTest
+from .download_test import connect
+
+
+def dynamic_handle(**kwargs):
+    handle = XcpTest(dynamic_config(**kwargs))
+    connect(handle)
+    return handle
+
+
+def exchange(handle, request, length=8):
+    handle.lib.Xcp_CanIfRxIndication(0x0001, handle.get_pdu_info(request))
+    handle.lib.Xcp_MainFunction()
+    handle.lib.Xcp_CanIfTxConfirmation(0x0002, handle.define('E_OK'))
+    return tuple(handle.can_if_transmit.call_args[0][1].SduDataPtr[0:length])
+```
+
+  Note the confirmation PDU id is `0x0002`, matching `DefaultConfig`'s `channel_tx_pdu_ref`, not the `0x0001` that `set_request_test.py` uses. Getting this wrong makes `exchange` return the previous frame.
+- Produces: `Xcp_DaqAllocStateType` with `XCP_DAQ_ALLOC_FREE`, `XCP_DAQ_ALLOC_DAQ`, `XCP_DAQ_ALLOC_ODT`, `XCP_DAQ_ALLOC_ODT_ENTRY`; `Xcp_Internal.daq_alloc_state`; `Xcp_Internal.allocated_daq_count` (`uint16`). `Xcp_DaqListIsValid` now bounds against `allocated_daq_count`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_a_dynamic_build_has_no_valid_daq_lists_until_alloc_daq():
+    """DD32. The spec's ALLOC_ODT range [MIN_DAQ, MIN_DAQ+DAQ_COUNT-1] is over what ALLOC_DAQ
+    allocated, not over the configured pool, so a list inside the pool but not yet allocated is
+    "not available" and answers ERR_OUT_OF_RANGE. One runtime count gives both models the right
+    answer: it starts at daqCount under STATIC and at zero under DYNAMIC."""
+    handle = dynamic_handle(daq_count=4)
+    # CLEAR_DAQ_LIST on list 0, which the pool has room for but nothing has allocated.
+    assert exchange(handle, (0xE3, 0x00, 0x00, 0x00))[0:2] == (0xFE, 0x22)
+```
+
+- [ ] **Step 2: Run and verify it fails**
+
+Expected: FAIL — list 0 is valid because `Xcp_DaqListIsValid` bounds against the configured `daqCount`.
+
+- [ ] **Step 3: Add the state**
+
+In `source/Xcp_Internal.h`, before `Xcp_InternalType`:
+
+```c
+/**
+ * @brief where a dynamic DAQ list configuration sequence has got to.
+ * @details XCP part 2 - Protocol Layer Specification 1.1/1.6.4.3.1 enumerates six ERR_SEQUENCE
+ * cases, which reduce to these four states and the transition table in Xcp_Daq.c. The initial
+ * value is XCP_DAQ_ALLOC_FREE: §1.6.4.3.1.1 requires the master to send FREE_DAQ first, but that
+ * is a requirement on the master and the slave's enumerated refusals do not include an ALLOC_DAQ
+ * with no preceding command -- nothing is allocated at that point, so accepting it is defined.
+ * @note explicitly 0, since it may live in a cleared memory section.
+ */
+typedef enum {
+    XCP_DAQ_ALLOC_FREE = 0x00u,
+    XCP_DAQ_ALLOC_DAQ,
+    XCP_DAQ_ALLOC_ODT,
+    XCP_DAQ_ALLOC_ODT_ENTRY
+} Xcp_DaqAllocStateType;
+```
+
+In `Xcp_InternalType`, beside `daq_pointer`:
+
+```c
+    Xcp_DaqAllocStateType daq_alloc_state;
+
+    /**
+     * @brief DAQ lists currently available to the master.
+     * @details Equals Xcp_Ptr->general->daqCount under a STATIC configuration and is raised from
+     * zero by ALLOC_DAQ under a DYNAMIC one, so Xcp_DaqListIsValid serves both models unchanged.
+     */
+    uint16 allocated_daq_count;
+```
+
+- [ ] **Step 4: Initialise it and use it**
+
+In `source/Xcp.c`, beside `Xcp_Internal.session_status = 0x00u;`:
+
+```c
+            Xcp_Internal.daq_alloc_state = XCP_DAQ_ALLOC_FREE;
+            Xcp_Internal.allocated_daq_count =
+                    (Xcp_Ptr->general->daqConfigType == DAQ_DYNAMIC) ? 0x0000u
+                                                                     : Xcp_Ptr->general->daqCount;
+```
+
+In `source/Xcp_Daq.c`, `Xcp_DaqListIsValid` becomes:
+
+```c
+static boolean Xcp_DaqListIsValid(uint16 daqListNumber)
+{
+    return (boolean)((daqListNumber < Xcp_Internal.allocated_daq_count) ? TRUE : FALSE);
+}
+```
+
+- [ ] **Step 5: Run the new test, then the full suite**
+
+Expected: the new test passes. The whole existing suite must be unaffected — under STATIC `allocated_daq_count` equals `daqCount`, so the predicate is unchanged.
+
+- [ ] **Step 6: Mutation-verify**
+
+Set the DYNAMIC branch to `daqCount` and confirm only the new test fails.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add source/Xcp_Internal.h source/Xcp.c source/Xcp_Daq.c test/daq_dynamic_acceptance_test.py
+git commit -m "feat: track allocated DAQ lists separately from the configured pool"
+```
+
+---
+
+## Task 4: FREE_DAQ — 0xD6
+
+**Files:**
+- Modify: `source/Xcp_Daq.c`, `source/Xcp.c:131` (PID table)
+- Test: `test/free_daq_test.py` (create)
+
+**Interfaces:**
+- Consumes: `Xcp_Internal.daq_alloc_state`, `.allocated_daq_count` (Task 3); the Task 3 test boilerplate.
+- Produces, local to `test/free_daq_test.py`, a handle with one list allocated, configured and running:
+
+```python
+def running_dynamic_handle():
+    handle = dynamic_handle(daq_count=1, odt_count=1, odt_entries_count=1)
+    exchange(handle, (0xD5, 0x00, 0x01, 0x00))                    # ALLOC_DAQ 1
+    exchange(handle, (0xD4, 0x00, 0x00, 0x00, 0x01))              # ALLOC_ODT list 0, 1 ODT
+    exchange(handle, (0xD3, 0x00, 0x00, 0x00, 0x00, 0x01))        # ALLOC_ODT_ENTRY
+    exchange(handle, (0xE0, 0x10, 0x00, 0x00, 0x07, 0x00, 0x02))  # SET_DAQ_LIST_MODE, event 7
+    exchange(handle, (0xDE, 0x01, 0x00, 0x00, 0x00, 0x00))        # START_STOP_DAQ_LIST start
+    return handle
+```
+- Produces: `uint8 Xcp_DTOCmdDaqFreeDaq(boolean *responseExpected, const PduInfoType *pPduInfo)`; `static void Xcp_DaqListReset(uint16 daqListNumber)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+def test_free_daq_releases_every_allocation():
+    handle = dynamic_handle(daq_count=2, odt_count=2, odt_entries_count=2)
+    assert exchange(handle, (0xD5, 0x00, 0x02, 0x00))[0] == 0xFF   # ALLOC_DAQ 2
+    assert exchange(handle, (0xD6,))[0] == 0xFF                     # FREE_DAQ
+    # Nothing is allocated any more, so list 0 is not available.
+    assert exchange(handle, (0xE3, 0x00, 0x00, 0x00))[0:2] == (0xFE, 0x22)
+
+
+def test_free_daq_stops_a_running_daq_rather_than_refusing_it():
+    """DD29. Xcp_CTOErrorMatrix gives 0xD6 only CMD_BUSY, PGM_ACTIVE, CMD_UNKNOWN and CMD_SYNTAX;
+    ERR_DAQ_ACTIVE is absent, so refusing a running slave is not authorised. FREE_DAQ therefore
+    stops every running list and clears DAQ_RUNNING."""
+    handle = running_dynamic_handle()
+    assert exchange(handle, (0xD6,))[0] == 0xFF
+    assert exchange(handle, (0xFD,))[1] & 0b01000000 == 0x00   # GET_STATUS: DAQ_RUNNING clear
+
+
+def test_free_daq_clears_the_runtime_state_not_only_the_descriptor():
+    """DD30. Mode, prescaler, prescalerCounter, priority and eventChannelNumber live in
+    Xcp_DaqListRt, a separate array from the descriptor. A freed-then-reallocated list that
+    inherited them would start with a binding the master never set for it."""
+    handle = dynamic_handle(daq_count=1, odt_count=1, odt_entries_count=1)
+    exchange(handle, (0xD5, 0x00, 0x01, 0x00))
+    exchange(handle, (0xD4, 0x00, 0x00, 0x00, 0x01))
+    exchange(handle, (0xE0, 0x10, 0x00, 0x00, 0x07, 0x00, 0x02))   # SET_DAQ_LIST_MODE
+    exchange(handle, (0xD6,))
+    exchange(handle, (0xD5, 0x00, 0x01, 0x00))
+    rt = handle.lib.Xcp_Rt[handle.lib.Xcp_Ptr.xcpRtRef].daqList[0]
+    assert (rt.mode, rt.eventChannelNumber, rt.prescaler, rt.prescalerCounter, rt.priority) == \
+           (0x00, 0x0000, 0x01, 0x00, 0x00)
+```
+
+- [ ] **Step 2: Run and verify they fail**
+
+Expected: FAIL — `0xD6` answers `ERR_CMD_UNKNOWN` (`0xFE, 0x20`).
+
+- [ ] **Step 3: Extract the shared per-list reset**
+
+`Xcp_DTOCmdDaqClearDaqList` already resets one list exactly as `FREE_DAQ` must. Lift that into a helper and have both call it:
+
+```c
+/**
+ * @brief returns one DAQ list's runtime state to its power-up values.
+ * @details XCP part 2 - Protocol Layer Specification 1.1/1.6.4.2.1.1 for CLEAR_DAQ_LIST and
+ * 1.1/1.6.4.3.1.1 for FREE_DAQ: both stop transmission on the list and reset its state. The
+ * prescaler returns to 1, not 0 -- a zero prescaler would mean no trigger ever elapses.
+ * @note the caller invalidates the DAQ pointer if it names this list, and calls
+ * Xcp_DaqSessionStatusUpdate once it has reset every list it intends to.
+ */
+static void Xcp_DaqListReset(uint16 daqListNumber)
+{
+    Xcp_DaqListClearEntries(daqListNumber);
+
+    Xcp_DaqListRt(daqListNumber)->mode = 0x00u;
+    Xcp_DaqListRt(daqListNumber)->eventChannelNumber = 0x0000u;
+    Xcp_DaqListRt(daqListNumber)->prescaler = 0x01u;
+    Xcp_DaqListRt(daqListNumber)->prescalerCounter = 0x00u;
+    Xcp_DaqListRt(daqListNumber)->priority = 0x00u;
+}
+```
+
+- [ ] **Step 4: Write the handler**
+
+```c
+uint8 Xcp_DTOCmdDaqFreeDaq(boolean *responseExpected, const PduInfoType *pPduInfo)
+{
+    uint16 daq_idx;
+
+    (void)pPduInfo;
+
+    *responseExpected = TRUE;
+
+    /* XCP part 2 - Protocol Layer Specification 1.1/1.6.4.3.1.1: "This command clears all DAQ
+     * lists and frees all dynamically allocated DAQ lists, ODTs and ODT entries."
+     *
+     * The unwind order matters and is the reverse of allocation. Xcp_TriggerEventChannel runs in
+     * interrupt context and reaches entry storage by walking maxOdt, then each ODT's entryCount,
+     * so a count must never outlive the storage it describes -- the DD14 failure class. Stopping
+     * the lists first means no new sampling begins; zeroing the counts next means a trigger
+     * interleaved at any later point sees zero and samples nothing, rather than a stale count
+     * into released storage. Xcp_DaqListClearEntries, called through Xcp_DaqListReset, takes the
+     * DAQ exclusive area for the entry writes themselves. */
+    for (daq_idx = 0x0000u; daq_idx < Xcp_Internal.allocated_daq_count; daq_idx++)
+    {
+        Xcp_DaqListReset(daq_idx);
+    }
+
+    if (Xcp_Ptr->general->daqConfigType == DAQ_DYNAMIC)
+    {
+        for (daq_idx = 0x0000u; daq_idx < Xcp_Internal.allocated_daq_count; daq_idx++)
+        {
+            uint8 odt_idx;
+
+            SchM_Enter_Xcp_DtoQueue();
+
+            for (odt_idx = 0x00u; odt_idx < Xcp_Ptr->config->daqList[daq_idx].maxOdt; odt_idx++)
+            {
+                Xcp_Ptr->config->daqList[daq_idx].odt[odt_idx].entryCount = 0x00u;
+            }
+
+            Xcp_Ptr->config->daqList[daq_idx].maxOdt = 0x00u;
+            Xcp_Ptr->config->daqList[daq_idx].firstPid = 0x00u;
+
+            SchM_Exit_Xcp_DtoQueue();
+        }
+
+        Xcp_Internal.allocated_daq_count = 0x0000u;
+    }
+
+    /* The resets above may have stopped the only running list, so DAQ_RUNNING (1.1/1.6.1.1.3)
+     * needs recomputing across every list rather than per list. */
+    Xcp_DaqSessionStatusUpdate();
+
+    Xcp_Internal.daq_pointer.valid = FALSE;
+    Xcp_Internal.daq_alloc_state = XCP_DAQ_ALLOC_FREE;
+
+    Xcp_Internal.cto_response.pdu_info.SduDataPtr[0x00u] = XCP_PID_RESPONSE;
+
+    Xcp_FinalizeResPacket(0x01u, &Xcp_Internal.cto_response.pdu_info);
+
+    return E_OK;
+}
+```
+
+Declare it in `source/Xcp_Internal.h` beside the other DAQ handlers, and replace `Xcp_CmdNotImplemented, /* 0xD6, optional */` in `Xcp_PIDTable` with `Xcp_DTOCmdDaqFreeDaq`.
+
+- [ ] **Step 5: Run the new tests and the full suite**
+
+Expected: the three new tests pass; `cmd_unknown_test.py` still passes, because a STATIC build has `0xD6` disabled and the dispatcher's disabled path fills `ERR_CMD_UNKNOWN`.
+
+- [ ] **Step 6: Attempt the interleaving test, and record the outcome**
+
+Give `handle.sch_m_enter_xcp_dto_queue` a `side_effect` that calls `Xcp_TriggerEventChannel`, so a trigger lands inside the area-taking call, and assert no frame reaches the ring. If CFFI reentrancy makes that impossible, write the post-condition test instead — trigger after `FREE_DAQ`, assert nothing is sampled — and **update spec §10 to say the outcome is covered and the interleaving is not.** Do not leave the spec claiming more than the tests do.
+
+- [ ] **Step 7: Mutation-verify, then commit**
+
+```bash
+git add source/Xcp_Daq.c source/Xcp_Internal.h source/Xcp.c test/free_daq_test.py
+git commit -m "feat: implement FREE_DAQ"
+```
+
+---
+
+## Task 5: ALLOC_DAQ — 0xD5
+
+**Files:**
+- Modify: `source/Xcp_Daq.c`, `source/Xcp_Internal.h`, `source/Xcp.c:131`
+- Test: `test/alloc_daq_test.py` (create)
+
+**Interfaces:**
+- Produces: `uint8 Xcp_DTOCmdDaqAllocDaq(boolean *responseExpected, const PduInfoType *pPduInfo)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+def test_alloc_daq_makes_lists_available():
+    handle = dynamic_handle(daq_count=4)
+    assert exchange(handle, (0xD5, 0x00, 0x02, 0x00))[0] == 0xFF
+    assert exchange(handle, (0xE3, 0x00, 0x01, 0x00))[0] == 0xFF          # list 1 available
+    assert exchange(handle, (0xE3, 0x00, 0x02, 0x00))[0:2] == (0xFE, 0x22)  # list 2 is not
+
+
+def test_alloc_daq_accumulates_across_repeated_calls():
+    """DD28. The specification forbids ALLOC_DAQ only after ALLOC_ODT and ALLOC_ODT_ENTRY, so a
+    repeat from FREE or DAQ is permitted -- and each call therefore adds to what is allocated.
+    Treating a repeat as a replacement would make the permitted repeat meaningless."""
+    handle = dynamic_handle(daq_count=4)
+    exchange(handle, (0xD5, 0x00, 0x01, 0x00))
+    exchange(handle, (0xD5, 0x00, 0x02, 0x00))
+    assert exchange(handle, (0xE3, 0x00, 0x02, 0x00))[0] == 0xFF          # three allocated
+    assert exchange(handle, (0xE3, 0x00, 0x03, 0x00))[0:2] == (0xFE, 0x22)
+
+
+def test_alloc_daq_refuses_more_lists_than_the_pool_holds():
+    handle = dynamic_handle(daq_count=4)
+    assert exchange(handle, (0xD5, 0x00, 0x05, 0x00))[0:2] == (0xFE, 0x30)
+    # The rejected request left nothing allocated.
+    assert exchange(handle, (0xE3, 0x00, 0x00, 0x00))[0:2] == (0xFE, 0x22)
+```
+
+- [ ] **Step 2: Run and verify they fail** — `0xD5` answers `0xFE, 0x20`.
+
+- [ ] **Step 3: Write the handler**
+
+```c
+uint8 Xcp_DTOCmdDaqAllocDaq(boolean *responseExpected, const PduInfoType *pPduInfo)
+{
+    uint16 daq_count;
+    uint8 error = 0x00u;
+
+    *responseExpected = TRUE;
+
+    Xcp_CopyToU16WithOrder(&pPduInfo->SduDataPtr[0x02u], &daq_count, Xcp_Ptr->general->byteOrder);
+
+    /* XCP part 2 - Protocol Layer Specification 1.1/1.6.4.3.1.2: ERR_SEQUENCE for an ALLOC_DAQ
+     * directly after an ALLOC_ODT or an ALLOC_ODT_ENTRY without a FREE_DAQ in between. Sequence is
+     * checked before the argument, because it is a statement about the command stream rather than
+     * about this command's parameters. */
+    if ((Xcp_Internal.daq_alloc_state != XCP_DAQ_ALLOC_FREE) &&
+        (Xcp_Internal.daq_alloc_state != XCP_DAQ_ALLOC_DAQ))
+    {
+        error = XCP_E_ASAM_SEQUENCE;
+    }
+    else if ((uint32)((uint32)Xcp_Internal.allocated_daq_count + (uint32)daq_count) >
+             (uint32)Xcp_Ptr->general->daqCount)
+    {
+        /* "If there's not enough memory available to allocate the requested DAQ lists an
+         * ERR_MEMORY_OVERFLOW will be returned." Rejected whole: a partly applied allocation
+         * would leave the master unaware of how much it actually has. */
+        error = XCP_E_ASAM_MEMORY_OVERFLOW;
+    }
+    else
+    {
+        Xcp_Internal.allocated_daq_count = (uint16)(Xcp_Internal.allocated_daq_count + daq_count);
+        Xcp_Internal.daq_alloc_state = XCP_DAQ_ALLOC_DAQ;
+    }
+
+    if (error == 0x00u)
+    {
+        Xcp_Internal.cto_response.pdu_info.SduDataPtr[0x00u] = XCP_PID_RESPONSE;
+        Xcp_FinalizeResPacket(0x01u, &Xcp_Internal.cto_response.pdu_info);
+    }
+    else
+    {
+        Xcp_FillErrorPacket(error, &Xcp_Internal.cto_response.pdu_info);
+    }
+
+    return E_OK;
+}
+```
+
+Declare it, and wire `0xD5` in `Xcp_PIDTable`.
+
+- [ ] **Step 4: Run the new tests and the full suite**
+- [ ] **Step 5: Mutation-verify, then commit**
+
+```bash
+git add source/Xcp_Daq.c source/Xcp_Internal.h source/Xcp.c test/alloc_daq_test.py
+git commit -m "feat: implement ALLOC_DAQ"
+```
+
+---
+
+## Task 6: ALLOC_ODT — 0xD4, with the firstPid prefix sum
+
+**Files:**
+- Modify: `source/Xcp_Daq.c`, `source/Xcp_Internal.h`, `source/Xcp.c:131`
+- Test: `test/alloc_odt_test.py` (create)
+
+**Interfaces:**
+- Produces: `uint8 Xcp_DTOCmdDaqAllocOdt(boolean *responseExpected, const PduInfoType *pPduInfo)`; `static void Xcp_DaqRecomputeFirstPids(void)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+def test_alloc_odt_assigns_contiguous_first_pids_whatever_the_allocation_order():
+    """DD31. Assigning PIDs in call order breaks under DD28's accumulate rule: ALLOC_ODT(0, 2),
+    ALLOC_ODT(1, 3), ALLOC_ODT(0, 1) leaves list 0 needing three contiguous PIDs when list 1
+    already owns 2..4. The absolute ODT number is firstPid + relative, so contiguity is required.
+    firstPid is therefore a prefix sum over list index, recomputed whenever an ODT count changes --
+    the same rule the generator applies to static lists."""
+    handle = dynamic_handle(daq_count=2, odt_count=4)
+    exchange(handle, (0xD5, 0x00, 0x02, 0x00))
+    exchange(handle, (0xD4, 0x00, 0x00, 0x00, 0x02))   # list 0 gets 2 ODTs
+    exchange(handle, (0xD4, 0x00, 0x01, 0x00, 0x03))   # list 1 gets 3
+    exchange(handle, (0xD4, 0x00, 0x00, 0x00, 0x01))   # list 0 gets 1 more, now 3
+    assert handle.lib.Xcp_Ptr.config.daqList[0].firstPid == 0
+    assert handle.lib.Xcp_Ptr.config.daqList[1].firstPid == 3   # not 2
+
+
+def test_alloc_odt_refuses_a_list_that_was_never_allocated():
+    handle = dynamic_handle(daq_count=4, odt_count=4)
+    exchange(handle, (0xD5, 0x00, 0x01, 0x00))
+    assert exchange(handle, (0xD4, 0x00, 0x01, 0x00, 0x01))[0:2] == (0xFE, 0x22)
+
+
+def test_alloc_odt_refuses_more_odts_than_one_list_may_hold():
+    handle = dynamic_handle(daq_count=1, odt_count=4)
+    exchange(handle, (0xD5, 0x00, 0x01, 0x00))
+    assert exchange(handle, (0xD4, 0x00, 0x00, 0x00, 0x05))[0:2] == (0xFE, 0x30)
+
+
+def test_alloc_odt_refuses_to_exhaust_the_pid_space():
+    """DD31. Slave-to-master PIDs 0xFC..0xFF are SERV, EV, ERR and RES, leaving 0x00..0xFB -- 252
+    absolute ODT numbers. Checked at runtime rather than at generation: guarding
+    daq_count * odt_count <= 252 in the template would reject configurations a master can use
+    perfectly well, since it rarely allocates the whole rectangle."""
+    handle = dynamic_handle(daq_count=2, odt_count=252)
+    exchange(handle, (0xD5, 0x00, 0x02, 0x00))
+    assert exchange(handle, (0xD4, 0x00, 0x00, 0x00, 0xFC))[0] == 0xFF     # 252 exactly
+    assert exchange(handle, (0xD4, 0x00, 0x01, 0x00, 0x01))[0:2] == (0xFE, 0x30)
+    assert handle.lib.Xcp_Ptr.config.daqList[0].maxOdt == 252               # unchanged
+```
+
+- [ ] **Step 2: Run and verify they fail** — `0xD4` answers `0xFE, 0x20`.
+
+- [ ] **Step 3: Write the prefix sum and the handler**
+
+```c
+/**
+ * @brief reassigns every DAQ list's FIRST_PID as a prefix sum over the ODT counts.
+ * @details XCP part 2 - Protocol Layer Specification 1.1/1.6.4.1.1.4: the absolute ODT number of
+ * relative ODT i in a list is FIRST_PID + i, so each list's block must be contiguous and no two
+ * blocks may overlap. Assigning PIDs in ALLOC_ODT call order cannot hold that once a list may
+ * receive ODTs in more than one call, so the whole set is recomputed instead. This is the same
+ * rule script/source_cfg.c.jinja2 applies to a static configuration.
+ */
+static void Xcp_DaqRecomputeFirstPids(void)
+{
+    uint16 daq_idx;
+    uint8 next = 0x00u;
+
+    for (daq_idx = 0x0000u; daq_idx < Xcp_Internal.allocated_daq_count; daq_idx++)
+    {
+        Xcp_Ptr->config->daqList[daq_idx].firstPid = next;
+        next = (uint8)(next + Xcp_Ptr->config->daqList[daq_idx].maxOdt);
+    }
+}
+```
+
+The handler reads `DAQ_LIST_NUMBER` from bytes 2,3 and `ODT_COUNT` from byte 4, then, in order:
+
+- `ERR_SEQUENCE` unless the state is `XCP_DAQ_ALLOC_DAQ` or `XCP_DAQ_ALLOC_ODT`;
+- `ERR_OUT_OF_RANGE` when `Xcp_DaqListIsValid(daq_list_number) == FALSE`;
+- `ERR_MEMORY_OVERFLOW` when that list's `maxOdt + odt_count > Xcp_Ptr->general->odtCount`, **or** when the total ODT count across the allocated lists would exceed 252;
+- otherwise raise `maxOdt` under `SchM_Enter_Xcp_DtoQueue`, call `Xcp_DaqRecomputeFirstPids`, and set the state to `XCP_DAQ_ALLOC_ODT`.
+
+Compute the running total in a `uint16` so 252 + 252 cannot wrap.
+
+- [ ] **Step 4: Run the new tests and the full suite**
+- [ ] **Step 5: Mutation-verify** — replace the prefix sum with call-order assignment and confirm the contiguity test is what fails.
+- [ ] **Step 6: Commit**
+
+```bash
+git add source/Xcp_Daq.c source/Xcp_Internal.h source/Xcp.c test/alloc_odt_test.py
+git commit -m "feat: implement ALLOC_ODT, assigning FIRST_PID as a prefix sum"
+```
+
+---
+
+## Task 7: ALLOC_ODT_ENTRY — 0xD3
+
+**Files:**
+- Modify: `source/Xcp_Daq.c`, `source/Xcp_Internal.h`, `source/Xcp.c:131`
+- Test: `test/alloc_odt_entry_test.py` (create)
+
+**Interfaces:**
+- Produces: `uint8 Xcp_DTOCmdDaqAllocOdtEntry(boolean *responseExpected, const PduInfoType *pPduInfo)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+def test_alloc_odt_entry_gives_each_odt_its_own_count():
+    """DD34. This is what the per-ODT entryCount exists for: the per-list maxOdtEntries cannot
+    express one ODT holding four entries and another two."""
+    handle = dynamic_handle(daq_count=1, odt_count=2, odt_entries_count=4)
+    exchange(handle, (0xD5, 0x00, 0x01, 0x00))
+    exchange(handle, (0xD4, 0x00, 0x00, 0x00, 0x02))
+    assert exchange(handle, (0xD3, 0x00, 0x00, 0x00, 0x00, 0x04))[0] == 0xFF
+    assert exchange(handle, (0xD3, 0x00, 0x00, 0x00, 0x01, 0x02))[0] == 0xFF
+    daq_list = handle.lib.Xcp_Ptr.config.daqList[0]
+    assert (daq_list.odt[0].entryCount, daq_list.odt[1].entryCount) == (4, 2)
+
+
+def test_alloc_odt_entry_refuses_an_odt_the_list_does_not_have():
+    handle = dynamic_handle(daq_count=1, odt_count=4, odt_entries_count=4)
+    exchange(handle, (0xD5, 0x00, 0x01, 0x00))
+    exchange(handle, (0xD4, 0x00, 0x00, 0x00, 0x02))
+    assert exchange(handle, (0xD3, 0x00, 0x00, 0x00, 0x02, 0x01))[0:2] == (0xFE, 0x22)
+
+
+def test_alloc_odt_entry_refuses_more_entries_than_one_odt_may_hold():
+    handle = dynamic_handle(daq_count=1, odt_count=1, odt_entries_count=4)
+    exchange(handle, (0xD5, 0x00, 0x01, 0x00))
+    exchange(handle, (0xD4, 0x00, 0x00, 0x00, 0x01))
+    assert exchange(handle, (0xD3, 0x00, 0x00, 0x00, 0x00, 0x05))[0:2] == (0xFE, 0x30)
+```
+
+- [ ] **Step 2: Run and verify they fail** — `0xD3` answers `0xFE, 0x20`.
+
+- [ ] **Step 3: Write the handler**
+
+Reads `DAQ_LIST_NUMBER` from bytes 2,3, `ODT_NUMBER` from byte 4, `ODT_ENTRIES_COUNT` from byte 5, then in order:
+
+- `ERR_SEQUENCE` unless the state is `XCP_DAQ_ALLOC_ODT` or `XCP_DAQ_ALLOC_ODT_ENTRY`;
+- `ERR_OUT_OF_RANGE` when the list is not valid, or `odt_number >= maxOdt` for it;
+- `ERR_MEMORY_OVERFLOW` when that ODT's `entryCount + odt_entries_count > Xcp_Ptr->general->odtEntriesCount`;
+- otherwise raise `entryCount` under `SchM_Enter_Xcp_DtoQueue` and set the state to `XCP_DAQ_ALLOC_ODT_ENTRY`.
+
+The entry-count sum goes in a `uint16` so 255 + 255 cannot wrap.
+
+- [ ] **Step 4: Run the new tests and the full suite**
+- [ ] **Step 5: Mutation-verify, then commit**
+
+```bash
+git add source/Xcp_Daq.c source/Xcp_Internal.h source/Xcp.c test/alloc_odt_entry_test.py
+git commit -m "feat: implement ALLOC_ODT_ENTRY"
+```
+
+---
+
+## Task 8: What the slave reports
+
+**Files:**
+- Modify: `source/Xcp_Daq.c:1143` area (`GET_DAQ_PROCESSOR_INFO`), `source/Xcp_Daq.c:885` (`GET_DAQ_EVENT_INFO`), `script/source_cfg.c.jinja2`
+- Test: `test/get_daq_processor_info_test.py`, `test/get_daq_event_info_test.py`
+
+**Interfaces:**
+- Consumes: `Xcp_GeneralType.daqConfigType`, `.daqCount` (Task 2).
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+def test_get_daq_processor_info_reports_dynamic_configuration_and_the_whole_pool():
+    """DD33. MAX_DAQ is the configured pool, constant across allocation: ECUC_Xcp_00164's
+    dependency is MAX_DAQ = MIN_DAQ + DAQ_COUNT with minDaq 0, and the allocated count would tell
+    a master nothing before it allocates -- which is exactly when it needs to know how much it may
+    ask for."""
+    handle = dynamic_handle(daq_count=4)
+    response = exchange(handle, (0xDA,))
+    assert response[1] & 0b00000001 == 0b00000001      # DAQ_CONFIG_TYPE set
+    assert response[2:4] == (0x04, 0x00)               # MAX_DAQ, little endian
+    exchange(handle, (0xD5, 0x00, 0x02, 0x00))
+    assert exchange(handle, (0xDA,))[2:4] == (0x04, 0x00)   # still the pool, not the 2 allocated
+
+
+def test_get_daq_event_info_reports_the_pool_as_max_daq_list_under_dynamic():
+    """Any allocated list may bind to any event channel, so the pool size is the honest answer."""
+    handle = dynamic_handle(daq_count=4)
+    assert exchange(handle, (0xD7, 0x00, 0x00, 0x00))[2] == 0x04
+```
+
+- [ ] **Step 2: Run and verify they fail** — `DAQ_CONFIG_TYPE` is hard-cleared.
+
+- [ ] **Step 3: Set the bit and the counts**
+
+At `source/Xcp_Daq.c:1143`, replace the "DAQ_CONFIG_TYPE stays clear" comment and add:
+
+```c
+    /* XCP part 2 - Protocol Layer Specification 1.1/1.6.4.1.2.4. DAQ_CONFIG_TYPE now follows the
+     * configuration: a DAQ_DYNAMIC build lets the master allocate lists through 1.1/1.6.4.3.1,
+     * where a DAQ_STATIC build serves the lists the generator declared. RESUME and BIT_STIM
+     * remain unimplemented and so remain reported unsupported, which is what lets
+     * SET_DAQ_LIST_MODE refuse the matching mode bits. */
+    if (Xcp_Ptr->general->daqConfigType == DAQ_DYNAMIC)
+    {
+        properties |= XCP_DAQ_PROPERTIES_DAQ_CONFIG_TYPE;
+    }
+```
+
+`MAX_DAQ` already reads `Xcp_Ptr->general->daqCount` and needs no change — Task 2 made that the pool size. In the generator, `maxDaqList` per event channel becomes `daq_count` under DYNAMIC instead of `event.triggered_daq_list_ref|length`.
+
+- [ ] **Step 4: Run the new tests and the full suite**
+- [ ] **Step 5: Mutation-verify, then commit**
+
+```bash
+git add source/Xcp_Daq.c script/source_cfg.c.jinja2 test/get_daq_processor_info_test.py test/get_daq_event_info_test.py
+git commit -m "feat: report DAQ_CONFIG_TYPE, MAX_DAQ and MAX_DAQ_LIST for a dynamic pool"
+```
+
+---
+
+## Task 9: The state machine sweep and the acceptance round trip
+
+**Files:**
+- Modify: `test/daq_dynamic_acceptance_test.py`, `test/cmd_unknown_test.py`
+- Test: both of the above
+
+- [ ] **Step 1: Write the 16-cell sweep**
+
+Four states × four commands. Reaching a state: `FREE` is `(0xD6,)`; `DAQ` is `FREE` then `ALLOC_DAQ`; `ODT` is `DAQ` then `ALLOC_ODT`; `ODT_ENTRY` is `ODT` then `ALLOC_ODT_ENTRY`. Parametrise over every cell with its expected outcome — `0xFF` for the ten accepted, `(0xFE, 0x29)` for the six refused — and name each `id` `<state>-<command>` so a failure names the cell rather than an index.
+
+```python
+@pytest.mark.parametrize('state, command, expected', (
+    ('FREE',      'FREE_DAQ',        0xFF), ('FREE',      'ALLOC_DAQ',       0xFF),
+    ('FREE',      'ALLOC_ODT',       0x29), ('FREE',      'ALLOC_ODT_ENTRY', 0x29),
+    ('DAQ',       'FREE_DAQ',        0xFF), ('DAQ',       'ALLOC_DAQ',       0xFF),
+    ('DAQ',       'ALLOC_ODT',       0xFF), ('DAQ',       'ALLOC_ODT_ENTRY', 0x29),
+    ('ODT',       'FREE_DAQ',        0xFF), ('ODT',       'ALLOC_DAQ',       0x29),
+    ('ODT',       'ALLOC_ODT',       0xFF), ('ODT',       'ALLOC_ODT_ENTRY', 0xFF),
+    ('ODT_ENTRY', 'FREE_DAQ',        0xFF), ('ODT_ENTRY', 'ALLOC_DAQ',       0x29),
+    ('ODT_ENTRY', 'ALLOC_ODT',       0x29), ('ODT_ENTRY', 'ALLOC_ODT_ENTRY', 0xFF),
+), ids=lambda v: str(v))
+def test_the_allocation_sequence_refuses_exactly_what_the_specification_enumerates(state, command,
+                                                                                   expected):
+    """DD28. 1.1/1.6.4.3.1 enumerates six ERR_SEQUENCE cases and no others. The initial state is
+    FREE: §1.6.4.3.1.1 requires the master to send FREE_DAQ first, but that is a requirement on
+    the master, and a refusal absent from the enumerated list is not the slave's to invent."""
+```
+
+- [ ] **Step 2: Write the acceptance round trip**
+
+`FREE_DAQ` → `ALLOC_DAQ(1)` → `ALLOC_ODT(0, 1)` → `ALLOC_ODT_ENTRY(0, 0, 1)` → `SET_DAQ_PTR` → `WRITE_DAQ` → `SET_DAQ_LIST_MODE` → `START_STOP_DAQ_LIST` → `Xcp_TriggerEventChannel` → assert the sampled frame carries the expected PID and payload → `START_STOP_DAQ_LIST` stop. This is the test that proves the pool is genuinely usable end to end, not merely allocatable.
+
+- [ ] **Step 2b: Cover the three spec §6 interactions that have no test yet**
+
+In `test/daq_dynamic_acceptance_test.py`:
+
+```python
+def test_clear_daq_list_clears_entries_without_releasing_the_allocation():
+    """Spec §6: CLEAR_DAQ_LIST and FREE_DAQ stay distinct. CLEAR_DAQ_LIST clears one list's
+    entries and keeps its allocation; only FREE_DAQ releases it. Both call Xcp_DaqListReset, so
+    this is what stops that shared helper from being given FREE_DAQ's deallocation as well."""
+    handle = dynamic_handle(daq_count=1, odt_count=1, odt_entries_count=1)
+    exchange(handle, (0xD5, 0x00, 0x01, 0x00))
+    exchange(handle, (0xD4, 0x00, 0x00, 0x00, 0x01))
+    assert exchange(handle, (0xE3, 0x00, 0x00, 0x00))[0] == 0xFF
+    # Still allocated: the list is valid and still has its ODT.
+    assert handle.lib.Xcp_Ptr.config.daqList[0].maxOdt == 1
+    assert exchange(handle, (0xE3, 0x00, 0x00, 0x00))[0] == 0xFF
+
+
+def test_set_daq_ptr_is_refused_on_a_list_the_master_never_allocated():
+    """Spec §6 and DD32: no new bounds check was added for this. maxOdt is zero until ALLOC_ODT,
+    so the check already in SET_DAQ_PTR refuses it."""
+    handle = dynamic_handle(daq_count=2, odt_count=2, odt_entries_count=2)
+    exchange(handle, (0xD5, 0x00, 0x01, 0x00))
+    assert exchange(handle, (0xE2, 0x00, 0x00, 0x00, 0x00, 0x00))[0:2] == (0xFE, 0x22)
+
+
+def test_get_daq_list_info_reports_the_allocated_shape_not_the_configured_one():
+    """Spec §6: GET_DAQ_LIST_INFO reads the descriptor, so it reports runtime MAX_ODT with no
+    change. Before ALLOC_ODT the list holds no ODTs, and that is what it must say."""
+    handle = dynamic_handle(daq_count=1, odt_count=8, odt_entries_count=4)
+    exchange(handle, (0xD5, 0x00, 0x01, 0x00))
+    assert exchange(handle, (0xD8, 0x00, 0x00, 0x00))[2] == 0x00
+    exchange(handle, (0xD4, 0x00, 0x00, 0x00, 0x03))
+    assert exchange(handle, (0xD8, 0x00, 0x00, 0x00))[2] == 0x03
+
+
+@pytest.mark.parametrize('lists, accepted', ((1, True), (2, False)))
+def test_pid_off_under_dynamic_follows_the_shared_tx_pdu_rule(lists, accepted):
+    """Spec §6. Every dynamic list shares the one configured pdu_mapping, so SP2b's rule applies
+    unchanged: Xcp_DaqListTxPduIsExclusive is true only while no other list shares this list's TX
+    PDU. With one CAN-ID and several lists, §1.1.2.1 identification genuinely cannot be recovered
+    without a PID, so refusing it is honest rather than restrictive."""
+    handle = dynamic_handle(daq_count=2, odt_count=1, odt_entries_count=1,
+                            identification_field_type='ABSOLUTE_ODT_NUMBER')
+    exchange(handle, (0xD5, 0x00, lists, 0x00))
+    exchange(handle, (0xD4, 0x00, 0x00, 0x00, 0x01))
+    # SET_DAQ_LIST_MODE with PID_OFF (bit 5) on list 0.
+    result = exchange(handle, (0xE0, 0x20, 0x00, 0x00, 0x07, 0x00, 0x02))
+    assert (result[0] == 0xFF) == accepted
+```
+
+- [ ] **Step 3: Add the DYNAMIC counterpart to `cmd_unknown_test.py`**
+
+The existing test asserts `0xD3`–`0xD6` answer `ERR_CMD_UNKNOWN`; leave it exactly as it is, since it pins STATIC. Add the Task 3 boilerplate to this file too — it currently has neither `dynamic_handle` nor `exchange` — then add:
+
+```python
+@pytest.mark.parametrize('pid', (0xD3, 0xD4, 0xD5, 0xD6))
+def test_the_dynamic_allocation_commands_are_known_in_a_dynamic_build(pid):
+    """The four are optional and answer ERR_CMD_UNKNOWN under a STATIC configuration, which the
+    test above pins. Under DYNAMIC they must not: a dynamic build with no way to allocate is what
+    the generator's own guard refuses."""
+    handle = dynamic_handle()
+    assert exchange(handle, (pid, 0x00, 0x00, 0x00, 0x00, 0x00))[0:2] != (0xFE, 0x20)
+```
+
+- [ ] **Step 4: Run the full suite with the filter reset**
+
+```bash
+docker run --rm --user $(id -u):$(id -g) -v $(pwd):/usr/project xcp-test:local sh -c "cd /usr/project/build && cmake .. -DXCP_ENABLE_TEST=ON -DXCP_PYTEST_ARGS= >/dev/null" && docker run --rm --user $(id -u):$(id -g) -v $(pwd):/usr/project xcp-test:local sh -c "cd /usr/project && ./test.sh"
+```
+
+Confirm coverage of `Xcp_Daq.c` and `Xcp_DaqRuntime.c` is no lower than at the branch point (98.43% of 445 and 98.40% of 125), and that `test.sh` reports more variant groups for both files than before — the DYNAMIC build is a new compilation variant, and the union is what keeps it from collapsing coverage the way `Xcp_Daq.c` collapsed to 0.00% during SP2b.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add test/daq_dynamic_acceptance_test.py test/cmd_unknown_test.py
+git commit -m "test: cover the allocation sequence exhaustively and the dynamic round trip"
+```
+
+---
+
+## Acceptance
+
+- The four commands behave per spec §5, including all six `ERR_SEQUENCE` cases and every `ERR_MEMORY_OVERFLOW` boundary.
+- A STATIC build is behaviourally identical; `cmd_unknown_test.py` passes unchanged.
+- `DAQ_CONFIG_TYPE`, `MAX_DAQ` and `MAX_DAQ_LIST` report per DD33 and spec §6.
+- `firstPid` blocks are contiguous and non-overlapping under any allocation order.
+- No new bounds check in any DAQ handler; the six relocated entry bounds compare against the same values under STATIC.
+- No list-validity check was added to `Xcp_TriggerEventChannel`.
+- `CLEAR_DAQ_LIST` keeps its allocation, `SET_DAQ_PTR` is refused on an unallocated list,
+  `GET_DAQ_LIST_INFO` reports the allocated shape, and `PID_OFF` follows the shared-PDU rule.
+- Coverage of `Xcp_Daq.c` and `Xcp_DaqRuntime.c` no lower than at the branch point.
+- Full suite green with `XCP_PYTEST_ARGS` confirmed empty.
+- Spec §10 updated if the `FREE_DAQ` interleaving test could not be written (Task 4, Step 6).

--- a/docs/superpowers/specs/2026-09-03-xcp-daq-sp2d-design.md
+++ b/docs/superpowers/specs/2026-09-03-xcp-daq-sp2d-design.md
@@ -93,17 +93,33 @@ makes allocation failure depend on the order the master allocates in rather than
 per-list cap. Reserving the full rectangle costs RAM in the corners a master never uses; that cost
 buys an allocation that cannot fail while every request stays inside its cap.
 
-**DD27 — the DAQ list descriptor becomes mutable rather than indirect.** `Xcp_DaqListType` is
-generated `const` today. The generator emits it `const` for STATIC and non-`const` for DYNAMIC;
-`ALLOC_*` fills it in. Struct layout is unchanged, so the 14 DAQ handlers, and in particular the
-23 sites that bound an ODT number against `maxOdt` and the 13 that bound an entry against
-`maxOdtEntries`, compile and behave exactly as they do now.
+**DD27 — the DAQ list descriptor becomes mutable rather than indirect.** `ALLOC_*` writes the
+descriptor in place; the handlers keep reading the same fields and see values that changed at
+runtime.
+
+Two implementation facts, both established by reading the code rather than assumed:
+
+- **The arrays are already declared non-`const`.** `static Xcp_DaqListType Xcp_DaqListConfigNN[]`
+  and `static Xcp_OdtType Xcp_OdtConfigNNDaqNN[]` carry no `const` keyword. What places them in
+  flash is the AUTOSAR MemMap section around them — `Xcp_START_SEC_CONST_UNSPECIFIED`. So the
+  build-time difference is a **MemMap section**, not a `const` qualifier: DYNAMIC emits these two
+  arrays into a VAR section, STATIC leaves them exactly where they are. The ODT *entry* arrays are
+  already in `Xcp_START_SEC_VAR_FAST_POWER_ON_INIT_UNSPECIFIED`, because `WRITE_DAQ` writes them.
+- **The `const` that must go is on the struct members** — `Xcp_DaqListType.number`, `.firstPid`,
+  `.maxOdt`, `.maxOdtEntries` and `Xcp_OdtType.odtNumber`. A struct definition cannot differ
+  between builds without an `#if` in the header, which would create a type variant the CFFI
+  harness compiles separately, so these lose `const` in **both** builds. STATIC keeps its flash
+  placement regardless, since that comes from MemMap.
+
+**Cost, counted rather than estimated.** The fields the allocator writes are read at 16 code sites:
+`.maxOdt` at 7, `.maxOdtEntries` at 7, `.firstPid` at 2. Of those, only the 7 `.maxOdtEntries`
+sites change, and for the reason in DD34 rather than for this decision. An earlier draft of this
+document put the figure at 62 and called them all bounds checks; that came from grepping comments
+along with code, and is corrected here.
 
 The alternative — accessor functions resolving to the const table or to pool state — separates the
-two models more cleanly and keeps `const` where it belongs, but it rewrites all 62 read sites,
-every one of them a bounds check, in the area where this codebase's defects have clustered. The
-mutable descriptor buys the same capability for a fraction of that risk. STATIC keeps its tables
-in flash; DYNAMIC pays RAM, which runtime allocation requires in any design.
+two models more cleanly, but converts every one of those sites in the area where this codebase's
+defects have clustered, and buys no capability the mutable descriptor lacks.
 
 **DD28 — the allocation state machine refuses exactly what the specification enumerates, and
 nothing more.** §1.6.4.3.1 lists six `ERR_SEQUENCE` cases. They reduce to four states and this
@@ -183,6 +199,21 @@ until allocated. **SP2d adds no new bounds check anywhere.**
 dependency is `MAX_DAQ = MIN_DAQ + DAQ_COUNT`, and `minDaq` is 0. Reporting the allocated count
 would tell a master nothing before it allocates, which is precisely when it needs to know how much
 it may ask for.
+
+**DD34 — `Xcp_OdtType` gains a per-ODT entry count.** `ALLOC_ODT_ENTRY` assigns entries to *one
+ODT*, but the module has no per-ODT count: every entry bound goes through the per-list
+`daqList[n].maxOdtEntries`, at 7 code sites. That field cannot express "ODT 0 has four entries and
+ODT 1 has two", so allocating per ODT is not representable without a new field.
+
+`Xcp_OdtType` therefore gains `uint8 entryCount` — how many entries this ODT has — while
+`daqList[n].maxOdtEntries` keeps its present meaning as the cap any one ODT in the list may reach
+(`odt_entries_count` under DYNAMIC). The 7 bound sites move from the list field to the ODT field.
+
+**STATIC behaviour is provably unchanged**: the generator initialises every ODT's `entryCount` to
+that list's `max_odt_entries`, so each of the 7 checks compares against exactly the value it
+compares against today. This is the only place SP2d edits an existing bounds check, and it does so
+by changing which field is read, not the comparison — DD32's claim that SP2d adds no new bounds
+check stands.
 
 ---
 
@@ -296,7 +327,8 @@ Bytes 2,3 are `DAQ_LIST_NUMBER`; byte 4 is `ODT_NUMBER`, relative within the lis
 - `source/Xcp_Daq.c` — the four new handlers, the state machine, the prefix-sum recomputation.
 - `source/Xcp_Internal.h` — the allocation state enum, `allocatedDaqCount`.
 - `source/Xcp.c` — reset of the allocation state in `Xcp_Init` and on DISCONNECT.
-- `interface/Xcp_Types.h` — no new types; `Xcp_DaqListType`'s qualifiers become generator-driven.
+- `interface/Xcp_Types.h` — `const` dropped from the descriptor members the allocator writes,
+  and `uint8 entryCount` added to `Xcp_OdtType` (DD27, DD34).
 - `script/source_cfg.c.jinja2`, `script/header_cfg.h.jinja2` — §8.
 - `config/xcp.schema.json` — §4.
 
@@ -313,8 +345,13 @@ Bytes 2,3 are `DAQ_LIST_NUMBER`; byte 4 is `ODT_NUMBER`, relative within the lis
   `DAQ_DYNAMIC`. No `.c` file reads either field, so this corrects a latent wrong value rather than
   changing behaviour — but SP2d is what would otherwise start relying on the wrong reading. They
   become `0` under STATIC and `odt_count` / `odt_entries_count` under DYNAMIC.
-- The DAQ list descriptor arrays are emitted `const` under STATIC and non-`const` under DYNAMIC,
-  zero-initialised, sized `daq_count` × `odt_count` × `odt_entries_count`.
+- The `Xcp_DaqListType` and `Xcp_OdtType` arrays are emitted into `Xcp_START_SEC_CONST_UNSPECIFIED`
+  under STATIC, exactly as today, and into a VAR section under DYNAMIC, where the allocator writes
+  them (DD27). Under DYNAMIC they are zero-initialised and sized `daq_count`, `daq_count ×
+  odt_count` and `daq_count × odt_count × odt_entries_count` respectively.
+- Every ODT's `entryCount` (DD34) is emitted as that list's `max_odt_entries` under STATIC, which
+  is what keeps the 7 relocated bound checks comparing against the same value they do today, and
+  as `0` under DYNAMIC, where `ALLOC_ODT_ENTRY` raises it.
 - The existing `pid.next > 252` guard stays for STATIC. DYNAMIC gets no such generation guard, per
   DD31.
 
@@ -334,10 +371,11 @@ strings are documentation for whoever reads the template.
 
 ## 9. Risks
 
-- **The descriptor loses `const` under DYNAMIC.** The compiler no longer prevents a handler from
-  writing a field it should not. Mitigated by the fields being written in exactly one place — the
-  allocator — and by DD27's alternative being a rewrite of 62 bounds checks, which is the larger
-  risk.
+- **The descriptor members lose `const` in both builds** (DD27), so the compiler no longer
+  prevents a handler from writing a field it should not. Mitigated by those fields being written
+  in exactly one place, the allocator, and by the alternative converting all 16 read sites for no
+  extra capability. Flash placement is unaffected: it comes from the MemMap section, which STATIC
+  keeps.
 - **The sampler race is only partly testable.** §10 says what is covered and what is not.
 - **A DYNAMIC build reserves the full rectangle.** An integrator declaring
   `daq_count: 16, odt_count: 32, odt_entries_count: 64` reserves 32768 entry slots. The generator
@@ -398,6 +436,7 @@ Generator guards are tested by asserting generation fails, not by matching the m
   unchanged for it.
 - `DAQ_CONFIG_TYPE`, `MAX_DAQ` and `MAX_DAQ_LIST` report per DD33 and §6.
 - `firstPid` blocks are contiguous and non-overlapping under any allocation order.
-- No new bounds check was added to any DAQ handler (DD32).
+- No new bounds check was added to any DAQ handler (DD32); the 7 entry bounds moved from the
+  per-list field to the per-ODT one (DD34) and compare against the same values under STATIC.
 - Coverage of `Xcp_Daq.c` and `Xcp_DaqRuntime.c` is no lower than before the branch.
 - The full suite passes, with the pytest filter confirmed empty for the final run.

--- a/docs/superpowers/specs/2026-09-03-xcp-daq-sp2d-design.md
+++ b/docs/superpowers/specs/2026-09-03-xcp-daq-sp2d-design.md
@@ -326,7 +326,10 @@ Bytes 2,3 are `DAQ_LIST_NUMBER`; byte 4 is `ODT_NUMBER`, relative within the lis
 
 - `source/Xcp_Daq.c` — the four new handlers, the state machine, the prefix-sum recomputation.
 - `source/Xcp_Internal.h` — the allocation state enum, `allocatedDaqCount`.
-- `source/Xcp.c` — reset of the allocation state in `Xcp_Init` and on DISCONNECT.
+- `source/Xcp.c` — reset of the allocation state in `Xcp_Init`, and the `FREE_DAQ` PID table entry.
+- `source/Xcp_Std.c` — DISCONNECT calls the same unwind `FREE_DAQ` does (`Xcp_DaqFreeAll`), so a
+  master that allocates and disconnects without freeing does not leave its allocation for the next
+  one to accumulate onto (XCP part 1 — Overview 1.0/2.3).
 - `interface/Xcp_Types.h` — `const` dropped from the descriptor members the allocator writes,
   and `uint8 entryCount` added to `Xcp_OdtType` (DD27, DD34).
 - `script/source_cfg.c.jinja2`, `script/header_cfg.h.jinja2` — §8.
@@ -414,13 +417,38 @@ named so a change fails with the cell's name rather than a bare index.
 `test/cmd_unknown_test.py` already asserts 0xD3–0xD6 answer `ERR_CMD_UNKNOWN`, which must stay true
 for a STATIC build; it gains a DYNAMIC counterpart asserting they no longer do.
 
-**On the sampler race, plainly:** the harness asserts exclusive-area nesting, balance and
-non-leakage globally on every test, so DD30's area discipline is checked throughout. The
-interleaving itself is harder. The `SchM` mock's `side_effect` is a preemption-injection point — a
-trigger can be driven from inside the area-taking call — and that is to be attempted first. If
-CFFI reentrancy makes it impractical, the fallback is the post-condition alone: after `FREE_DAQ`, a
-trigger samples nothing and no frame reaches the ring. If that is where it lands, this document
-must be updated to say the outcome is covered and the interleaving is not.
+**On the sampler race, plainly** (settled in Task 4; this replaces the plan this section carried):
+the harness asserts exclusive-area nesting, balance and non-leakage globally on every test, so
+DD30's area discipline is checked throughout. Beyond that, `test/free_daq_test.py` covers:
+
+- **The interleaving, at the points where a preemption can actually land.** Driving the trigger
+  from `SchM_Exit_Xcp_DtoQueue`'s `side_effect` puts it at each point in the unwind where the DAQ
+  exclusive area is *not* held, one point per run, swept over all of them. At every one the
+  sampler reads no slave memory and queues no frame: at the first release the ODT's entries have
+  been cleared while its counts still describe them, at the second the counts are already zero.
+  The sweep's width is pinned by a companion test, so a critical section added to the unwind fails
+  loudly rather than silently going unswept.
+- **The post-condition.** After `FREE_DAQ` returns, a trigger samples nothing and no frame reaches
+  the ring — with a named control test showing the same configuration does sample when `FREE_DAQ`
+  does not run, so the post-condition cannot pass vacuously.
+
+**What is deliberately not covered:** a trigger driven from *inside* a held area, i.e. from
+`SchM_Enter_Xcp_DtoQueue`'s `side_effect`. It was attempted first, as this section originally
+asked. CFFI reentrancy is not the obstacle — the trigger runs — but the scenario is not one the
+module can face: `SchM_Enter_Xcp_DtoQueue` exists precisely to suppress the interrupt the sampler
+runs in, so a trigger inside the held area models a preemption the exclusive area forbids rather
+than one it must survive. The harness agrees, and says so: it records the injection as
+`SchM_Enter_Xcp_DtoQueue called while already held` plus an unbalanced exit, because it models the
+area as one boolean and cannot distinguish a forbidden preemption from a double-enter defect.
+Suppressing those violations to let such a test pass would disable, for that test, the very
+invariant the suite relies on everywhere else. So it is not written.
+
+**One gap this exposed, not closed by SP2d so far:** `Xcp_Init` resets `Xcp_Internal` and every
+`Xcp_DaqListRt`, and clears the ODT entries, but never resets the descriptor's own `maxOdt`,
+`firstPid` or per-ODT `entryCount` — which under DYNAMIC *are* the allocation. A re-initialised
+module therefore reports nothing allocated while the descriptor still describes the previous
+session's lists. `Xcp_DaqFreeAll` is exactly the operation `Xcp_Init` is missing; see the Task 4
+report.
 
 Generator guards are tested by asserting generation fails, not by matching the message.
 

--- a/docs/superpowers/specs/2026-09-03-xcp-daq-sp2d-design.md
+++ b/docs/superpowers/specs/2026-09-03-xcp-daq-sp2d-design.md
@@ -1,0 +1,403 @@
+# SP2d — Dynamic DAQ list configuration
+
+**Status:** design approved 2026-09-03. Implements the four dynamic configuration commands and the
+`DAQ_CONFIG_TYPE = dynamic` branch.
+
+**Predecessors:** SP2a (static DAQ lists, the command surface), SP2b (optional commands, the
+timestamp field, `PID_OFF`). SP2c — DAQ list prioritisation and more than one outstanding DTO
+frame — is deliberately *not* a predecessor; it was deferred because it buys no conformance, and
+nothing here depends on it.
+
+---
+
+## 0. Which specification numbering this document uses
+
+Citations are to **XCP Part 2 — Protocol Layer Specification 1.1** unless a citation names 1.0,
+matching SP2a and SP2b. §0 of the SP2a design records that 1.0 and 1.1 renumber §1.6.4 wholesale
+and carries the mapping table; it already covers all four commands here, and is not repeated. In
+short: dynamic configuration is §1.6.4.2 in 1.0 and §1.6.4.3 in 1.1.
+
+The command codes, byte layouts and error codes are identical in both revisions.
+
+One practical note, as in SP2b. The 1.1 PDF in `docs/external/` is a scan and its OCR is
+unreliable; the 1.0 PDF is text and extracts cleanly. Every quotation and every table-shaped claim
+in this document was therefore read from the 1.0 text and is cited by its 1.1 number. The defect
+fixed in PR #9 came from reasoning about a bit table through that OCR, so where a layout matters,
+read the 1.0 text or render the 1.1 page rather than trusting the transcription.
+
+---
+
+## 1. Scope
+
+**In:**
+
+- `FREE_DAQ` (0xD6), `ALLOC_DAQ` (0xD5), `ALLOC_ODT` (0xD4), `ALLOC_ODT_ENTRY` (0xD3),
+  the four commands of §1.6.4.3.1.
+- A build-time choice between static and dynamic DAQ list configuration.
+- The `DAQ_CONFIG_TYPE` bit in `DAQ_PROPERTIES`, currently hard-cleared.
+- Correcting `XcpOdtCount` and `XcpOdtEntriesCount`, which the generator currently emits with the
+  wrong meaning (§8).
+
+**Out:**
+
+- DAQ list prioritisation and multiple outstanding DTO frames (SP2c).
+- STIM (SP3), non-volatile DAQ storage and RESUME (SP5-NV).
+- Distinct TX PDUs per dynamic DAQ list. See DD31 for the consequence and §9 for the follow-up.
+
+---
+
+## 2. What already exists
+
+More than expected. SP2a laid most of the groundwork and left it unpopulated:
+
+| Thing | State |
+|---|---|
+| `Xcp_DaqConfigTypeType`, with `XCP_DAQ_STATIC` / `XCP_DAQ_DYNAMIC` | declared, hard-coded to `DAQ_STATIC` in the generator |
+| `Xcp_GeneralType.daqCount`, `.odtCount`, `.odtEntriesCount`, `.minDaq` | declared; `odtCount` and `odtEntriesCount` read by no `.c` file |
+| `Xcp_CTOErrorMatrix` rows for 0xD3–0xD6 | present, carrying `SEQUENCE` and `MEMORY_OVERFLOW` where the spec needs them |
+| `ctoInfo` enable/protected bits and minimum request sizes for all four | present and correct: `0x06`, `0x05`, `0x04`, `0x01` |
+| `Xcp_PIDToCmdGroupTable` entries for all four | present, `XCP_RESOURCE_PROTECTION_STATUS_MASK_DAQ` |
+| `Xcp_DaqListClearEntries(daqListNumber)` | exists, takes the DAQ exclusive area |
+| `Xcp_DaqListTxPduIsExclusive` | exists, added by SP2b for `PID_OFF` |
+| Sampling by runtime event binding | already the case; `triggeredDaqListRef` has no runtime role |
+
+The four commands answer `ERR_CMD_UNKNOWN` today, and `test/cmd_unknown_test.py` pins that.
+
+---
+
+## 3. Design decisions
+
+**DD25 — static and dynamic are a build-time choice, not a runtime one.** A slave declares
+`DAQ_CONFIG_TYPE` as one bit, so one running slave is one or the other. `daq_config_type` in the
+configuration selects which is generated. A STATIC build is byte-for-byte what the module produces
+today and pays no ROM for the dynamic path; a DYNAMIC build has no statically declared lists.
+Generating both and choosing at initialisation was rejected: it costs ROM and RAM for the unused
+model in every build and doubles the state every DAQ handler must reason about.
+
+**DD26 — capacity is AUTOSAR's rectangle, not a fungible pool.** AUTOSAR defines, in `XcpGeneral`
+with ECU scope:
+
+- `XcpDaqCount` (ECUC_Xcp_00012) — "the number of DAQ lists for dynamic configuration", 0..65535
+- `XcpOdtCount` (ECUC_Xcp_00054) — "the amount of ODTs **of a DAQ list** using dynamic DAQ list
+  configuration", 0..252
+- `XcpOdtEntriesCount` (ECUC_Xcp_00059) — "the amount of entries **into an ODT** using dynamic DAQ
+  list configuration", 0..255
+
+All three are "available only if XcpDaqConfigType is set to DAQ_DYNAMIC". So capacity is
+`daq_count` × `odt_count` × `odt_entries_count`, reserved in full, and `ERR_MEMORY_OVERFLOW` means
+a request exceeded its own declared cap.
+
+An earlier draft of this design proposed aggregate totals divided freely between lists, which
+would let one list take eight ODTs where another took two. That is not the AUTOSAR model, and it
+makes allocation failure depend on the order the master allocates in rather than on a declared
+per-list cap. Reserving the full rectangle costs RAM in the corners a master never uses; that cost
+buys an allocation that cannot fail while every request stays inside its cap.
+
+**DD27 — the DAQ list descriptor becomes mutable rather than indirect.** `Xcp_DaqListType` is
+generated `const` today. The generator emits it `const` for STATIC and non-`const` for DYNAMIC;
+`ALLOC_*` fills it in. Struct layout is unchanged, so the 14 DAQ handlers, and in particular the
+23 sites that bound an ODT number against `maxOdt` and the 13 that bound an entry against
+`maxOdtEntries`, compile and behave exactly as they do now.
+
+The alternative — accessor functions resolving to the const table or to pool state — separates the
+two models more cleanly and keeps `const` where it belongs, but it rewrites all 62 read sites,
+every one of them a bounds check, in the area where this codebase's defects have clustered. The
+mutable descriptor buys the same capability for a fraction of that risk. STATIC keeps its tables
+in flash; DYNAMIC pays RAM, which runtime allocation requires in any design.
+
+**DD28 — the allocation state machine refuses exactly what the specification enumerates, and
+nothing more.** §1.6.4.3.1 lists six `ERR_SEQUENCE` cases. They reduce to four states and this
+table:
+
+| command | accepted from | moves to |
+|---|---|---|
+| `FREE_DAQ` | any | `FREE` |
+| `ALLOC_DAQ` | `FREE`, `DAQ` | `DAQ` |
+| `ALLOC_ODT` | `DAQ`, `ODT` | `ODT` |
+| `ALLOC_ODT_ENTRY` | `ODT`, `ODT_ENTRY` | `ODT_ENTRY` |
+
+**The initial state is `FREE`.** §1.6.4.3.1.1 says the master "always first has to send a
+FREE_DAQ", but that is a requirement on the master, and the slave's enumerated refusals do not
+include an `ALLOC_DAQ` with no preceding command. Nothing is allocated at that point, so accepting
+it is well-defined. Defect D9 was the module accepting a mode it could not fulfil; the discipline
+that fixed it — refuse what the specification authorises refusing, and only that — says equally
+that a refusal absent from the list should not be invented.
+
+**Repeats accumulate.** `ALLOC_DAQ` after `ALLOC_DAQ`, and `ALLOC_ODT` after `ALLOC_ODT`, are
+permitted by their omission from the refusal list. Each call adds to what is allocated, and
+`ERR_MEMORY_OVERFLOW` is measured against the running total. Treating a repeat as a replacement
+would make the permitted repeat meaningless.
+
+**Error precedence:** `CMD_SYNTAX` (length, enforced by the dispatcher from `ctoInfo`) →
+`SEQUENCE` → `OUT_OF_RANGE` → `MEMORY_OVERFLOW`. Sequence precedes the argument checks because it
+is a statement about the command stream rather than about this command's arguments.
+
+**DD29 — `FREE_DAQ` stops a running DAQ rather than refusing.** `Xcp_CTOErrorMatrix` gives 0xD6
+only `CMD_BUSY | PGM_ACTIVE | CMD_UNKNOWN | CMD_SYNTAX`; `ERR_DAQ_ACTIVE` is absent, so refusing a
+running slave is not authorised. `FREE_DAQ` stops every running list, frees, and clears
+`DAQ_RUNNING` through the existing `Xcp_DaqSessionStatusUpdate`.
+
+**DD30 — freeing unwinds in the reverse of allocation, inside the DAQ exclusive area.**
+`Xcp_TriggerEventChannel` runs in interrupt context and reaches entry storage by walking `maxOdt`
+and then each ODT's entry count. Freeing must never leave a count that outlives the storage it
+describes — the DD14 failure class. So `FREE_DAQ` stops the lists first, so no new sampling
+begins; then zeroes the per-list `maxOdt` and per-ODT entry counts; then resets the pool cursors.
+A trigger interleaved at any point sees a zero count and samples nothing, rather than a stale
+count into released storage.
+
+`FREE_DAQ` must also clear `Xcp_DaqListRt` — mode, prescaler, prescaler counter, priority and
+`eventChannelNumber`. These live in a separate array from the descriptor, so "free the descriptor"
+is not sufficient: a freed-then-reallocated list would otherwise start with a binding the master
+never set for it.
+
+**DD31 — `firstPid` is a prefix sum over list index, recomputed whenever ODT counts change.**
+Assigning PIDs in call order fails under DD28's accumulate rule: `ALLOC_ODT(0, 2)`,
+`ALLOC_ODT(1, 3)`, `ALLOC_ODT(0, 1)` leaves list 0 needing three contiguous PIDs when list 1
+already owns 2..4. Since the absolute ODT number is `firstPid + relative`, contiguity is required.
+`firstPid[i] = Σ maxOdt[0..i-1]` is order-independent, contiguous by construction, and `O(daq_count)`
+to recompute. It is also exactly what the generator does for STATIC at `script/source_cfg.c.jinja2`,
+so both models compute `firstPid` the same way — one at generation, one at allocation.
+
+The ceiling is 252: slave-to-master PIDs `0xFC..0xFF` are `SERV`, `EV`, `ERR` and `RES`, leaving
+`0x00..0xFB`. `ALLOC_ODT` answers `ERR_MEMORY_OVERFLOW` when the new total would pass it, and
+rejects the request whole rather than applying part of it — a partially applied allocation leaves
+counts the master does not know about.
+
+This ceiling is checked at runtime rather than at generation. Guarding `daq_count × odt_count ≤ 252`
+in the template would reject configurations a master can use perfectly well, since a master rarely
+allocates the full rectangle. Storage is fully reserved and so can never overflow; the PID space
+is the only exhaustible resource, and it fails where the master can see it.
+
+**DD32 — one runtime list count serves both models.** `Xcp_DaqListIsValid` bounds against a
+runtime `allocatedDaqCount`, initialised to `daqCount` in a STATIC build and to `0` in a DYNAMIC
+one, then raised by `ALLOC_DAQ`. This is what makes DD27 pay: all 14 handlers keep calling the same
+predicate unchanged.
+
+It also gives `ALLOC_ODT` the right range for free. The spec's `[MIN_DAQ, MIN_DAQ+DAQ_COUNT-1]` is
+over what `ALLOC_DAQ` allocated, not over the configured pool, so a list inside the pool but not
+yet allocated is "not available" and answers `ERR_OUT_OF_RANGE`. The same holds one level down:
+ODT and entry numbers are already bounded against `maxOdt` and `maxOdtEntries`, which are zero
+until allocated. **SP2d adds no new bounds check anywhere.**
+
+**DD33 — `MAX_DAQ` reports the configured pool, not the allocated count.** ECUC_Xcp_00164's
+dependency is `MAX_DAQ = MIN_DAQ + DAQ_COUNT`, and `minDaq` is 0. Reporting the allocated count
+would tell a master nothing before it allocates, which is precisely when it needs to know how much
+it may ask for.
+
+---
+
+## 4. Configuration model
+
+### 4.1 New keys
+
+`configurations[x].protocol_layer.daq_config_type`: `"STATIC" | "DYNAMIC"`, default `"STATIC"`, so
+every existing configuration keeps working untouched (ECUC_Xcp_00164).
+
+When it is `"DYNAMIC"`, a sibling `configurations[x].daq_dynamic` object is required and
+`configurations[x].daqs` must be absent:
+
+```json
+"daq_dynamic": {
+  "daq_count": 4,
+  "odt_count": 8,
+  "odt_entries_count": 16,
+  "pdu_mapping": "XCP_PDU_ID_TRANSMIT"
+}
+```
+
+`pdu_mapping` exists because dynamic lists have no `daqs[n]` entry to carry one. A single shared TX
+PDU matches what `config/xcp.json` already does for its two static lists.
+
+`configurations[x].events[y].triggered_daq_list_ref` is forbidden under DYNAMIC: it names entries
+in `daqs`, which is absent.
+
+### 4.2 Schema validation
+
+JSON Schema `if/then` enforces the pairing, so a configuration can declare neither model nor both.
+
+---
+
+## 5. Command specifications
+
+### 5.1 FREE_DAQ — 0xD6 (§1.6.4.3.1.1)
+
+Request is one byte. Clears all DAQ lists and frees every allocated list, ODT and ODT entry.
+
+Per DD29 it never answers `ERR_DAQ_ACTIVE`; per DD30 it stops the lists, zeroes counts, resets
+cursors and clears `Xcp_DaqListRt`, in that order, inside the DAQ exclusive area. Moves the state
+machine to `FREE` from any state. Positive response is one byte.
+
+### 5.2 ALLOC_DAQ — 0xD5 (§1.6.4.3.1.2)
+
+Bytes 2,3 are `DAQ_COUNT`, read with the configured byte order.
+
+- `ERR_SEQUENCE` from `ODT` or `ODT_ENTRY`.
+- `ERR_MEMORY_OVERFLOW` when `allocatedDaqCount + DAQ_COUNT > daq_count`.
+- Otherwise raises `allocatedDaqCount` by `DAQ_COUNT` and moves to `DAQ`.
+
+### 5.3 ALLOC_ODT — 0xD4 (§1.6.4.3.1.3)
+
+Bytes 2,3 are `DAQ_LIST_NUMBER`; byte 4 is `ODT_COUNT`.
+
+- `ERR_SEQUENCE` from `FREE` or `ODT_ENTRY`.
+- `ERR_OUT_OF_RANGE` when the list is not allocated (DD32).
+- `ERR_MEMORY_OVERFLOW` when the list's `maxOdt + ODT_COUNT > odt_count`, or when the resulting
+  total ODT count across all lists would exceed 252 (DD31).
+- Otherwise raises that list's `maxOdt`, recomputes every `firstPid` as a prefix sum, and moves
+  to `ODT`.
+
+### 5.4 ALLOC_ODT_ENTRY — 0xD3 (§1.6.4.3.1.4)
+
+Bytes 2,3 are `DAQ_LIST_NUMBER`; byte 4 is `ODT_NUMBER`, relative within the list; byte 5 is
+`ODT_ENTRIES_COUNT`.
+
+- `ERR_SEQUENCE` from `FREE` or `DAQ`.
+- `ERR_OUT_OF_RANGE` when the list is not allocated, or `ODT_NUMBER >= maxOdt` for it.
+- `ERR_MEMORY_OVERFLOW` when that ODT's entry count `+ ODT_ENTRIES_COUNT > odt_entries_count`.
+- Otherwise raises that ODT's entry count and moves to `ODT_ENTRY`.
+
+---
+
+## 6. Interaction with the existing surface
+
+- **Sampling is unchanged.** `triggeredDaqListRef` has no runtime role; `Xcp_TriggerEventChannel`
+  scans lists by their runtime `eventChannelNumber`, which `SET_DAQ_LIST_MODE` sets. Dynamic lists
+  bind exactly as static ones do.
+- **The sampler keeps iterating the whole pool, and that is correct.** Its loop bound is
+  `daq_idx < Xcp_Ptr->general->daqCount` — the configured pool, not `allocatedDaqCount`, and
+  `Xcp_DaqListIsValid` is `static` to `source/Xcp_Daq.c` so the sampler could not call it anyway.
+  An unallocated list is skipped twice over: it is never `RUNNING`, because `START_STOP_DAQ_LIST`
+  is gated by `Xcp_DaqListIsValid` and so refuses it, and its `maxOdt` is zero, so the inner ODT
+  loop does not execute. **Do not add a third check here.** It would be redundant, and it would
+  put an `allocatedDaqCount` read in interrupt context against a value written by the command
+  handlers — a race the current structure does not have.
+- **`MAX_DAQ_LIST`** in `GET_DAQ_EVENT_INFO` reports `daq_count` for every event channel under
+  DYNAMIC, since any allocated list may bind to any channel.
+- **`GET_DAQ_PROCESSOR_INFO`** sets `DAQ_CONFIG_TYPE` from `daqConfigType` instead of leaving it
+  clear, and reports `MAX_DAQ` per DD33.
+- **`GET_DAQ_LIST_INFO`** reads the descriptor, so it reports runtime `MAX_ODT` and
+  `MAX_ODT_ENTRIES` with no change.
+- **`START_STOP_DAQ_LIST`** already returns `FIRST_PID` from the descriptor and needs no change; it
+  reads a value assigned at allocation rather than at generation.
+- **`CLEAR_DAQ_LIST` and `FREE_DAQ` stay distinct.** `CLEAR_DAQ_LIST` clears one list's entries and
+  keeps its allocation. Its behaviour is unchanged in both models.
+- **`SET_DAQ_PTR` and `WRITE_DAQ` against an unallocated list** are refused by the bounds checks
+  that already exist, since `maxOdt` is zero.
+- **`PID_OFF` under DYNAMIC is available only while exactly one list is allocated.** All dynamic
+  lists share the configured `pdu_mapping`, so SP2b's rule applies unchanged:
+  `Xcp_DaqListTxPduIsExclusive` is true only while no other list shares that PDU. This is honest
+  rather than restrictive — with one CAN-ID and several lists, §1.1.2.1 identification genuinely
+  cannot be recovered without a PID.
+
+---
+
+## 7. Source layout
+
+- `source/Xcp_Daq.c` — the four new handlers, the state machine, the prefix-sum recomputation.
+- `source/Xcp_Internal.h` — the allocation state enum, `allocatedDaqCount`.
+- `source/Xcp.c` — reset of the allocation state in `Xcp_Init` and on DISCONNECT.
+- `interface/Xcp_Types.h` — no new types; `Xcp_DaqListType`'s qualifiers become generator-driven.
+- `script/source_cfg.c.jinja2`, `script/header_cfg.h.jinja2` — §8.
+- `config/xcp.schema.json` — §4.
+
+---
+
+## 8. Generator and schema changes
+
+- `XcpDaqConfigType` becomes derived rather than the hard-coded `DAQ_STATIC`, whose comment says
+  dynamic "arrives in SP2c" and is stale twice over.
+- `XcpDaqCount` stays `daqs|length` under STATIC and becomes `daq_count` under DYNAMIC.
+- **`XcpOdtCount` and `XcpOdtEntriesCount` get their AUTOSAR meaning.** The generator currently
+  emits the sum of `max_odt` across all lists, and the sum of `max_odt × max_odt_entries`,
+  into fields AUTOSAR defines as ODTs *per list* and entries *per ODT*, and defines only for
+  `DAQ_DYNAMIC`. No `.c` file reads either field, so this corrects a latent wrong value rather than
+  changing behaviour — but SP2d is what would otherwise start relying on the wrong reading. They
+  become `0` under STATIC and `odt_count` / `odt_entries_count` under DYNAMIC.
+- The DAQ list descriptor arrays are emitted `const` under STATIC and non-`const` under DYNAMIC,
+  zero-initialised, sized `daq_count` × `odt_count` × `odt_entries_count`.
+- The existing `pid.next > 252` guard stays for STATIC. DYNAMIC gets no such generation guard, per
+  DD31.
+
+New guards, each aborting rendering:
+
+1. `daq_count > 255` under DYNAMIC — `maxDaqList` is a `uint8` and `MAX_DAQ_LIST` is one byte in
+   §1.6.4.1.2.7. Same shape as the existing `triggered_daq_list_ref|length > 255` guard.
+2. Any of the four ALLOC APIs enabled under STATIC.
+3. Any of the four ALLOC APIs disabled under DYNAMIC — a dynamic build with no way to allocate.
+4. `daqs` present under DYNAMIC, or `daq_dynamic` present under STATIC.
+
+`raise` is not a registered Jinja global in `bsw_code_gen`; referencing it aborts rendering with
+`UndefinedError`, which is the intended effect, but the message never reaches the caller. The
+strings are documentation for whoever reads the template.
+
+---
+
+## 9. Risks
+
+- **The descriptor loses `const` under DYNAMIC.** The compiler no longer prevents a handler from
+  writing a field it should not. Mitigated by the fields being written in exactly one place — the
+  allocator — and by DD27's alternative being a rewrite of 62 bounds checks, which is the larger
+  risk.
+- **The sampler race is only partly testable.** §10 says what is covered and what is not.
+- **A DYNAMIC build reserves the full rectangle.** An integrator declaring
+  `daq_count: 16, odt_count: 32, odt_entries_count: 64` reserves 32768 entry slots. The generator
+  does not guard total RAM; that is the integrator's sizing decision, as it is for the static
+  model.
+- **`PID_OFF` is effectively unavailable under DYNAMIC** beyond a single list (§6). The follow-up,
+  if a project needs it, is a TX PDU pool in `daq_dynamic` rather than one `pdu_mapping`. Deferred:
+  nothing in the specification requires it and it doubles the configuration surface.
+
+---
+
+## 10. Test strategy
+
+Both variants are exercised through `DefaultConfig(daq_config_type='DYNAMIC', ...)`. This adds a
+compilation variant of `Xcp_Daq.c` and `Xcp_DaqRuntime.c`; `script/gcov_union.py` already unions
+variant groups, so coverage stays whole rather than collapsing as `Xcp_Daq.c` did to 0.00% during
+SP2b.
+
+New files: `free_daq_test.py`, `alloc_daq_test.py`, `alloc_odt_test.py`,
+`alloc_odt_entry_test.py`, and `daq_dynamic_acceptance_test.py` doing a full
+`FREE → ALLOC → WRITE_DAQ → START → sample → STOP` round trip.
+
+**A 16-cell state machine sweep** — 4 states × 4 commands, 6 refusals and 10 acceptances, each cell
+named so a change fails with the cell's name rather than a bare index.
+
+**Three tests come directly from the design work:**
+
+- **PID contiguity.** Allocate ODTs out of order — list 1, then list 0, then more to list 0 — and
+  assert `FIRST_PID` blocks are contiguous and non-overlapping. This is the case that ruled out
+  call-order assignment in DD31, so it goes in as a named regression from the start.
+- **The 252 ceiling.** Allocate to exactly 252 and assert success; ask for one more and assert
+  `ERR_MEMORY_OVERFLOW` *and* that the total is unchanged.
+- **`FREE_DAQ` clears runtime state.** Allocate, set a mode and event binding, free, reallocate,
+  and assert mode, prescaler and `eventChannelNumber` are back to defaults (DD30).
+
+`test/cmd_unknown_test.py` already asserts 0xD3–0xD6 answer `ERR_CMD_UNKNOWN`, which must stay true
+for a STATIC build; it gains a DYNAMIC counterpart asserting they no longer do.
+
+**On the sampler race, plainly:** the harness asserts exclusive-area nesting, balance and
+non-leakage globally on every test, so DD30's area discipline is checked throughout. The
+interleaving itself is harder. The `SchM` mock's `side_effect` is a preemption-injection point — a
+trigger can be driven from inside the area-taking call — and that is to be attempted first. If
+CFFI reentrancy makes it impractical, the fallback is the post-condition alone: after `FREE_DAQ`, a
+trigger samples nothing and no frame reaches the ring. If that is where it lands, this document
+must be updated to say the outcome is covered and the interleaving is not.
+
+Generator guards are tested by asserting generation fails, not by matching the message.
+
+**Every new test is mutation-verified:** it must fail for the reason it names, and nothing else.
+
+---
+
+## 11. Acceptance
+
+- The four commands behave per §5, including all six `ERR_SEQUENCE` cases and every
+  `ERR_MEMORY_OVERFLOW` boundary.
+- A STATIC build is behaviourally identical to today, and `cmd_unknown_test.py` still passes
+  unchanged for it.
+- `DAQ_CONFIG_TYPE`, `MAX_DAQ` and `MAX_DAQ_LIST` report per DD33 and §6.
+- `firstPid` blocks are contiguous and non-overlapping under any allocation order.
+- No new bounds check was added to any DAQ handler (DD32).
+- Coverage of `Xcp_Daq.c` and `Xcp_DaqRuntime.c` is no lower than before the branch.
+- The full suite passes, with the pytest filter confirmed empty for the final run.

--- a/docs/superpowers/specs/2026-09-03-xcp-daq-sp2d-design.md
+++ b/docs/superpowers/specs/2026-09-03-xcp-daq-sp2d-design.md
@@ -326,10 +326,12 @@ Bytes 2,3 are `DAQ_LIST_NUMBER`; byte 4 is `ODT_NUMBER`, relative within the lis
 
 - `source/Xcp_Daq.c` — the four new handlers, the state machine, the prefix-sum recomputation.
 - `source/Xcp_Internal.h` — the allocation state enum, `allocatedDaqCount`.
-- `source/Xcp.c` — reset of the allocation state in `Xcp_Init`, and the `FREE_DAQ` PID table entry.
-- `source/Xcp_Std.c` — DISCONNECT calls the same unwind `FREE_DAQ` does (`Xcp_DaqFreeAll`), so a
-  master that allocates and disconnects without freeing does not leave its allocation for the next
-  one to accumulate onto (XCP part 1 — Overview 1.0/2.3).
+- `source/Xcp.c` — the `FREE_DAQ` PID table entry, and `Xcp_Init` calling the same unwind
+  `FREE_DAQ` does (`Xcp_DaqFreeAll`) in place of its open-coded per-list reset loop, so
+  initialisation establishes the same invariant rather than a slightly different one.
+- `source/Xcp_Std.c` — DISCONNECT calls that unwind too, **under `DAQ_DYNAMIC` only**, so a master
+  that allocates and disconnects without freeing does not leave its allocation for the next one to
+  accumulate onto. A STATIC build has no allocation to leak and is left exactly as it is (DD25).
 - `interface/Xcp_Types.h` — `const` dropped from the descriptor members the allocator writes,
   and `uint8 entryCount` added to `Xcp_OdtType` (DD27, DD34).
 - `script/source_cfg.c.jinja2`, `script/header_cfg.h.jinja2` — §8.
@@ -443,12 +445,12 @@ area as one boolean and cannot distinguish a forbidden preemption from a double-
 Suppressing those violations to let such a test pass would disable, for that test, the very
 invariant the suite relies on everywhere else. So it is not written.
 
-**One gap this exposed, not closed by SP2d so far:** `Xcp_Init` resets `Xcp_Internal` and every
-`Xcp_DaqListRt`, and clears the ODT entries, but never resets the descriptor's own `maxOdt`,
-`firstPid` or per-ODT `entryCount` — which under DYNAMIC *are* the allocation. A re-initialised
-module therefore reports nothing allocated while the descriptor still describes the previous
-session's lists. `Xcp_DaqFreeAll` is exactly the operation `Xcp_Init` is missing; see the Task 4
-report.
+**One gap this exposed, since closed:** `Xcp_Init` reset `Xcp_Internal` and every `Xcp_DaqListRt`
+and cleared the ODT entries, but never reset the descriptor's own `maxOdt`, `firstPid` or per-ODT
+`entryCount` — which under DYNAMIC *are* the allocation. A re-initialised module therefore reported
+nothing allocated while the descriptor still described the previous session's lists, and its clear
+missed the entries too, being bounded by exactly the counts left behind. `Xcp_Init` now calls
+`Xcp_DaqFreeAll`, which is precisely the operation it was missing.
 
 Generator guards are tested by asserting generation fails, not by matching the message.
 

--- a/docs/superpowers/specs/2026-09-03-xcp-daq-sp2d-design.md
+++ b/docs/superpowers/specs/2026-09-03-xcp-daq-sp2d-design.md
@@ -314,11 +314,23 @@ Bytes 2,3 are `DAQ_LIST_NUMBER`; byte 4 is `ODT_NUMBER`, relative within the lis
   keeps its allocation. Its behaviour is unchanged in both models.
 - **`SET_DAQ_PTR` and `WRITE_DAQ` against an unallocated list** are refused by the bounds checks
   that already exist, since `maxOdt` is zero.
-- **`PID_OFF` under DYNAMIC is available only while exactly one list is allocated.** All dynamic
-  lists share the configured `pdu_mapping`, so SP2b's rule applies unchanged:
-  `Xcp_DaqListTxPduIsExclusive` is true only while no other list shares that PDU. This is honest
-  rather than restrictive — with one CAN-ID and several lists, §1.1.2.1 identification genuinely
-  cannot be recovered without a PID.
+- **`PID_OFF` under DYNAMIC is available only in a pool configured with exactly one list.** All
+  dynamic lists share the configured `pdu_mapping`, so SP2b's rule applies unchanged:
+  `Xcp_DaqListTxPduIsExclusive` is true only while no other list shares that PDU. The
+  discriminator is the *configured* pool — that function walks `Xcp_Ptr->general->daqCount`, not
+  `allocatedDaqCount` — so a second pool slot refuses `PID_OFF` whether or not `ALLOC_DAQ` has
+  handed it out. That is the conservative direction and it is deliberate: reading the allocated
+  count here would make `PID_OFF` legal for a lone allocated list and then silently wrong the
+  moment the master allocated a second one, since nothing revisits a mode already set. This is
+  honest rather than restrictive — with one CAN-ID and several lists, §1.1.2.1 identification
+  genuinely cannot be recovered without a PID.
+- **`FREE_DAQ` does not flush the DTO ring.** Frames sampled before or during the unwind are still
+  transmitted after `FREE_DAQ` or `DISCONNECT` releases the lists that produced them. This is
+  correct rather than overlooked: those frames were validly sampled, their PIDs match the layout
+  that was in force at sample time, and §1.6.4.3.1.1 requires the command to clear and free DAQ
+  lists, not to discard data already acquired. `Xcp_DaqFreeAll` therefore touches the descriptors,
+  the entries and `Xcp_DaqListRt`, and leaves `Xcp_Rt[...].dtoQueue` alone. Recorded here so it is
+  read as a decision rather than rediscovered as a surprise.
 
 ---
 
@@ -389,6 +401,27 @@ strings are documentation for whoever reads the template.
 - **`PID_OFF` is effectively unavailable under DYNAMIC** beyond a single list (§6). The follow-up,
   if a project needs it, is a TX PDU pool in `daq_dynamic` rather than one `pdu_mapping`. Deferred:
   nothing in the specification requires it and it doubles the configuration surface.
+- **The `FIRST_PID` unreachability argument rests on two preconditions that are not visible where
+  it is stated.** The argument is that a *running* list's `FIRST_PID` can never move under it:
+  `Xcp_DaqRecomputeFirstPids` runs only from `ALLOC_ODT`, and `ALLOC_ODT` answers `ERR_SEQUENCE`
+  once the state has reached `XCP_DAQ_ALLOC_ODT_ENTRY`, which any list carrying an entry has
+  passed through. It holds only while both of these do, and either one can be removed without
+  breaking any other claim in this document:
+
+  1. **A refused `ALLOC_ODT_ENTRY`, `ALLOC_ODT` or `ALLOC_DAQ` must leave `daq_alloc_state` where
+     it found it.** Each handler assigns the state inside its `else`, after the error chain. Move
+     that assignment out to after the `if/else` and the state advances on a refusal: from
+     `ODT_ENTRY`, a refused `ALLOC_ODT` would set the state to `ODT`, the next `ALLOC_ODT` would
+     be accepted, and `FIRST_PID` would move under a list that is already running. Pinned by
+     `test_alloc_odt_entry_refusal_leaves_the_allocation_state_unadvanced` and its two siblings for
+     `ALLOC_ODT` and `ALLOC_DAQ`; all three exist for this reason and are not redundant with each
+     other.
+  2. **`Xcp_Init` and `DISCONNECT` must zero every ODT's `entryCount`.** The state machine's memory
+     of "this list has entries" is `daq_alloc_state`, which both paths reset to `FREE`. If the
+     counts survived while the state did not, a list would re-enter `ALLOC_ODT` carrying entries
+     from the previous session and the argument's premise — that state `ODT_ENTRY` covers every
+     list with an entry — would be false. `Xcp_DaqFreeAll` is what supplies this, from both call
+     sites.
 
 ---
 
@@ -448,9 +481,15 @@ invariant the suite relies on everywhere else. So it is not written.
 **One gap this exposed, since closed:** `Xcp_Init` reset `Xcp_Internal` and every `Xcp_DaqListRt`
 and cleared the ODT entries, but never reset the descriptor's own `maxOdt`, `firstPid` or per-ODT
 `entryCount` — which under DYNAMIC *are* the allocation. A re-initialised module therefore reported
-nothing allocated while the descriptor still described the previous session's lists, and its clear
-missed the entries too, being bounded by exactly the counts left behind. `Xcp_Init` now calls
-`Xcp_DaqFreeAll`, which is precisely the operation it was missing.
+nothing allocated while the descriptor still described the previous session's lists, and the
+surviving `entryCount`s break the `FIRST_PID` argument in §9. `Xcp_Init` now calls `Xcp_DaqFreeAll`,
+which is precisely the operation it was missing.
+
+The entries themselves were *not* left populated, and an earlier version of this paragraph said
+they were. `Xcp_DaqListClearEntries` is bounded by `maxOdt` and each ODT's `entryCount`, so counts
+surviving is exactly the condition under which the clear covers every allocated entry — the old
+clear was correct, and correct *because* the counts still stood. The call is kept for the two
+reasons above, not for that one.
 
 Generator guards are tested by asserting generation fails, not by matching the message.
 

--- a/interface/Xcp_Types.h
+++ b/interface/Xcp_Types.h
@@ -385,7 +385,17 @@ typedef struct
     /**
      * @brief index number of this ODT within the DAQ list
      */
-    const uint8 odtNumber;
+    uint8 odtNumber;
+
+    /**
+     * @brief number of ODT entries allocated to this ODT.
+     * @details Under a STATIC configuration the generator seeds this with the DAQ list's
+     * max_odt_entries for every ODT, so it equals maxOdtEntries throughout. Under DYNAMIC it
+     * starts at zero and ALLOC_ODT_ENTRY raises it, which is what lets two ODTs of one list hold
+     * different numbers of entries.
+     * @note XCP part 2 - Protocol Layer Specification 1.1/1.6.4.3.1.4.
+     */
+    uint8 entryCount;
 
     /**
      * @brief this reference maps the ODT to the according DTO in which it will be transmitted
@@ -398,9 +408,17 @@ typedef struct
     Xcp_OdtEntryType *odtEntry;
 } Xcp_OdtType;
 
+/**
+ * @note The members below are not const because a DAQ_DYNAMIC configuration assigns them at
+ * runtime from ALLOC_DAQ, ALLOC_ODT and ALLOC_ODT_ENTRY (1.1/1.6.4.3.1). A struct definition
+ * cannot differ between builds without an #if here, which would give the CFFI test harness a
+ * second type to compile, so they are non-const in both. Flash placement is unaffected: it comes
+ * from the Xcp_START_SEC_CONST_UNSPECIFIED MemMap section the generator emits around these
+ * arrays, which a STATIC configuration keeps. Only the allocator writes them.
+ */
 typedef struct
 {
-    const uint16 number;
+    uint16 number;
 
     /**
      * @brief absolute ODT number of this DAQ list's first ODT.
@@ -408,10 +426,10 @@ typedef struct
      * START_STOP_DAQ_LIST. The absolute ODT number of ODT i is firstPid + i.
      * @note XCP part 2 - Protocol Layer Specification 1.1/1.6.4.1.1.4.
      */
-    const uint8 firstPid;
+    uint8 firstPid;
     const Xcp_EventChannelTypeType type;
-    const uint8 maxOdt;
-    const uint8 maxOdtEntries;
+    uint8 maxOdt;
+    uint8 maxOdtEntries;
     const Xcp_DtoType *dto;
     const uint32 dtoCount; /* TODO: check if this value can be retrieved from somewhere else... */
     Xcp_OdtType *odt;

--- a/script/source_cfg.c.jinja2
+++ b/script/source_cfg.c.jinja2
@@ -443,8 +443,19 @@ static const Xcp_SegmentType Xcp_SegmentConfig{{'%02X' % loop.index0}}[{{'0x%02X
         {%- if event.time_unit is not defined %}
 {{ raise('event channel {} has no time_unit configured'.format(event_index)) }}
         {%- endif %}
-        {%- if (not daq_dynamic) and event.triggered_daq_list_ref | length == 0 %}
-{{ raise('event channel {} has an empty triggered_daq_list_ref; a zero-length C array is not portable'.format(event_index)) }}
+        {#- One guard for both models, because the array below is sized from daq_list_ref_count in
+            both: a static configuration with an empty triggered_daq_list_ref and a dynamic one
+            with daq_count 0 emit the same zero-length Xcp_EventChannelDaqListRef. Scoping this to
+            `not daq_dynamic` left the dynamic half unguarded -- daq_count's schema minimum is 0,
+            and every channel references the whole pool, so daq_count 0 rendered exactly the array
+            this guard's own message says is not portable. Neither the schema's absent `minItems`
+            on triggered_daq_list_ref nor its `minimum: 0` on daq_count catches it.
+
+            The ODT and ODT-entry arrays are deliberately not covered here: `max_odt: 0` making
+            those zero-length is pre-existing tolerated behaviour, documented above
+            Xcp_OdtUsedBytes in source/Xcp_Daq.c. #}
+        {%- if daq_list_ref_count == 0 %}
+{{ raise('event channel {} would emit a zero-length Xcp_EventChannelDaqListRef, which is not portable C -- a GCC extension, an ISO C constraint violation, and rejected by MISRA and several embedded toolchains. Under DAQ_STATIC that means an empty triggered_daq_list_ref; under DAQ_DYNAMIC it means daq_count is 0, since every channel references the whole pool'.format(event_index)) }}
         {%- endif %}
         {%- for name in event.triggered_daq_list_ref | default([]) %}
         {%- if name not in daq_index_by_name %}

--- a/script/source_cfg.c.jinja2
+++ b/script/source_cfg.c.jinja2
@@ -75,6 +75,7 @@ static Xcp_OdtType Xcp_OdtConfig{{'%02X' % configuration_loop.index0}}Daq{{'%02X
     {
         {{'0x%02Xu' % odt_entry_size_daq}}, /* XcpOdtEntryMaxSize */
         {{'0x%02Xu' % i}}, /* XcpOdtNumber */
+        {{'0x%02Xu' % daq.max_odt_entries}}, /* entryCount */
         0x00u, /* XcpOdt2DtoMapping */
         &Xcp_OdtEntryConfig{{'%02X' % configuration_loop.index0}}Daq{{'%02X' % daq_loop.index0}}Odt{{'%02X' % i}}[0x00u] /* reference to XcpOdtEntry */
     },

--- a/script/source_cfg.c.jinja2
+++ b/script/source_cfg.c.jinja2
@@ -132,15 +132,23 @@ static Xcp_OdtEntryType Xcp_OdtEntryConfig{{'%02X' % configuration_loop.index0}}
         ODT wired to its own slice of the entry pool above.
 
         Xcp_START_SEC_VAR_FAST_POWER_ON_INIT_UNSPECIFIED rather than the static branch's
-        Xcp_START_SEC_CONST_UNSPECIFIED, and likewise for the DAQ lists further down: ALLOC_ODT and
-        ALLOC_ODT_ENTRY write odtNumber and entryCount at runtime (XCP part 2 1.1/1.6.4.3.1). The
-        section is what places these arrays, not the `const` keyword they already lack -- see the
-        note above Xcp_DaqListType in interface/Xcp_Types.h -- so leaving them here would put them
-        in flash and make every allocation a write to read-only memory.
+        Xcp_START_SEC_CONST_UNSPECIFIED, and likewise for the DAQ lists further down:
+        ALLOC_ODT_ENTRY writes entryCount here, and ALLOC_ODT writes maxOdt and firstPid in the DAQ
+        list descriptors below, at runtime (XCP part 2 1.1/1.6.4.3.1). The section is what places
+        these arrays, not the `const` keyword they already lack -- see the note above
+        Xcp_DaqListType in interface/Xcp_Types.h -- so leaving them here would put them in flash
+        and make every allocation a write to read-only memory.
 
-        odtNumber and entryCount start at zero, not at their index and the entry cap: an ODT the
-        master has not allocated holds nothing, and entryCount is exactly what ALLOC_ODT_ENTRY
-        raises. odtEntryMaxSize is a build-time property of MAX_DTO, so it is seeded here. #}
+        entryCount starts at zero rather than at the entry cap: an ODT the master has not allocated
+        holds nothing, and entryCount is exactly what ALLOC_ODT_ENTRY raises. odtEntryMaxSize is a
+        build-time property of MAX_DTO, so it is seeded here.
+
+        odtNumber is zero here where the static branch seeds it with the ODT's index, and that
+        difference costs nothing: nothing in source/ or interface/ ever reads Xcp_OdtType.odtNumber
+        -- the sampler and the DAQ pointer both carry an ODT number of their own (the `odtNumber`
+        parameters in source/Xcp_DaqRuntime.c and Xcp_Internal.daq_pointer.odtNumber are locals,
+        not this field). It is left as the dead descriptive field it is in both branches rather
+        than being given a runtime meaning no allocation command implements. #}
     {%- if daq_dynamic %}
         {%- set pool = configuration.daq_dynamic %}
 #define Xcp_START_SEC_VAR_FAST_POWER_ON_INIT_UNSPECIFIED
@@ -304,15 +312,22 @@ static const Xcp_DtoType Xcp_DtoConfig{{'%02X' % configuration_loop.index0}}Daq{
 
 /* The DAQ list pool. Every descriptor starts empty and ALLOC_DAQ, ALLOC_ODT and ALLOC_ODT_ENTRY
  * fill it in place (XCP part 2 1.1/1.6.4.3.1), which is why this array is in a writable section
- * and why number, FIRST_PID and MAX_ODT are zero rather than derived: a list nobody has allocated
- * owns no ODTs, so it fails the bounds checks that already exist without any new check being
- * added for it. MAX_ODT_ENTRIES is the rectangle's width, the cap the allocator may never exceed.
- * FIRST_PID is assigned at allocation time, not here, because it is a prefix sum over the ODT
- * counts the master chooses. */
+ * and why FIRST_PID and MAX_ODT are zero rather than derived: a list nobody has allocated owns no
+ * ODTs, so it fails the bounds checks that already exist without any new check being added for it.
+ * MAX_ODT_ENTRIES is the rectangle's width, the cap the allocator may never exceed. FIRST_PID is
+ * assigned at allocation time, not here, because it is a prefix sum over the ODT counts the master
+ * chooses.
+ *
+ * XcpDaqListNumber is the exception: it is the slot's own index, seeded here exactly as the static
+ * branch below seeds it, and no allocation command writes it. It is an identity, not a resource --
+ * ALLOC_DAQ hands out the first N slots of this pool in order (source/Xcp_Daq.c), so slot i is
+ * always list number i whether or not it has been handed out. Zeroing it made every slot claim to
+ * be list 0, and Xcp_DTOCmdStdTransportLayerCmd's GET_DAQ_ID scan (source/Xcp_Std.c) matches on
+ * this field: it answered ERR_OUT_OF_RANGE for every allocated list but the first. */
 static Xcp_DaqListType Xcp_DaqListConfig{{'%02X' % loop.index0}}[{{'0x%02Xu' % pool.daq_count}}] = {
     {%- for i in range(pool.daq_count) %}
     {
-        0x0000u, /* XcpDaqListNumber, assigned by ALLOC_DAQ */
+        {{'0x%04Xu' % i}}, /* XcpDaqListNumber */
         0x00u, /* FIRST_PID, assigned by ALLOC_ODT */
         DAQ, /* XcpDaqListType */
         0x00u, /* XcpMaxOdt, raised by ALLOC_ODT */

--- a/script/source_cfg.c.jinja2
+++ b/script/source_cfg.c.jinja2
@@ -6,6 +6,33 @@
     Xcp_EventChannelConsistencyType in interface/Xcp_Types.h for why the enumerator it maps to is
     named DAQ_LIST and appended rather than spelled DAQ and inserted. #}
 {%- set event_channel_consistency = {'ODT': 'ODT', 'EVENT': 'EVENT', 'DAQ': 'DAQ_LIST'} %}
+{#- The DAQ_STATIC/DAQ_DYNAMIC coherence guards. They sit here, ahead of every emission block,
+    because they are about whether the configuration says one thing or two contradictory ones --
+    there is no point half-generating a file from a configuration that cannot mean anything. The
+    two range guards this feature adds are not here: daq_count's uint8 ceiling lives beside the
+    identical ceiling on triggered_daq_list_ref near Xcp_GeneralConfig, because both protect the
+    same field of the same response byte from the two configuration models.
+
+    `raise(...)` is not a registered Jinja global here or at any other call site in this file --
+    see the comment above the FIRST_PID guard further down for what that means, and why these
+    messages are written for whoever is reading this template rather than for the caller. #}
+{%- for configuration in configurations %}
+    {%- set daq_dynamic = configuration.protocol_layer.daq_config_type | default('STATIC') == 'DYNAMIC' %}
+    {%- for name in ['xcp_free_daq_api_enable', 'xcp_alloc_daq_api_enable', 'xcp_alloc_odt_api_enable', 'xcp_alloc_odt_entry_api_enable'] %}
+        {%- if configuration.apis[name].enabled and not daq_dynamic %}
+{{ raise('{} is enabled but daq_config_type is STATIC; FREE_DAQ, ALLOC_DAQ, ALLOC_ODT and ALLOC_ODT_ENTRY exist to build DAQ lists at runtime (XCP part 2 1.1/1.6.4.3.1), and a static configuration generates its lists from `daqs` instead, leaving the four commands nothing to act on'.format(name)) }}
+        {%- endif %}
+        {%- if daq_dynamic and not configuration.apis[name].enabled %}
+{{ raise('{} is disabled but daq_config_type is DYNAMIC; that is a dynamic configuration with no way to allocate, because the pool generated below starts empty and these four commands are the only thing that fills it (XCP part 2 1.1/1.6.4.3.1)'.format(name)) }}
+        {%- endif %}
+    {%- endfor %}
+    {%- if daq_dynamic and (configuration.daqs | default([]) | length) > 0 %}
+{{ raise('daq_config_type is DYNAMIC but {} DAQ list(s) are declared under `daqs`; a dynamic configuration declares the pool the master allocates out of, not the lists themselves, so these would be generated nowhere and silently ignored'.format(configuration.daqs|length)) }}
+    {%- endif %}
+    {%- if not daq_dynamic and configuration.daq_dynamic is defined %}
+{{ raise('a `daq_dynamic` pool is configured but daq_config_type is STATIC; nothing would ever allocate out of that pool, so its dimensions would silently go nowhere -- set daq_config_type to DYNAMIC, or remove the block') }}
+    {%- endif %}
+{%- endfor %}
 {% for configuration in configurations %}
 #ifndef {{configuration.communication.channel_rx_pdu_ref}}
 #warning {{configuration.communication.channel_rx_pdu_ref}} not defined, assigning 0x0001u as default value. This definition should be passed trough the build system ({{configuration.communication.channel_rx_pdu_ref}}=0xXXXX).
@@ -20,7 +47,7 @@
 {% set default_pdu_mapping = namespace(value=3) %}
 {%- for configuration in configurations %}
     {%- set configuration_loop = loop %}
-    {%- for daq in configuration.daqs %}
+    {%- for daq in configuration.daqs | default([]) %}
         {%- if daq.pdu_mapping is string %}
 #ifndef {{daq.pdu_mapping}}
 #warning {{daq.pdu_mapping}} not defined, assigning {{'0x%04Xu' % default_pdu_mapping.value}} as default value. This definition should be passed trough the build system ({{daq.pdu_mapping}}=0xXXXX).
@@ -29,10 +56,45 @@
             {%- set default_pdu_mapping.value = default_pdu_mapping.value + 1 %}
         {%- endif %}
     {%- endfor %}
+    {#- The one pdu_mapping every list in a dynamic pool transmits on, given the same fallback
+        treatment as a static list's: the name is a build-system definition either way. #}
+    {%- if configuration.daq_dynamic is defined and configuration.daq_dynamic.pdu_mapping is string %}
+#ifndef {{configuration.daq_dynamic.pdu_mapping}}
+#warning {{configuration.daq_dynamic.pdu_mapping}} not defined, assigning {{'0x%04Xu' % default_pdu_mapping.value}} as default value. This definition should be passed trough the build system ({{configuration.daq_dynamic.pdu_mapping}}=0xXXXX).
+#define {{configuration.daq_dynamic.pdu_mapping}} ({{'0x%04Xu' % default_pdu_mapping.value}})
+#endif /* #ifndef {{configuration.daq_dynamic.pdu_mapping}} */
+        {%- set default_pdu_mapping.value = default_pdu_mapping.value + 1 %}
+    {%- endif %}
 {%- endfor %}
 {%- for configuration in configurations %}
     {%- set configuration_loop = loop %}
-    {%- for daq in configuration.daqs %}
+    {%- set daq_dynamic = configuration.protocol_layer.daq_config_type | default('STATIC') == 'DYNAMIC' %}
+    {#- The dynamic pool's ODT entries, as ONE flat array sliced by the ODT array below rather than
+        one array per (list, ODT) the way the static branch emits them. AUTOSAR's dynamic capacity
+        model is rectangular -- daq_count x odt_count x odt_entries_count, ECUC_Xcp_00012/54/59 --
+        so every slice is the same width and its offset is arithmetic, whereas the static branch
+        has a differently shaped list to name at every level.
+
+        Emitted one element per line rather than in the static branch's field-per-line form: the
+        rectangle is reserved in full, so a default pool is already 512 entries, and the verbose
+        form would be several thousand lines of identical zeroes. The field order is the one the
+        static branch spells out immediately below. #}
+    {%- if daq_dynamic %}
+        {%- set pool = configuration.daq_dynamic %}
+#define Xcp_START_SEC_VAR_FAST_POWER_ON_INIT_UNSPECIFIED
+#include "Xcp_MemMap.h"
+
+/* {XcpOdtEntryAddress, XcpOdtEntryBitOffset, XcpOdtEntryAddressExtension, XcpOdtEntryLength, XcpOdtEntryNumber} */
+static Xcp_OdtEntryType Xcp_OdtEntryConfig{{'%02X' % configuration_loop.index0}}[{{'0x%02Xu' % (pool.daq_count * pool.odt_count * pool.odt_entries_count)}}] = {
+        {%- for entry_index in range(pool.daq_count * pool.odt_count * pool.odt_entries_count) %}
+    {NULL_PTR, 0x00u, 0x00u, 0x00u, {{'0x%02Xu' % (entry_index % pool.odt_entries_count)}}},
+        {%- endfor %}
+};
+
+#define Xcp_STOP_SEC_VAR_FAST_POWER_ON_INIT_UNSPECIFIED
+#include "Xcp_MemMap.h"
+    {% endif %}
+    {%- for daq in configuration.daqs | default([]) %}
         {%- set daq_loop = loop %}
         {%- for i in range(daq.max_odt) %}
 #define Xcp_START_SEC_VAR_FAST_POWER_ON_INIT_UNSPECIFIED
@@ -65,7 +127,36 @@ static Xcp_OdtEntryType Xcp_OdtEntryConfig{{'%02X' % configuration_loop.index0}}
     {%- set identification_field_size = {'ABSOLUTE': 1, 'RELATIVE_BYTE': 2, 'RELATIVE_WORD': 3, 'RELATIVE_WORD_ALIGNED': 4} %}
     {%- set identification_field_type = configuration.protocol_layer.identification_field_type | default('ABSOLUTE') %}
     {%- set odt_entry_size_daq = configuration.protocol_layer.max_dto - identification_field_size[identification_field_type] %}
-    {%- for daq in configuration.daqs %}
+    {%- set daq_dynamic = configuration.protocol_layer.daq_config_type | default('STATIC') == 'DYNAMIC' %}
+    {#- The dynamic pool's ODTs: one flat array, list i owning [i*odt_count, (i+1)*odt_count), each
+        ODT wired to its own slice of the entry pool above.
+
+        Xcp_START_SEC_VAR_FAST_POWER_ON_INIT_UNSPECIFIED rather than the static branch's
+        Xcp_START_SEC_CONST_UNSPECIFIED, and likewise for the DAQ lists further down: ALLOC_ODT and
+        ALLOC_ODT_ENTRY write odtNumber and entryCount at runtime (XCP part 2 1.1/1.6.4.3.1). The
+        section is what places these arrays, not the `const` keyword they already lack -- see the
+        note above Xcp_DaqListType in interface/Xcp_Types.h -- so leaving them here would put them
+        in flash and make every allocation a write to read-only memory.
+
+        odtNumber and entryCount start at zero, not at their index and the entry cap: an ODT the
+        master has not allocated holds nothing, and entryCount is exactly what ALLOC_ODT_ENTRY
+        raises. odtEntryMaxSize is a build-time property of MAX_DTO, so it is seeded here. #}
+    {%- if daq_dynamic %}
+        {%- set pool = configuration.daq_dynamic %}
+#define Xcp_START_SEC_VAR_FAST_POWER_ON_INIT_UNSPECIFIED
+#include "Xcp_MemMap.h"
+
+/* {XcpOdtEntryMaxSize, XcpOdtNumber, entryCount, XcpOdt2DtoMapping, reference to XcpOdtEntry} */
+static Xcp_OdtType Xcp_OdtConfig{{'%02X' % configuration_loop.index0}}[{{'0x%02Xu' % (pool.daq_count * pool.odt_count)}}] = {
+        {%- for odt_index in range(pool.daq_count * pool.odt_count) %}
+    {{ '{' }}{{'0x%02Xu' % odt_entry_size_daq}}, 0x00u, 0x00u, NULL_PTR, &Xcp_OdtEntryConfig{{'%02X' % configuration_loop.index0}}[{{'0x%02Xu' % (odt_index * pool.odt_entries_count)}}]},
+        {%- endfor %}
+};
+
+#define Xcp_STOP_SEC_VAR_FAST_POWER_ON_INIT_UNSPECIFIED
+#include "Xcp_MemMap.h"
+    {% endif %}
+    {%- for daq in configuration.daqs | default([]) %}
         {%- set daq_loop = loop %}
 #define Xcp_START_SEC_CONST_UNSPECIFIED
 #include "Xcp_MemMap.h"
@@ -112,7 +203,29 @@ static const Xcp_TxPduType Xcp_CommunicationChannelTxPduConfig{{'%02X' % loop.in
 {% endfor %}
 {%- for configuration in configurations %}
     {%- set configuration_loop = loop %}
-    {%- for daq in configuration.daqs %}
+    {%- set daq_dynamic = configuration.protocol_layer.daq_config_type | default('STATIC') == 'DYNAMIC' %}
+    {#- One DTO for the whole dynamic pool, not one per list. The master chooses which lists it
+        allocates, never which PDU they leave on: a dynamic configuration names a single
+        pdu_mapping, so every list in the pool shares this element and Xcp_DaqListTxPduIsExclusive
+        (source/Xcp_Daq.c) correctly sees them all as sharing one transmit PDU. It stays in the
+        const section: nothing writes a DTO, only the descriptors that point at it. #}
+    {%- if daq_dynamic %}
+#define Xcp_START_SEC_CONST_UNSPECIFIED
+#include "Xcp_MemMap.h"
+
+static const Xcp_DtoType Xcp_DtoConfig{{'%02X' % configuration_loop.index0}}[0x01u] = {
+    {
+        {
+            {{configuration.daq_dynamic.pdu_mapping}}, /* XcpDto2PduMapping */
+            NULL_PTR
+        }
+    },
+};
+
+#define Xcp_STOP_SEC_CONST_UNSPECIFIED
+#include "Xcp_MemMap.h"
+    {% endif %}
+    {%- for daq in configuration.daqs | default([]) %}
 #define Xcp_START_SEC_CONST_UNSPECIFIED
 #include "Xcp_MemMap.h"
 
@@ -136,9 +249,10 @@ static const Xcp_DtoType Xcp_DtoConfig{{'%02X' % configuration_loop.index0}}Daq{
     {#- FIRST_PID is derived, not configured: absolute ODT numbers must be contiguous and unique
         across every DAQ list, so first_pids[i] is the running sum of the preceding lists' max_odt
         (XCP part 2 1.1/1.6.4.1.1.4). #}
+    {%- set daq_dynamic = configuration.protocol_layer.daq_config_type | default('STATIC') == 'DYNAMIC' %}
     {%- set first_pids = [] %}
     {%- set pid = namespace(next=0) %}
-    {%- for daq in configuration.daqs %}
+    {%- for daq in configuration.daqs | default([]) %}
     {%- if first_pids.append(pid.next) %}{% endif %}
     {%- set pid.next = pid.next + daq.max_odt %}
     {%- endfor %}
@@ -149,10 +263,14 @@ static const Xcp_DtoType Xcp_DtoConfig{{'%02X' % configuration_loop.index0}}Daq{
         generation stops. The string passed to raise(...) never reaches that exception, though, so
         read it as documentation for whoever is looking at this template, not as output the caller
         will ever see. #}
-    {%- if pid.next > 252 %}
+    {#- STATIC only. A dynamic configuration gets no generation-time PID guard (DD31): its ODTs
+        exist only once ALLOC_ODT has run, so the total that would have to be checked is not known
+        until runtime, and the pool's rectangle is an upper bound the master need never reach.
+        ALLOC_ODT enforces the same 0xFB ceiling itself, against what is actually allocated. #}
+    {%- if (not daq_dynamic) and pid.next > 252 %}
 {{ raise('{} ODTs across {} DAQ lists exceed the 0xFB PID ceiling of XCP part 2 1.1/1.1.4.1'.format(pid.next, configuration.daqs|length)) }}
     {%- endif %}
-    {%- for daq in configuration.daqs %}
+    {%- for daq in configuration.daqs | default([]) %}
         {%- set daq_index = loop.index0 %}
         {#- A pure STIM list is refused rather than generated. source/Xcp_Daq.c's
             Xcp_DTOCmdDaqGetDaqListInfo would answer DAQ_LIST_PROPERTIES with both type bits clear
@@ -179,6 +297,36 @@ static const Xcp_DtoType Xcp_DtoConfig{{'%02X' % configuration_loop.index0}}Daq{
         {%- endif %}
         {%- endfor %}
     {%- endfor %}
+{%- if daq_dynamic %}
+    {%- set pool = configuration.daq_dynamic %}
+#define Xcp_START_SEC_VAR_FAST_POWER_ON_INIT_UNSPECIFIED
+#include "Xcp_MemMap.h"
+
+/* The DAQ list pool. Every descriptor starts empty and ALLOC_DAQ, ALLOC_ODT and ALLOC_ODT_ENTRY
+ * fill it in place (XCP part 2 1.1/1.6.4.3.1), which is why this array is in a writable section
+ * and why number, FIRST_PID and MAX_ODT are zero rather than derived: a list nobody has allocated
+ * owns no ODTs, so it fails the bounds checks that already exist without any new check being
+ * added for it. MAX_ODT_ENTRIES is the rectangle's width, the cap the allocator may never exceed.
+ * FIRST_PID is assigned at allocation time, not here, because it is a prefix sum over the ODT
+ * counts the master chooses. */
+static Xcp_DaqListType Xcp_DaqListConfig{{'%02X' % loop.index0}}[{{'0x%02Xu' % pool.daq_count}}] = {
+    {%- for i in range(pool.daq_count) %}
+    {
+        0x0000u, /* XcpDaqListNumber, assigned by ALLOC_DAQ */
+        0x00u, /* FIRST_PID, assigned by ALLOC_ODT */
+        DAQ, /* XcpDaqListType */
+        0x00u, /* XcpMaxOdt, raised by ALLOC_ODT */
+        {{'0x%02Xu' % pool.odt_entries_count}}, /* XcpMaxOdtEntries */
+        &Xcp_DtoConfig{{'%02X' % configuration_loop.index0}}[0x00u], /* reference to XcpDto */
+        0x00000001u, /* not part of the specification... */
+        &Xcp_OdtConfig{{'%02X' % configuration_loop.index0}}[{{'0x%02Xu' % (i * pool.odt_count)}}] /* reference to XcpOdt */
+    },
+    {%- endfor %}
+};
+
+#define Xcp_STOP_SEC_VAR_FAST_POWER_ON_INIT_UNSPECIFIED
+#include "Xcp_MemMap.h"
+{%- else %}
 #define Xcp_START_SEC_CONST_UNSPECIFIED
 #include "Xcp_MemMap.h"
 
@@ -199,6 +347,7 @@ static Xcp_DaqListType Xcp_DaqListConfig{{'%02X' % loop.index0}}[{{'0x%02Xu' % c
 
 #define Xcp_STOP_SEC_CONST_UNSPECIFIED
 #include "Xcp_MemMap.h"
+{%- endif %}
 {% endfor %}
 #define Xcp_START_SEC_CONST_UNSPECIFIED
 #include "Xcp_MemMap.h"
@@ -272,8 +421,9 @@ static const Xcp_SegmentType Xcp_SegmentConfig{{'%02X' % loop.index0}}[{{'0x%02X
 {%- endfor %}
 {%- for configuration in configurations %}
     {%- set configuration_loop = loop %}
+    {%- set daq_dynamic = configuration.protocol_layer.daq_config_type | default('STATIC') == 'DYNAMIC' %}
     {%- set daq_index_by_name = {} %}
-    {%- for daq in configuration.daqs %}
+    {%- for daq in configuration.daqs | default([]) %}
         {%- if daq_index_by_name.update({daq.name: loop.index0}) %}{% endif %}
     {%- endfor %}
 #define Xcp_START_SEC_CONST_UNSPECIFIED
@@ -281,13 +431,22 @@ static const Xcp_SegmentType Xcp_SegmentConfig{{'%02X' % loop.index0}}[{{'0x%02X
 
     {%- for event in configuration.events %}
         {%- set event_index = loop.index0 %}
+        {#- Under DAQ_DYNAMIC every channel references the whole pool. Any list the master
+            allocates may be bound to any channel by SET_DAQ_LIST_MODE -- there is no configured
+            binding to narrow it -- so the pool size is the honest answer, and it is what
+            GET_DAQ_EVENT_INFO then reports as MAX_DAQ_LIST. maxDaqList and triggeredDaqListRefCount
+            come from this one expression in both models, which is the property
+            Xcp_DTOCmdDaqGetDaqEventInfo's own comment relies on when it reads the uint8 field
+            rather than casting the uint32 one. It is also what makes daq_count's uint8 ceiling a
+            real constraint rather than a theoretical one. #}
+        {%- set daq_list_ref_count = configuration.daq_dynamic.daq_count if daq_dynamic else event.triggered_daq_list_ref | length %}
         {%- if event.time_unit is not defined %}
 {{ raise('event channel {} has no time_unit configured'.format(event_index)) }}
         {%- endif %}
-        {%- if event.triggered_daq_list_ref | length == 0 %}
+        {%- if (not daq_dynamic) and event.triggered_daq_list_ref | length == 0 %}
 {{ raise('event channel {} has an empty triggered_daq_list_ref; a zero-length C array is not portable'.format(event_index)) }}
         {%- endif %}
-        {%- for name in event.triggered_daq_list_ref %}
+        {%- for name in event.triggered_daq_list_ref | default([]) %}
         {%- if name not in daq_index_by_name %}
 {{ raise('event channel {} references DAQ list "{}", which no configuration declares'.format(event_index, name)) }}
         {%- endif %}
@@ -299,10 +458,16 @@ static const Xcp_SegmentType Xcp_SegmentConfig{{'%02X' % loop.index0}}[{{'0x%02X
 {{ raise('event channel {} has consistency "{}", which maps to no Xcp_EventChannelConsistencyType enumerator; the schema permits {}'.format(event_index, event.consistency, event_channel_consistency.keys()|list|sort)) }}
         {%- endif %}
 
-static const Xcp_DaqListType * const Xcp_EventChannelDaqListRef{{'%02X' % configuration_loop.index0}}{{'%02X' % event_index}}[{{'0x%02Xu' % event.triggered_daq_list_ref|length}}] = {
-        {%- for name in event.triggered_daq_list_ref %}
+static const Xcp_DaqListType * const Xcp_EventChannelDaqListRef{{'%02X' % configuration_loop.index0}}{{'%02X' % event_index}}[{{'0x%02Xu' % daq_list_ref_count}}] = {
+        {%- if daq_dynamic %}
+            {%- for i in range(daq_list_ref_count) %}
+    &Xcp_DaqListConfig{{'%02X' % configuration_loop.index0}}[{{'0x%02Xu' % i}}],
+            {%- endfor %}
+        {%- else %}
+            {%- for name in event.triggered_daq_list_ref %}
     &Xcp_DaqListConfig{{'%02X' % configuration_loop.index0}}[{{'0x%02Xu' % daq_index_by_name[name]}}],
-        {%- endfor %}
+            {%- endfor %}
+        {%- endif %}
 };
         {%- if configuration.protocol_layer.publish_names | default(true) and event.name is defined %}
 
@@ -312,16 +477,17 @@ static const uint8 Xcp_EventChannelName{{'%02X' % configuration_loop.index0}}{{'
 
 static const Xcp_EventChannelType Xcp_EventChannelConfig{{'%02X' % configuration_loop.index0}}[{{'0x%02Xu' % configuration.events|length}}] = {
     {%- for event in configuration.events %}
+    {%- set daq_list_ref_count = configuration.daq_dynamic.daq_count if daq_dynamic else event.triggered_daq_list_ref | length %}
     {
         {{event_channel_consistency[event.consistency | default('ODT')]}}, /* XcpEventChannelConsistency */
-        {{'0x%02Xu' % event.triggered_daq_list_ref|length}}, /* XcpEventChannelMaxDaqList */
+        {{'0x%02Xu' % daq_list_ref_count}}, /* XcpEventChannelMaxDaqList */
         {{'0x%04Xu' % loop.index0}}, /* XcpEventChannelNumber */
         {{'0x%02Xu' % event.priority}}, /* XcpEventChannelPriority */
         {{'0x%02Xu' % event.time_cycle}}, /* XcpEventChannelTimeCycle */
         {{event.time_unit}}, /* XcpEventChannelTimeUnit */
         {{event.type}}, /* XcpEventChannelType */
         &Xcp_EventChannelDaqListRef{{'%02X' % configuration_loop.index0}}{{'%02X' % loop.index0}}[0x00u],
-        {{'0x%08Xu' % event.triggered_daq_list_ref|length}},
+        {{'0x%08Xu' % daq_list_ref_count}},
         {%- if configuration.protocol_layer.publish_names | default(true) and event.name is defined %}
         &Xcp_EventChannelName{{'%02X' % configuration_loop.index0}}{{'%02X' % loop.index0}}[0x00u],
         {{'0x%02Xu' % event.name|length}}
@@ -337,13 +503,23 @@ static const Xcp_EventChannelType Xcp_EventChannelConfig{{'%02X' % configuration
 #include "Xcp_MemMap.h"
 {%- endfor %}
 {% for configuration in configurations %}
+{%- set daq_dynamic = configuration.protocol_layer.daq_config_type | default('STATIC') == 'DYNAMIC' %}
 #define Xcp_START_SEC_CONST_UNSPECIFIED
 #include "Xcp_MemMap.h"
 
 static Xcp_ConfigType Xcp_ConfigConfig{{'%02X' % loop.index0}} = {
     &Xcp_CommunicationChannelConfig[{{'0x%02Xu' % loop.index0}}], /* reference to XcpCommunicationChannel */
     &Xcp_DaqListConfig{{'%02X' % loop.index0}}[0x00u], /* reference to XcpDaqList */
-    {{'%04Xu' % configuration.daqs | length}},
+    {#- daqListCount is the length of the array above, not the number of lists the master has
+        allocated, so under DAQ_DYNAMIC it is the whole pool.
+
+        '0x%04Xu', not the '%04Xu' this line carried before. Without the prefix the literal has a
+        leading zero, which makes it OCTAL: 0001u and 0002u happened to be the same value in octal
+        as in hex, which is why one and two DAQ lists never showed it, but 0008u is not a valid
+        octal constant at all and 0010u is octal 8 -- a build that silently reported half its DAQ
+        lists. A 255-list dynamic pool emitted 00FFu and failed to compile, which is what found
+        it. Every other value in this template already carries the prefix. #}
+    {{'0x%04Xu' % (configuration.daq_dynamic.daq_count if daq_dynamic else configuration.daqs | length)}},
     &Xcp_EventChannelConfig{{'%02X' % loop.index0}}[0x00u], /* reference to XcpEventChannel */
     NULL_PTR, /* reference to XcpPdu */
     &Xcp_SegmentConfig{{'%02X' % loop.index0}}[0x00u] /* reference to XcpSegment */
@@ -356,11 +532,7 @@ static Xcp_ConfigType Xcp_ConfigConfig{{'%02X' % loop.index0}} = {
 {%- set identification_field_size = {'ABSOLUTE': 1, 'RELATIVE_BYTE': 2, 'RELATIVE_WORD': 3, 'RELATIVE_WORD_ALIGNED': 4} %}
 {%- set identification_field_type = configuration.protocol_layer.identification_field_type | default('ABSOLUTE') %}
 {%- set odt_entry_size_daq = configuration.protocol_layer.max_dto - identification_field_size[identification_field_type] %}
-{%- set counters = namespace(odt=0, odt_entries=0) %}
-{%- for daq in configuration.daqs %}
-{%- set counters.odt = counters.odt + daq.max_odt %}
-{%- set counters.odt_entries = counters.odt_entries + (daq.max_odt * daq.max_odt_entries) %}
-{%- endfor %}
+{%- set daq_dynamic = configuration.protocol_layer.daq_config_type | default('STATIC') == 'DYNAMIC' %}
 {%- if odt_entry_size_daq < 1 %}
 {{ raise('MAX_DTO {} leaves no room for data after a {}-byte {} identification field'.format(configuration.protocol_layer.max_dto, identification_field_size[identification_field_type], identification_field_type)) }}
 {%- endif %}
@@ -378,16 +550,19 @@ static Xcp_ConfigType Xcp_ConfigConfig{{'%02X' % loop.index0}} = {
 {{ raise('MAX_DTO {} leaves {} bytes after a {}-byte {} identification field, less than the {}-byte timestamp XCP part 2 1.1/1.1.2.2 puts in ODT 0; the ODT-0 budget arithmetic in source/Xcp_Daq.c assumes odtEntrySizeDaq minus the timestamp size does not underflow'.format(configuration.protocol_layer.max_dto, odt_entry_size_daq, identification_field_size[identification_field_type], identification_field_type, wire_size)) }}
 {%- endif %}
 {%- endif %}
-{#- counters.odt is deliberately absent from this guard. It is the same sum as pid.next above, and
-    the PID-ceiling guard there refuses anything over 252 -- so by the time rendering reaches this
-    point counters.odt cannot exceed 252, and a `counters.odt > 255` condition here could never
-    fire. Reordering the two would only move which guard reports the same configuration; the
-    252 ceiling subsumes the 255 one outright, so XcpOdtCount's uint8 field is protected there
-    rather than here. Its two neighbours below have no such stricter guard upstream and are the
-    only live halves. #}
-{%- if counters.odt_entries > 255 %}
-{{ raise('odtEntriesCount {} exceeds the uint8 XcpOdtEntriesCount field of Xcp_GeneralType'.format(counters.odt_entries)) }}
-{%- endif %}
+{#- There is no aggregate odtEntriesCount guard here any more, and there never was a live
+    odtCount one. Both guarded a uint8 field of Xcp_GeneralType against a sum this template used
+    to emit into it -- the total ODTs across every DAQ list, and the grand total of entries. Those
+    sums are not what AUTOSAR means by XcpOdtCount (ECUC_Xcp_00054, the ODTs *of a DAQ list*) or
+    XcpOdtEntriesCount (ECUC_Xcp_00059, the entries *into an ODT*), and it defines both only for
+    DAQ_DYNAMIC, so a static configuration now emits 0x00u into each and there is nothing left to
+    truncate. Keeping the guard would have gone on refusing a perfectly ordinary static
+    configuration -- three lists of a hundred entries -- to protect a field that is always zero.
+
+    Under DAQ_DYNAMIC the two fields do carry a real value, and both fit their uint8 field by
+    construction: config/xcp.schema.json caps odt_count at 252 and odt_entries_count at 255.
+    daq_count is the one dimension whose schema range (0..65535) is wider than the field that
+    reports it, which is what the guard immediately below exists for. #}
 {#- odtEntrySizeDaq is emitted below as '0x%02Xu', into the uint8 XcpOdtEntrySizeDaq field, but it
     is derived from max_dto, whose schema maximum is 65535. Without this guard max_dto 1000 emitted
     0x3E7u -- 231 after truncation -- so GET_DAQ_RESOLUTION_INFO reported MAX_ODT_ENTRY_SIZE_DAQ 231
@@ -396,8 +571,15 @@ static Xcp_ConfigType Xcp_ConfigConfig{{'%02X' % loop.index0}} = {
 {%- if odt_entry_size_daq > 255 %}
 {{ raise('MAX_DTO {} leaves {} bytes after a {}-byte {} identification field, which exceeds the uint8 XcpOdtEntrySizeDaq field of Xcp_GeneralType; MAX_ODT_ENTRY_SIZE_DAQ is one byte in the GET_DAQ_RESOLUTION_INFO response (XCP part 2 1.1/1.6.4.1.2.5), so a larger value cannot be reported and would be emitted here as a truncated literal'.format(configuration.protocol_layer.max_dto, odt_entry_size_daq, identification_field_size[identification_field_type], identification_field_type)) }}
 {%- endif %}
+{#- The same uint8 maxDaqList ceiling, from the two configuration models. A static configuration
+    reports the length of each channel's configured triggered_daq_list_ref; a dynamic one has no
+    configured binding to report, so every channel names the whole pool and MAX_DAQ_LIST is
+    daq_count -- see the comment beside Xcp_EventChannelDaqListRef above. #}
+{%- if daq_dynamic and configuration.daq_dynamic.daq_count > 255 %}
+{{ raise('daq_count {} exceeds the uint8 maxDaqList field of Xcp_EventChannelType; GET_DAQ_EVENT_INFO transmits MAX_DAQ_LIST as one byte (XCP part 2 1.1/1.6.4.1.2.7), and a DAQ_DYNAMIC configuration reports daq_count there because any allocated list may bind to any event channel'.format(configuration.daq_dynamic.daq_count)) }}
+{%- endif %}
 {%- for event in configuration.events %}
-{%- if event.triggered_daq_list_ref|length > 255 %}
+{%- if (not daq_dynamic) and event.triggered_daq_list_ref|length > 255 %}
 {{ raise('event channel {} references {} DAQ lists, which exceeds the uint8 maxDaqList field of Xcp_EventChannelType; GET_DAQ_EVENT_INFO transmits MAX_DAQ_LIST as one byte (XCP part 2 1.1/1.6.4.1.2.7), so a larger count cannot be reported and would be emitted here as a truncated literal'.format(loop.index0, event.triggered_daq_list_ref|length)) }}
 {%- endif %}
 {%- endfor %}
@@ -408,8 +590,8 @@ static Xcp_ConfigType Xcp_ConfigConfig{{'%02X' % loop.index0}} = {
 #include "Xcp_MemMap.h"
 
 static Xcp_GeneralType Xcp_GeneralConfig{{'%02X' % loop.index0}} = {
-    DAQ_STATIC, /* XcpDaqConfigType; dynamic configuration arrives in SP2c */
-    {{'0x%04Xu' % configuration.daqs|length}}, /* XcpDaqCount */
+    {% if daq_dynamic %}DAQ_DYNAMIC{% else %}DAQ_STATIC{% endif %}, /* XcpDaqConfigType */
+    {{'0x%04Xu' % (configuration.daq_dynamic.daq_count if daq_dynamic else configuration.daqs|length)}}, /* XcpDaqCount */
     TRUE, /* hard-coded XcpDevErrorDetect */
     FALSE, /* hard-coded XcpFlashProgrammingEnabled */
     {{identification_field_type}}, /* XcpIdentificationFieldType */
@@ -418,8 +600,14 @@ static Xcp_GeneralType Xcp_GeneralConfig{{'%02X' % loop.index0}} = {
     {{'0x%04Xu' % configuration.protocol_layer.max_dto}}, /* XcpMaxDto */
     {{'0x%04Xu' % configuration.events|length}}, /* XcpMaxEventChannel */
     0x00u, /* XcpMinDaq; no DAQ list is PREDEFINED */
-    {{'0x%02Xu' % counters.odt}}, /* XcpOdtCount */
-    {{'0x%02Xu' % counters.odt_entries}}, /* XcpOdtEntriesCount */
+    {#- ECUC_Xcp_00054 and ECUC_Xcp_00059, defined by AUTOSAR only for DAQ_DYNAMIC: the ODTs of a
+        DAQ list, and the entries into an ODT. A static configuration's per-list caps live on each
+        Xcp_DaqListType instead, so there is nothing for these two to say and they stay at zero.
+        This template used to emit the aggregate sums here -- the total ODTs across every list, and
+        the grand total of entries -- which is neither field's meaning; no .c file read either one,
+        so correcting them changes no behaviour. #}
+    {{'0x%02Xu' % (configuration.daq_dynamic.odt_count if daq_dynamic else 0)}}, /* XcpOdtCount */
+    {{'0x%02Xu' % (configuration.daq_dynamic.odt_entries_count if daq_dynamic else 0)}}, /* XcpOdtEntriesCount */
     {{'0x%02Xu' % odt_entry_size_daq}}, /* XcpOdtEntrySizeDaq */
     0x00u, /* XcpOdtEntrySizeStim; STIM arrives in SP3 */
     TRUE, /* hard-coded XcpOnCanEnabled */

--- a/script/source_rt.c.jinja2
+++ b/script/source_rt.c.jinja2
@@ -37,7 +37,14 @@ static Xcp_SegmentRtType Xcp_SegmentRt{{'%02X' % loop.index0}}[{{'0x%02Xu' % ((c
 #define Xcp_START_SEC_VAR_FAST_POWER_ON_INIT_UNSPECIFIED
 #include "Xcp_MemMap.h"
 
-static Xcp_DaqListRtType Xcp_DaqListRt{{'%02X' % loop.index0}}[{{'0x%02Xu' % configuration.daqs|length}}];
+{#- One runtime record per DAQ list the configuration can present, which under DAQ_DYNAMIC is the
+   whole pool rather than the lists declared under `daqs` -- there are none. Xcp_Init and
+   Xcp_TriggerEventChannel both index this array by daqCount (source/Xcp.c, source/Xcp_DaqRuntime.c),
+   and daqCount is the pool size under DAQ_DYNAMIC, so anything smaller is read out of bounds
+   before the master has allocated a thing. #}
+{%- set daq_dynamic = configuration.protocol_layer.daq_config_type | default('STATIC') == 'DYNAMIC' %}
+
+static Xcp_DaqListRtType Xcp_DaqListRt{{'%02X' % loop.index0}}[{{'0x%02Xu' % (configuration.daq_dynamic.daq_count if daq_dynamic else configuration.daqs|length)}}];
 
 /* XCP_MAX_DTO reaches this module as a compile definition, so a mismatch between it and the
  * value this runtime was generated for would silently change the stride of the array below.

--- a/source/Xcp.c
+++ b/source/Xcp.c
@@ -341,7 +341,7 @@ static uint8 (* const Xcp_PIDTable[0x100u])(boolean *responseExpected, const Pdu
     Xcp_CmdNotImplemented, /* 0xD1 */
     Xcp_CmdNotImplemented, /* 0xD2 */
     Xcp_CmdNotImplemented, /* 0xD3, optional */
-    Xcp_CmdNotImplemented, /* 0xD4, optional */
+    Xcp_DTOCmdDaqAllocOdt, /* ALLOC_ODT 0xD4, optional */
     Xcp_DTOCmdDaqAllocDaq, /* ALLOC_DAQ 0xD5, optional */
     Xcp_DTOCmdDaqFreeDaq, /* FREE_DAQ 0xD6, optional */
     Xcp_DTOCmdDaqGetDaqEventInfo, /* GET_DAQ_EVENT_INFO 0xD7, optional */

--- a/source/Xcp.c
+++ b/source/Xcp.c
@@ -342,7 +342,7 @@ static uint8 (* const Xcp_PIDTable[0x100u])(boolean *responseExpected, const Pdu
     Xcp_CmdNotImplemented, /* 0xD2 */
     Xcp_CmdNotImplemented, /* 0xD3, optional */
     Xcp_CmdNotImplemented, /* 0xD4, optional */
-    Xcp_CmdNotImplemented, /* 0xD5, optional */
+    Xcp_DTOCmdDaqAllocDaq, /* ALLOC_DAQ 0xD5, optional */
     Xcp_DTOCmdDaqFreeDaq, /* FREE_DAQ 0xD6, optional */
     Xcp_DTOCmdDaqGetDaqEventInfo, /* GET_DAQ_EVENT_INFO 0xD7, optional */
     Xcp_DTOCmdDaqGetDaqListInfo, /* GET_DAQ_LIST_INFO 0xD8, optional */

--- a/source/Xcp.c
+++ b/source/Xcp.c
@@ -343,7 +343,7 @@ static uint8 (* const Xcp_PIDTable[0x100u])(boolean *responseExpected, const Pdu
     Xcp_CmdNotImplemented, /* 0xD3, optional */
     Xcp_CmdNotImplemented, /* 0xD4, optional */
     Xcp_CmdNotImplemented, /* 0xD5, optional */
-    Xcp_CmdNotImplemented, /* 0xD6, optional */
+    Xcp_DTOCmdDaqFreeDaq, /* FREE_DAQ 0xD6, optional */
     Xcp_DTOCmdDaqGetDaqEventInfo, /* GET_DAQ_EVENT_INFO 0xD7, optional */
     Xcp_DTOCmdDaqGetDaqListInfo, /* GET_DAQ_LIST_INFO 0xD8, optional */
     Xcp_DTOCmdDaqGetDaqResolutionInfo, /* GET_DAQ_RESOLUTION_INFO 0xD9, optional */

--- a/source/Xcp.c
+++ b/source/Xcp.c
@@ -340,7 +340,7 @@ static uint8 (* const Xcp_PIDTable[0x100u])(boolean *responseExpected, const Pdu
     Xcp_CmdNotImplemented, /* 0xD0 */
     Xcp_CmdNotImplemented, /* 0xD1 */
     Xcp_CmdNotImplemented, /* 0xD2 */
-    Xcp_CmdNotImplemented, /* 0xD3, optional */
+    Xcp_DTOCmdDaqAllocOdtEntry, /* ALLOC_ODT_ENTRY 0xD3, optional */
     Xcp_DTOCmdDaqAllocOdt, /* ALLOC_ODT 0xD4, optional */
     Xcp_DTOCmdDaqAllocDaq, /* ALLOC_DAQ 0xD5, optional */
     Xcp_DTOCmdDaqFreeDaq, /* FREE_DAQ 0xD6, optional */

--- a/source/Xcp.c
+++ b/source/Xcp.c
@@ -1143,12 +1143,22 @@ void Xcp_Init(const Xcp_Type *pConfig)
              * generated DAQ list descriptor and ODT entry arrays are module-level mutable statics
              * with no initialisation of their own, and under DYNAMIC maxOdt/firstPid/entryCount
              * ARE the allocation. The loop that used to stand here reset Xcp_DaqListRt and called
-             * Xcp_DaqListClearEntries, but left those three untouched -- so a re-initialised
-             * module set allocated_daq_count to 0 and daq_alloc_state to FREE, reporting nothing
-             * allocated, while the descriptor still described the previous session's lists. The
-             * two halves of the allocation state disagreed, and the clear itself missed the
-             * entries of any list whose maxOdt it had not reset, since Xcp_DaqListClearEntries is
-             * bounded by exactly the counts that were being left behind.
+             * Xcp_DaqListClearEntries, but left those three untouched. Two things follow, and
+             * only these two:
+             *
+             *   - A re-initialised module set allocated_daq_count to 0 and daq_alloc_state to
+             *     FREE, reporting nothing allocated, while the descriptor still described the
+             *     previous session's lists. The two halves of the allocation state disagreed,
+             *     and the previous session's shape leaked into the next one.
+             *   - The surviving entryCounts break the argument that a running list's FIRST_PID
+             *     cannot move (see Xcp_DaqRecomputeFirstPids and design §9): that argument needs
+             *     initialisation to zero them.
+             *
+             * What did NOT follow is that the entries themselves were left populated.
+             * Xcp_DaqListClearEntries is bounded by maxOdt and each ODT's entryCount, so counts
+             * surviving is exactly the condition under which it covers every allocated entry --
+             * the clear was correct, and it was correct BECAUSE the counts were still standing.
+             * An earlier version of this comment had that backwards; do not reason from it.
              *
              * Ordering: allocated_daq_count is assigned above, before this call. Xcp_DaqFreeAll
              * lowers it to zero only under DYNAMIC, which is what that assignment already says

--- a/source/Xcp.c
+++ b/source/Xcp.c
@@ -1107,6 +1107,10 @@ void Xcp_Init(const Xcp_Type *pConfig)
             Xcp_Internal.connect_mode = XCP_CONNECT_MODE_NORMAL;
             Xcp_Internal.connection_status = XCP_CONNECTION_STATE_DISCONNECTED;
             Xcp_Internal.session_status = 0x00u;
+            Xcp_Internal.daq_alloc_state = XCP_DAQ_ALLOC_FREE;
+            Xcp_Internal.allocated_daq_count =
+                    (Xcp_Ptr->general->daqConfigType == DAQ_DYNAMIC) ? 0x0000u
+                                                                     : Xcp_Ptr->general->daqCount;
             Xcp_Internal.protection_status = 0x00u;
             Xcp_Internal.requested_protected_resource = 0x00u;
             Xcp_Internal.last_pid = 0x00u;

--- a/source/Xcp.c
+++ b/source/Xcp.c
@@ -1133,20 +1133,27 @@ void Xcp_Init(const Xcp_Type *pConfig)
             for (idx = 0x00000000u; idx < Xcp_Ptr->general->maxSegment; idx ++) {
                 Xcp_Rt[Xcp_Ptr->xcpRtRef].segment[idx].freeze = FALSE;
             }
-            for (idx = 0x00u; idx < Xcp_Ptr->general->daqCount; idx++)
-            {
-                Xcp_Rt[Xcp_Ptr->xcpRtRef].daqList[idx].eventChannelNumber = 0x0000u;
-                Xcp_Rt[Xcp_Ptr->xcpRtRef].daqList[idx].mode = 0x00u;
-                /* 1.1/1.6.4.1.1.3: "Without reduction, the prescaler value must equal 1." */
-                Xcp_Rt[Xcp_Ptr->xcpRtRef].daqList[idx].prescaler = 0x01u;
-                Xcp_Rt[Xcp_Ptr->xcpRtRef].daqList[idx].prescalerCounter = 0x00u;
-                Xcp_Rt[Xcp_Ptr->xcpRtRef].daqList[idx].priority = 0x00u;
-                /* The generated ODT entry arrays are module-level mutable statics with no
-                 * initialisation of their own; reset them here too, or a re-initialised module
-                 * inherits a previous session's DAQ configuration. See
-                 * Xcp_DaqListClearEntries's own doc comment (Xcp_Daq.c). */
-                Xcp_DaqListClearEntries((uint16)idx);
-            }
+            /* Initialisation establishes exactly the invariant FREE_DAQ does, so it runs the same
+             * unwind rather than a second, slightly different copy of it: every DAQ list stopped,
+             * every ODT entry cleared, the prescaler back to 1 (1.1/1.6.4.1.1.3), and -- under
+             * DYNAMIC -- the descriptor's own maxOdt, firstPid and per-ODT entryCount back to
+             * zero.
+             *
+             * That last part is why this is a call and not the open-coded loop it replaces. The
+             * generated DAQ list descriptor and ODT entry arrays are module-level mutable statics
+             * with no initialisation of their own, and under DYNAMIC maxOdt/firstPid/entryCount
+             * ARE the allocation. The loop that used to stand here reset Xcp_DaqListRt and called
+             * Xcp_DaqListClearEntries, but left those three untouched -- so a re-initialised
+             * module set allocated_daq_count to 0 and daq_alloc_state to FREE, reporting nothing
+             * allocated, while the descriptor still described the previous session's lists. The
+             * two halves of the allocation state disagreed, and the clear itself missed the
+             * entries of any list whose maxOdt it had not reset, since Xcp_DaqListClearEntries is
+             * bounded by exactly the counts that were being left behind.
+             *
+             * Ordering: allocated_daq_count is assigned above, before this call. Xcp_DaqFreeAll
+             * lowers it to zero only under DYNAMIC, which is what that assignment already says
+             * there, and leaves the STATIC value (daqCount) alone. */
+            Xcp_DaqFreeAll();
 
             Xcp_Rt[Xcp_Ptr->xcpRtRef].dtoQueue->read = 0x00u;
             Xcp_Rt[Xcp_Ptr->xcpRtRef].dtoQueue->write = 0x00u;

--- a/source/Xcp_Daq.c
+++ b/source/Xcp_Daq.c
@@ -74,6 +74,36 @@ void Xcp_DaqListClearEntries(uint16 daqListNumber)
 }
 
 /**
+ * @brief returns one DAQ list's runtime state to its power-up values.
+ * @details XCP part 2 - Protocol Layer Specification 1.1/1.6.4.2.1.1 for CLEAR_DAQ_LIST and
+ * 1.1/1.6.4.3.1.1 for FREE_DAQ: both stop transmission on the list and reset its state. The
+ * prescaler returns to 1, not 0 -- 1.1/1.6.4.1.1.3, "Without reduction, the prescaler value must
+ * equal 1", and a zero prescaler would mean Xcp_TriggerEventChannel's `prescalerCounter >=
+ * prescaler` never fails, i.e. every trigger elapses, not none. Xcp_Init resets the same five
+ * fields to the same five values.
+ * @note the entries are cleared BEFORE any caller zeroes the counts that describe them:
+ * Xcp_DaqListClearEntries is bounded by this list's own maxOdt and per-ODT entryCount, so a
+ * caller that zeroed those first would leave the entries themselves untouched. Xcp_Init has
+ * exactly that shape in the other direction and is why a dynamic pool's entries are stale after
+ * a re-initialisation that follows an allocation -- there maxOdt is already zero when the clear
+ * runs. Xcp_DaqFreeAll below therefore clears first and zeroes second.
+ * @note the caller invalidates the DAQ pointer if it names this list, and calls
+ * Xcp_DaqSessionStatusUpdate once it has reset every list it intends to -- DAQ_RUNNING is a
+ * property of every list together (1.1/1.6.1.1.3), so recomputing it per list would be wrong for
+ * a caller resetting more than one.
+ */
+static void Xcp_DaqListReset(uint16 daqListNumber)
+{
+    Xcp_DaqListClearEntries(daqListNumber);
+
+    Xcp_DaqListRt(daqListNumber)->mode = 0x00u;
+    Xcp_DaqListRt(daqListNumber)->eventChannelNumber = 0x0000u;
+    Xcp_DaqListRt(daqListNumber)->prescaler = 0x01u;
+    Xcp_DaqListRt(daqListNumber)->prescalerCounter = 0x00u;
+    Xcp_DaqListRt(daqListNumber)->priority = 0x00u;
+}
+
+/**
  * @brief TRUE when no other DAQ list transmits through this list's TX PDU.
  * @details XCP part 2 - Protocol Layer Specification 1.1/1.1.2.1 makes the transport layer
  * responsible for identifying a DTO once PID_OFF removes the identification field, and gives the
@@ -328,6 +358,76 @@ static void Xcp_DaqSessionStatusUpdate(void)
     }
 }
 
+/**
+ * @brief returns every DAQ list, and the dynamic allocation state with it, to power-up values.
+ * @details The body of FREE_DAQ (1.1/1.6.4.3.1.1), factored out because DISCONNECT needs exactly
+ * the same unwind -- see this function's declaration in Xcp_Internal.h for why, and
+ * Xcp_CTOCmdStdDisconnect (source/Xcp_Std.c) for the other call site.
+ */
+void Xcp_DaqFreeAll(void)
+{
+    uint16 daq_idx;
+
+    /* XCP part 2 - Protocol Layer Specification 1.1/1.6.4.3.1.1: "This command clears all DAQ
+     * lists and frees all dynamically allocated DAQ lists, ODTs and ODT entries."
+     *
+     * DD30. The unwind order is the reverse of allocation and is not stylistic.
+     * Xcp_TriggerEventChannel (source/Xcp_DaqRuntime.c) runs in interrupt context and reaches
+     * entry storage by walking maxOdt, then each ODT's entryCount, so a count must never outlive
+     * the storage it describes -- the DD14 failure class. Stopping the lists first means no new
+     * sampling begins; clearing the entries while the counts still describe them means nothing is
+     * left behind (Xcp_DaqListReset's own note); zeroing the counts last means a trigger
+     * interleaved at any later point sees zero and samples nothing, rather than a stale count into
+     * released storage. Xcp_DaqListClearEntries, called through Xcp_DaqListReset, takes the DAQ
+     * exclusive area for the entry writes themselves, and the count writes below take it too.
+     *
+     * The loops are bounded by the configured pool, Xcp_Ptr->general->daqCount, rather than by
+     * Xcp_Internal.allocated_daq_count. That is the range Xcp_TriggerEventChannel itself walks
+     * (and Xcp_DaqSessionStatusUpdate above with it), so it is the range that has to be left safe
+     * against the sampler; bounding by the allocated count instead would, if the two ever
+     * disagreed, leave a list with a non-zero maxOdt standing while this function reported having
+     * freed everything. Under STATIC the two bounds are equal by construction (Xcp_Init), and
+     * under DYNAMIC every list above the allocated count already holds a zeroed descriptor, so
+     * the wider bound costs a few no-op writes and can never do less than the narrower one. */
+    for (daq_idx = 0x0000u; daq_idx < Xcp_Ptr->general->daqCount; daq_idx++)
+    {
+        Xcp_DaqListReset(daq_idx);
+    }
+
+    if (Xcp_Ptr->general->daqConfigType == DAQ_DYNAMIC)
+    {
+        for (daq_idx = 0x0000u; daq_idx < Xcp_Ptr->general->daqCount; daq_idx++)
+        {
+            uint8_least odt_idx;
+
+            SchM_Enter_Xcp_DtoQueue();
+
+            for (odt_idx = 0x00u; odt_idx < Xcp_Ptr->config->daqList[daq_idx].maxOdt; odt_idx++)
+            {
+                Xcp_Ptr->config->daqList[daq_idx].odt[odt_idx].entryCount = 0x00u;
+            }
+
+            Xcp_Ptr->config->daqList[daq_idx].maxOdt = 0x00u;
+            /* DD31: firstPid is a prefix sum over the lists' ODT counts, so zeroing every count
+             * makes every prefix sum zero. Recomputing it would produce the same answer; writing
+             * it here keeps the descriptor consistent without a second pass. */
+            Xcp_Ptr->config->daqList[daq_idx].firstPid = 0x00u;
+
+            SchM_Exit_Xcp_DtoQueue();
+        }
+
+        Xcp_Internal.allocated_daq_count = 0x0000u;
+    }
+
+    /* The resets above may have stopped the only running list, so DAQ_RUNNING (1.1/1.6.1.1.3)
+     * needs recomputing across every list rather than per list. */
+    Xcp_DaqSessionStatusUpdate();
+
+    /* The pointer names an ODT entry that no longer exists. */
+    Xcp_Internal.daq_pointer.valid = FALSE;
+    Xcp_Internal.daq_alloc_state = XCP_DAQ_ALLOC_FREE;
+}
+
 /*------------------------------------------------------------------------------------------------*/
 /* command handler definitions.                                                                  */
 /*------------------------------------------------------------------------------------------------*/
@@ -579,17 +679,17 @@ uint8 Xcp_DTOCmdDaqClearDaqList(boolean *responseExpected, const PduInfoType *pP
     {
         /* XCP part 2 - Protocol Layer Specification 1.1/1.6.4.2.1.1
          * "For a configurable DAQ list, all ODT entries will be reset to address=0, extension=0
-         * and size=0 (if valid : bit_offset = 0xFF)." */
-        Xcp_DaqListClearEntries(daq_list_number);
-
-        /* "For PREDEFINED and configurable DAQ lists, the running Data Transmission on this list
+         * and size=0 (if valid : bit_offset = 0xFF)."
+         *
+         * "For PREDEFINED and configurable DAQ lists, the running Data Transmission on this list
          * will be stopped and all DAQ list states are reset." The command is therefore legal
-         * while the list runs -- see defect D10 against the error matrix. */
-        Xcp_DaqListRt(daq_list_number)->mode = 0x00u;
-        Xcp_DaqListRt(daq_list_number)->eventChannelNumber = 0x0000u;
-        Xcp_DaqListRt(daq_list_number)->prescaler = 0x01u;
-        Xcp_DaqListRt(daq_list_number)->prescalerCounter = 0x00u;
-        Xcp_DaqListRt(daq_list_number)->priority = 0x00u;
+         * while the list runs -- see defect D10 against the error matrix.
+         *
+         * Both halves are Xcp_DaqListReset, shared with FREE_DAQ (1.1/1.6.4.3.1.1), which resets
+         * every list the same way. The two commands stay distinct in what they do around it:
+         * CLEAR_DAQ_LIST resets one list and keeps its allocation, FREE_DAQ resets all of them
+         * and releases the allocation as well. */
+        Xcp_DaqListReset(daq_list_number);
 
         /* The mode reset above may have just stopped the only list that was running, so
          * DAQ_RUNNING (1.1/1.6.1.1.3) needs recomputing across every list, not just this one. */
@@ -614,6 +714,26 @@ uint8 Xcp_DTOCmdDaqClearDaqList(boolean *responseExpected, const PduInfoType *pP
     {
         Xcp_FillErrorPacket(error, &Xcp_Internal.cto_response.pdu_info);
     }
+
+    return E_OK;
+}
+
+uint8 Xcp_DTOCmdDaqFreeDaq(boolean *responseExpected, const PduInfoType *pPduInfo)
+{
+    (void)pPduInfo;
+
+    *responseExpected = TRUE;
+
+    /* The request carries no argument, so there is nothing to validate and nothing to refuse.
+     * DD29: Xcp_CTOErrorMatrix (source/Xcp.c) gives 0xD6 only CMD_BUSY, PGM_ACTIVE, CMD_UNKNOWN
+     * and CMD_SYNTAX -- ERR_DAQ_ACTIVE is absent, so refusing a running slave is not authorised.
+     * FREE_DAQ therefore stops every running list rather than refusing, which Xcp_DaqFreeAll does.
+     * DD28 gives FREE_DAQ "any" as its accepted-from state, so there is no ERR_SEQUENCE either. */
+    Xcp_DaqFreeAll();
+
+    Xcp_Internal.cto_response.pdu_info.SduDataPtr[0x00u] = XCP_PID_RESPONSE;
+
+    Xcp_FinalizeResPacket(0x01u, &Xcp_Internal.cto_response.pdu_info);
 
     return E_OK;
 }

--- a/source/Xcp_Daq.c
+++ b/source/Xcp_Daq.c
@@ -722,6 +722,51 @@ uint8 Xcp_DTOCmdDaqClearDaqList(boolean *responseExpected, const PduInfoType *pP
     return E_OK;
 }
 
+uint8 Xcp_DTOCmdDaqAllocDaq(boolean *responseExpected, const PduInfoType *pPduInfo)
+{
+    uint16 daq_count;
+    uint8 error = 0x00u;
+
+    *responseExpected = TRUE;
+
+    Xcp_CopyToU16WithOrder(&pPduInfo->SduDataPtr[0x02u], &daq_count, Xcp_Ptr->general->byteOrder);
+
+    /* XCP part 2 - Protocol Layer Specification 1.1/1.6.4.3.1.2: ERR_SEQUENCE for an ALLOC_DAQ
+     * directly after an ALLOC_ODT or an ALLOC_ODT_ENTRY without a FREE_DAQ in between. Sequence is
+     * checked before the argument, because it is a statement about the command stream rather than
+     * about this command's parameters. */
+    if ((Xcp_Internal.daq_alloc_state != XCP_DAQ_ALLOC_FREE) &&
+        (Xcp_Internal.daq_alloc_state != XCP_DAQ_ALLOC_DAQ))
+    {
+        error = XCP_E_ASAM_SEQUENCE;
+    }
+    else if ((uint32)((uint32)Xcp_Internal.allocated_daq_count + (uint32)daq_count) >
+             (uint32)Xcp_Ptr->general->daqCount)
+    {
+        /* "If there's not enough memory available to allocate the requested DAQ lists an
+         * ERR_MEMORY_OVERFLOW will be returned." Rejected whole: a partly applied allocation
+         * would leave the master unaware of how much it actually has. */
+        error = XCP_E_ASAM_MEMORY_OVERFLOW;
+    }
+    else
+    {
+        Xcp_Internal.allocated_daq_count = (uint16)(Xcp_Internal.allocated_daq_count + daq_count);
+        Xcp_Internal.daq_alloc_state = XCP_DAQ_ALLOC_DAQ;
+    }
+
+    if (error == 0x00u)
+    {
+        Xcp_Internal.cto_response.pdu_info.SduDataPtr[0x00u] = XCP_PID_RESPONSE;
+        Xcp_FinalizeResPacket(0x01u, &Xcp_Internal.cto_response.pdu_info);
+    }
+    else
+    {
+        Xcp_FillErrorPacket(error, &Xcp_Internal.cto_response.pdu_info);
+    }
+
+    return E_OK;
+}
+
 uint8 Xcp_DTOCmdDaqFreeDaq(boolean *responseExpected, const PduInfoType *pPduInfo)
 {
     (void)pPduInfo;

--- a/source/Xcp_Daq.c
+++ b/source/Xcp_Daq.c
@@ -17,7 +17,7 @@
 
 static boolean Xcp_DaqListIsValid(uint16 daqListNumber)
 {
-    return (boolean)((daqListNumber < Xcp_Ptr->general->daqCount) ? TRUE : FALSE);
+    return (boolean)((daqListNumber < Xcp_Internal.allocated_daq_count) ? TRUE : FALSE);
 }
 
 static Xcp_DaqListRtType *Xcp_DaqListRt(uint16 daqListNumber)

--- a/source/Xcp_Daq.c
+++ b/source/Xcp_Daq.c
@@ -388,7 +388,11 @@ void Xcp_DaqFreeAll(void)
      * disagreed, leave a list with a non-zero maxOdt standing while this function reported having
      * freed everything. Under STATIC the two bounds are equal by construction (Xcp_Init), and
      * under DYNAMIC every list above the allocated count already holds a zeroed descriptor, so
-     * the wider bound costs a few no-op writes and can never do less than the narrower one. */
+     * the wider bound costs a few no-op writes and can never do less than the narrower one.
+     *
+     * Do not narrow this to allocated_daq_count. The no-op writes are what it looks like it
+     * buys, and they are not the point: the point is that the sampler's bound and this function's
+     * bound are the same number, so no list the sampler can reach is outside what this releases. */
     for (daq_idx = 0x0000u; daq_idx < Xcp_Ptr->general->daqCount; daq_idx++)
     {
         Xcp_DaqListReset(daq_idx);

--- a/source/Xcp_Daq.c
+++ b/source/Xcp_Daq.c
@@ -29,8 +29,9 @@ static Xcp_DaqListRtType *Xcp_DaqListRt(uint16 daqListNumber)
  * @brief resets every ODT entry of one DAQ list to its power-up state.
  * @details XCP part 2 - Protocol Layer Specification 1.1/1.6.4.2.1.1: "For a configurable DAQ
  * list, all ODT entries will be reset to address=0, extension=0 and size=0 (if valid :
- * bit_offset = 0xFF)." Bounded by daqListNumber's own maxOdt/maxOdtEntries, not any other list's,
- * so clearing one list never touches another's entries.
+ * bit_offset = 0xFF)." Bounded by daqListNumber's own maxOdt and, within each ODT, that ODT's own
+ * entryCount -- not maxOdtEntries, which is the slice's width rather than what is in it, and not
+ * any other list's counts, so clearing one list never touches another's entries.
  * @note Despite living beside this file's other file-local helpers, this one has external
  * linkage and a declaration in Xcp_Internal.h: Xcp_Init (source/Xcp.c) calls it too. The
  * generated ODT entry arrays are module-level mutable statics (script/source_cfg.c.jinja2 emits
@@ -42,10 +43,10 @@ static Xcp_DaqListRtType *Xcp_DaqListRt(uint16 daqListNumber)
  * CanIf's receive context while the sampler walks the same array from a task or an interrupt --
  * including the sampler's own interrupt preempting a clear already in progress at task level, the
  * direction a lock taken only on the read side cannot help with. The inner loop below is wrapped
- * per ODT, not once for the whole nest, so each critical section is bounded by maxOdtEntries field
- * writes rather than maxOdt * maxOdtEntries: neither Xcp_Init (source/Xcp.c) nor
- * Xcp_DTOCmdDaqClearDaqList, this function's only callers, hold the area themselves, so nesting
- * across ODTs is not a concern either way.
+ * per ODT, not once for the whole nest, so each critical section is bounded by that ODT's
+ * entryCount field writes rather than by the sum of them over maxOdt: neither Xcp_Init
+ * (source/Xcp.c) nor Xcp_DTOCmdDaqClearDaqList, this function's only callers, hold the area
+ * themselves, so nesting across ODTs is not a concern either way.
  */
 void Xcp_DaqListClearEntries(uint16 daqListNumber)
 {
@@ -83,10 +84,9 @@ void Xcp_DaqListClearEntries(uint16 daqListNumber)
  * fields to the same five values.
  * @note the entries are cleared BEFORE any caller zeroes the counts that describe them:
  * Xcp_DaqListClearEntries is bounded by this list's own maxOdt and per-ODT entryCount, so a
- * caller that zeroed those first would leave the entries themselves untouched. Xcp_Init has
- * exactly that shape in the other direction and is why a dynamic pool's entries are stale after
- * a re-initialisation that follows an allocation -- there maxOdt is already zero when the clear
- * runs. Xcp_DaqFreeAll below therefore clears first and zeroes second.
+ * caller that zeroed those first would leave the entries themselves untouched. Xcp_DaqFreeAll
+ * below therefore clears first and zeroes second, and Xcp_Init reaches this through that same
+ * function for the same reason.
  * @note the caller invalidates the DAQ pointer if it names this list, and calls
  * Xcp_DaqSessionStatusUpdate once it has reset every list it intends to -- DAQ_RUNNING is a
  * property of every list together (1.1/1.6.1.1.3), so recomputing it per list would be wrong for
@@ -374,12 +374,18 @@ void Xcp_DaqFreeAll(void)
      * DD30. The unwind order is the reverse of allocation and is not stylistic.
      * Xcp_TriggerEventChannel (source/Xcp_DaqRuntime.c) runs in interrupt context and reaches
      * entry storage by walking maxOdt, then each ODT's entryCount, so a count must never outlive
-     * the storage it describes -- the DD14 failure class. Stopping the lists first means no new
-     * sampling begins; clearing the entries while the counts still describe them means nothing is
-     * left behind (Xcp_DaqListReset's own note); zeroing the counts last means a trigger
-     * interleaved at any later point sees zero and samples nothing, rather than a stale count into
-     * released storage. Xcp_DaqListClearEntries, called through Xcp_DaqListReset, takes the DAQ
-     * exclusive area for the entry writes themselves, and the count writes below take it too.
+     * the storage it describes -- the DD14 failure class.
+     *
+     * The actual order, per list, is: entries cleared, then the list stopped (both inside
+     * Xcp_DaqListReset, in that order -- it calls Xcp_DaqListClearEntries before it writes
+     * mode = 0), then, in the second loop below, the counts zeroed. Clearing before stopping is
+     * not an oversight and is not the other way round: Xcp_DaqListClearEntries is bounded by
+     * maxOdt and each ODT's entryCount, so it must run while those counts still describe the
+     * storage, and a trigger interleaved between the clear and the stop finds entries whose
+     * length is already 0 and samples nothing from them. Zeroing the counts last means a trigger
+     * interleaved at any point after that sees zero and walks nothing at all, rather than a stale
+     * count into released storage. Xcp_DaqListClearEntries takes the DAQ exclusive area for the
+     * entry writes themselves, and the count writes below take it too.
      *
      * The loops are bounded by the configured pool, Xcp_Ptr->general->daqCount, rather than by
      * Xcp_Internal.allocated_daq_count. That is the range Xcp_TriggerEventChannel itself walks
@@ -746,8 +752,18 @@ uint8 Xcp_DTOCmdDaqClearDaqList(boolean *responseExpected, const PduInfoType *pP
  *
  * @note `next` is a uint8, matching the field, and cannot wrap: Xcp_DTOCmdDaqAllocOdt refuses any
  * request that would take the total past XCP_DAQ_ABSOLUTE_ODT_COUNT_MAX (0xFC), so the sum this
- * accumulates is at most 0xFC and every value written is at most 0xFB. The check is what makes
+ * accumulates is at most 0xFC and every value written is at most 0xFC. The check is what makes
  * the arithmetic here safe, not the other way round.
+ *
+ * 0xFC, not 0xFB: the bound on a *usable* absolute ODT number is 0xFB, because 0xFC..0xFF are the
+ * slave-to-master SERV, EV, ERR and RES codes, but a firstPid of exactly 0xFC is reachable and is
+ * written. With the total at 252 and an allocated-but-empty list after the full one, that list's
+ * prefix sum is 0xFC -- the state test_alloc_odt_refuses_to_exhaust_the_pid_space creates. It is
+ * harmless because it is the address of a first ODT that does not exist: that list's maxOdt is 0,
+ * so Xcp_TriggerEventChannel's ODT loop never runs for it and no frame can carry the value. It is
+ * still observable, in the FIRST_PID byte START_STOP_DAQ_LIST mode STOP returns for that list,
+ * which correctly names where its first ODT *would* begin. A master that then allocated an ODT
+ * there would be refused by the same 0xFC ceiling before the number could ever reach the wire.
  */
 static void Xcp_DaqRecomputeFirstPids(void)
 {
@@ -924,13 +940,22 @@ uint8 Xcp_DTOCmdDaqAllocOdt(boolean *responseExpected, const PduInfoType *pPduIn
     }
     else
     {
-        /* Both writes under one exclusive area, because the sampler reads them together:
-         * Xcp_TriggerEventChannel walks maxOdt and Xcp_DaqWriteIdentificationField
-         * (source/Xcp_DaqRuntime.c) computes an ABSOLUTE field's PID as firstPid + ODT number, so
-         * a trigger interleaved between the two would transmit a frame whose PID belongs to the
-         * layout that is being replaced. This is the DD14 failure class, and the reason the
-         * recompute is inside the area rather than after it -- raising maxOdt is what makes the
-         * standing firstPid values wrong.
+        /* Both writes under one exclusive area, because a trigger interleaved between them would
+         * transmit a frame whose PID belongs to the layout being replaced: Xcp_TriggerEventChannel
+         * walks maxOdt and Xcp_DaqWriteIdentificationField (source/Xcp_DaqRuntime.c) computes an
+         * ABSOLUTE field's PID as firstPid + ODT number. This is the DD14 failure class, and the
+         * reason the recompute is inside the area rather than after it -- raising maxOdt is what
+         * makes the standing firstPid values wrong.
+         *
+         * The mechanism is interrupt suppression, not mutual exclusion, and the difference matters
+         * for anyone reasoning about it: the sampler does NOT take this area around its own reads.
+         * Xcp_TriggerEventChannel reads maxOdt and Xcp_DaqWriteIdentificationField reads firstPid
+         * with no area held (Xcp_DaqSampleOdt takes it only around the ODT-entry copy, DD14). What
+         * protects the pair is that the sampler runs in an interrupt this area suppresses on a
+         * target, so it cannot land between the two writes at all. On the test harness, where
+         * SchM_Enter_Xcp_DtoQueue suppresses nothing, an injected trigger inside the held area is
+         * a preemption the target cannot have -- which is why test/free_daq_test.py sweeps its
+         * interleavings from SchM_Exit's side effect rather than SchM_Enter's.
          *
          * Raised, not assigned: DD28 makes a repeat naming the same list accumulate. Rejected
          * whole above, never in part -- a partly applied allocation would leave the master
@@ -1070,8 +1095,9 @@ uint8 Xcp_DTOCmdDaqSetDaqListMode(boolean *responseExpected, const PduInfoType *
      * Diagram 10), so enabling it shrinks that ODT's budget below the MAX_ODT_ENTRY_SIZE_DAQ that
      * GET_DAQ_RESOLUTION_INFO reports and WRITE_DAQ enforced when the entries were written. An ODT
      * 0 already filled past the reduced budget cannot carry one. 0xFFu as excludedEntry excludes
-     * nothing -- every configured slot is counted; no real index can equal it because the loop in
-     * Xcp_OdtUsedBytes bounds idx strictly below maxOdtEntries, itself a uint8.
+     * nothing -- every allocated slot is counted; no real index can equal it because the loop in
+     * Xcp_OdtUsedBytes bounds idx strictly below that ODT's entryCount, itself a uint8, so the
+     * largest index it ever reaches is 0xFE.
      *
      * maxOdt first, and short-circuited: a list configured with max_odt 0 has no ODT 0 at all, and
      * its generated Xcp_OdtType array is zero-length, so passing 0x00u to Xcp_OdtUsedBytes reads

--- a/source/Xcp_Daq.c
+++ b/source/Xcp_Daq.c
@@ -1548,12 +1548,16 @@ uint8 Xcp_DTOCmdDaqGetDaqProcessorInfo(boolean *responseExpected, const PduInfoT
 
     *responseExpected = TRUE;
 
-    /* XCP part 2 - Protocol Layer Specification 1.1/1.6.4.1.2.4
-     * DAQ_CONFIG_TYPE stays clear: this phase configures DAQ lists statically. RESUME and
-     * BIT_STIM are unimplemented and so are reported unsupported, which is what lets
-     * SET_DAQ_LIST_MODE refuse the matching mode bits. TIMESTAMP_SUPPORTED and PID_OFF_SUPPORTED
-     * are not in that group: TIMESTAMP_SUPPORTED follows whether the configuration declares a
-     * clock, set just below; PID_OFF_SUPPORTED follows the identification field type, set here. */
+    /* XCP part 2 - Protocol Layer Specification 1.1/1.6.4.1.2.4. DAQ_CONFIG_TYPE now follows the
+     * configuration: a DAQ_DYNAMIC build lets the master allocate lists through 1.1/1.6.4.3.1,
+     * where a DAQ_STATIC build serves the lists the generator declared. RESUME and BIT_STIM
+     * remain unimplemented and so remain reported unsupported, which is what lets
+     * SET_DAQ_LIST_MODE refuse the matching mode bits. */
+    if (Xcp_Ptr->general->daqConfigType == DAQ_DYNAMIC)
+    {
+        properties |= XCP_DAQ_PROPERTIES_DAQ_CONFIG_TYPE;
+    }
+
     if (Xcp_Ptr->general->prescalerSupported == TRUE)
     {
         properties |= XCP_DAQ_PROPERTIES_PRESCALER_SUPPORTED;

--- a/source/Xcp_Daq.c
+++ b/source/Xcp_Daq.c
@@ -790,6 +790,94 @@ static uint16 Xcp_DaqAllocatedOdtCount(void)
     return total;
 }
 
+/**
+ * @brief ALLOC_ODT_ENTRY, XCP part 2 - Protocol Layer Specification 1.1/1.6.4.3.1.4.
+ * @details The refusals are ordered the same way Xcp_DTOCmdDaqAllocOdt's are: SEQUENCE, then
+ * OUT_OF_RANGE -- the list, then the ODT within it -- then MEMORY_OVERFLOW, each a narrower
+ * question than the one before.
+ *
+ * Unlike ALLOC_ODT and ALLOC_DAQ, there is no second, cross-list ceiling to check here: an ODT's
+ * entries live in that ODT's own slice of the pool (script/source_cfg.c.jinja2's
+ * Xcp_OdtEntryConfig, sliced odt_entries_count wide per ODT), so the one bound against
+ * Xcp_Ptr->general->odtEntriesCount -- read from the general configuration rather than from
+ * daqList[n].maxOdtEntries so the ceiling is stated once, even though DYNAMIC gives both the same
+ * value -- is everything there is to check.
+ * @note DD28: repeated calls naming the same ODT accumulate onto its entryCount rather than
+ * replacing it, for the same reason ALLOC_ODT and ALLOC_DAQ accumulate: the specification's
+ * ERR_SEQUENCE cases forbid ALLOC_ODT_ENTRY only after FREE and DAQ, so a repeat from ODT or
+ * ODT_ENTRY is permitted, and a permitted repeat that merely replaced the previous grant would be
+ * indistinguishable from one that was refused.
+ * @note the running sum is a uint16: entryCount and odt_entries_count are both uint8, and 255 +
+ * 255 would wrap a uint8 total back under most any ceiling worth checking against.
+ * @note DD34, and the closing step of the running-list FIRST_PID safety argument -- see this
+ * function's declaration in Xcp_Internal.h for the full chain.
+ */
+uint8 Xcp_DTOCmdDaqAllocOdtEntry(boolean *responseExpected, const PduInfoType *pPduInfo)
+{
+    const uint8 odt_number = pPduInfo->SduDataPtr[0x04u];
+    const uint8 odt_entries_count = pPduInfo->SduDataPtr[0x05u];
+    uint16 daq_list_number;
+    uint8 error = 0x00u;
+
+    *responseExpected = TRUE;
+
+    Xcp_CopyToU16WithOrder(&pPduInfo->SduDataPtr[0x02u], &daq_list_number, Xcp_Ptr->general->byteOrder);
+
+    if ((Xcp_Internal.daq_alloc_state != XCP_DAQ_ALLOC_ODT) &&
+        (Xcp_Internal.daq_alloc_state != XCP_DAQ_ALLOC_ODT_ENTRY))
+    {
+        /* ERR_SEQUENCE for an ALLOC_ODT_ENTRY that has had no ALLOC_ODT before it -- unlike
+         * ALLOC_ODT, a bare ALLOC_DAQ is not enough -- or that follows a FREE_DAQ with nothing
+         * reallocated since. */
+        error = XCP_E_ASAM_SEQUENCE;
+    }
+    else if (Xcp_DaqListIsValid(daq_list_number) == FALSE)
+    {
+        /* DD32: valid means allocated, not merely inside the configured pool. */
+        error = XCP_E_ASAM_OUT_OF_RANGE;
+    }
+    else if (odt_number >= Xcp_Ptr->config->daqList[daq_list_number].maxOdt)
+    {
+        /* Bounded against this list's own maxOdt, the same way Xcp_DaqListIsValid bounds the list
+         * number against allocated_daq_count just above: an ODT ALLOC_ODT has not handed this
+         * list is "not available" either. */
+        error = XCP_E_ASAM_OUT_OF_RANGE;
+    }
+    else if ((uint16)((uint16)Xcp_Ptr->config->daqList[daq_list_number].odt[odt_number].entryCount +
+                       (uint16)odt_entries_count) >
+             (uint16)Xcp_Ptr->general->odtEntriesCount)
+    {
+        error = XCP_E_ASAM_MEMORY_OVERFLOW;
+    }
+    else
+    {
+        /* Raised, not assigned: DD28 makes a repeat naming the same ODT accumulate. Rejected
+         * whole above, never in part -- a partly applied allocation would leave the master unaware
+         * of how much it actually has. */
+        SchM_Enter_Xcp_DtoQueue();
+
+        Xcp_Ptr->config->daqList[daq_list_number].odt[odt_number].entryCount =
+                (uint8)(Xcp_Ptr->config->daqList[daq_list_number].odt[odt_number].entryCount +
+                        odt_entries_count);
+
+        SchM_Exit_Xcp_DtoQueue();
+
+        Xcp_Internal.daq_alloc_state = XCP_DAQ_ALLOC_ODT_ENTRY;
+    }
+
+    if (error == 0x00u)
+    {
+        Xcp_Internal.cto_response.pdu_info.SduDataPtr[0x00u] = XCP_PID_RESPONSE;
+        Xcp_FinalizeResPacket(0x01u, &Xcp_Internal.cto_response.pdu_info);
+    }
+    else
+    {
+        Xcp_FillErrorPacket(error, &Xcp_Internal.cto_response.pdu_info);
+    }
+
+    return E_OK;
+}
+
 uint8 Xcp_DTOCmdDaqAllocOdt(boolean *responseExpected, const PduInfoType *pPduInfo)
 {
     const uint8 odt_count = pPduInfo->SduDataPtr[0x04u];

--- a/source/Xcp_Daq.c
+++ b/source/Xcp_Daq.c
@@ -57,7 +57,7 @@ void Xcp_DaqListClearEntries(uint16 daqListNumber)
         SchM_Enter_Xcp_DtoQueue();
 
         for (entry_idx = 0x00u;
-             entry_idx < Xcp_Ptr->config->daqList[daqListNumber].maxOdtEntries;
+             entry_idx < Xcp_Ptr->config->daqList[daqListNumber].odt[odt_idx].entryCount;
              entry_idx++)
         {
             Xcp_OdtEntryType *p_entry =
@@ -122,7 +122,7 @@ static uint8 Xcp_OdtUsedBytes(uint16 daqListNumber, uint8 odtNumber, uint8 exclu
     uint8 used = 0x00u;
     uint8_least idx;
 
-    for (idx = 0x00u; idx < Xcp_Ptr->config->daqList[daqListNumber].maxOdtEntries; idx++)
+    for (idx = 0x00u; idx < p_odt->entryCount; idx++)
     {
         if (idx != (uint8_least)excludedEntry)
         {
@@ -170,7 +170,8 @@ static uint8 Xcp_DaqOdtEntryBudget(uint16 daqListNumber, uint8 odtNumber)
 static void Xcp_DaqPointerAdvance(void)
 {
     if ((uint16)(Xcp_Internal.daq_pointer.odtEntryNumber + 0x01u) <
-        (uint16)Xcp_Ptr->config->daqList[Xcp_Internal.daq_pointer.daqListNumber].maxOdtEntries)
+        (uint16)Xcp_Ptr->config->daqList[Xcp_Internal.daq_pointer.daqListNumber]
+                .odt[Xcp_Internal.daq_pointer.odtNumber].entryCount)
     {
         Xcp_Internal.daq_pointer.odtEntryNumber++;
     }
@@ -285,7 +286,7 @@ static boolean Xcp_DaqListIsConfigured(uint16 daqListNumber)
     for (odt_idx = 0x00u; odt_idx < Xcp_Ptr->config->daqList[daqListNumber].maxOdt; odt_idx++)
     {
         for (entry_idx = 0x00u;
-             entry_idx < Xcp_Ptr->config->daqList[daqListNumber].maxOdtEntries;
+             entry_idx < Xcp_Ptr->config->daqList[daqListNumber].odt[odt_idx].entryCount;
              entry_idx++)
         {
             if (Xcp_Ptr->config->daqList[daqListNumber].odt[odt_idx].odtEntry[entry_idx].length != 0x00u)
@@ -366,7 +367,7 @@ uint8 Xcp_DTOCmdDaqSetDaqPtr(boolean *responseExpected, const PduInfoType *pPduI
     {
         error = XCP_E_ASAM_OUT_OF_RANGE;
     }
-    else if (odt_entry_number >= Xcp_Ptr->config->daqList[daq_list_number].maxOdtEntries)
+    else if (odt_entry_number >= Xcp_Ptr->config->daqList[daq_list_number].odt[odt_number].entryCount)
     {
         error = XCP_E_ASAM_OUT_OF_RANGE;
     }

--- a/source/Xcp_Daq.c
+++ b/source/Xcp_Daq.c
@@ -722,6 +722,157 @@ uint8 Xcp_DTOCmdDaqClearDaqList(boolean *responseExpected, const PduInfoType *pP
     return E_OK;
 }
 
+/**
+ * @brief reassigns every DAQ list's FIRST_PID as a prefix sum over the ODT counts.
+ * @details XCP part 2 - Protocol Layer Specification 1.1/1.6.4.1.1.4: the absolute ODT number of
+ * relative ODT i in a list is FIRST_PID + i, so each list's block must be contiguous and no two
+ * blocks may overlap. Assigning PIDs in ALLOC_ODT call order cannot hold that once a list may
+ * receive ODTs in more than one call, so the whole set is recomputed instead. This is the same
+ * rule script/source_cfg.c.jinja2 applies to a static configuration.
+ *
+ * Concretely, ALLOC_ODT(0, 2), ALLOC_ODT(1, 3), ALLOC_ODT(0, 1) is a legal sequence -- DD28 makes
+ * the third call accumulate -- and it leaves list 0 needing three contiguous numbers when a
+ * call-order scheme has already handed 2..4 to list 1. There is no way to repair that by
+ * appending; the assignment has to be a function of the counts alone, which is what a prefix sum
+ * over list index is. It is also order-independent, so the same set of requests in any order
+ * produces the same layout.
+ *
+ * Bounded by Xcp_Internal.allocated_daq_count rather than by the configured pool, and that is the
+ * narrower bound on purpose: a list the master has not allocated cannot have ODTs (ALLOC_ODT
+ * refuses it), so including it would add nothing to the running sum, while the numbers it would
+ * write past the allocated count are meaningless -- no command reports them and no DTO carries
+ * them. Xcp_DaqFreeAll zeroes firstPid across the whole pool, so nothing stale survives there
+ * either.
+ *
+ * @note `next` is a uint8, matching the field, and cannot wrap: Xcp_DTOCmdDaqAllocOdt refuses any
+ * request that would take the total past XCP_DAQ_ABSOLUTE_ODT_COUNT_MAX (0xFC), so the sum this
+ * accumulates is at most 0xFC and every value written is at most 0xFB. The check is what makes
+ * the arithmetic here safe, not the other way round.
+ */
+static void Xcp_DaqRecomputeFirstPids(void)
+{
+    uint16 daq_idx;
+    uint8 next = 0x00u;
+
+    for (daq_idx = 0x0000u; daq_idx < Xcp_Internal.allocated_daq_count; daq_idx++)
+    {
+        Xcp_Ptr->config->daqList[daq_idx].firstPid = next;
+        next = (uint8)(next + Xcp_Ptr->config->daqList[daq_idx].maxOdt);
+    }
+}
+
+/**
+ * @brief total ODTs currently allocated across every DAQ list the master holds.
+ * @details The quantity XCP_DAQ_ABSOLUTE_ODT_COUNT_MAX bounds, and the same sum
+ * Xcp_DaqRecomputeFirstPids ends on.
+ * @note uint16, not the uint8 the ODT counts themselves live in, so that neither this total nor
+ * the caller's total-plus-ODT_COUNT is ever narrowed back to eight bits. That narrowing is a
+ * reachable defect, not a theoretical one: a pool whose odtCount is 252 admits a second request
+ * for 252 on a list holding none, and 252 + 252 is 248 in a uint8 -- under the very ceiling it is
+ * being compared against, so the check would pass exactly the request it exists to refuse.
+ * test/alloc_odt_test.py::test_alloc_odt_ceiling_holds_where_a_uint8_total_would_wrap pins that.
+ *
+ * The type that matters is the one the sum is stored or cast to, not this return type on its own:
+ * C's integer promotions widen both operands of the caller's addition to int, so a uint8 return
+ * value alone would still compute 504 correctly there. Spelling both uint16 is what keeps the
+ * result from depending on that, and on nobody later adding a cast back.
+ */
+static uint16 Xcp_DaqAllocatedOdtCount(void)
+{
+    uint16 daq_idx;
+    uint16 total = 0x0000u;
+
+    for (daq_idx = 0x0000u; daq_idx < Xcp_Internal.allocated_daq_count; daq_idx++)
+    {
+        total = (uint16)(total + (uint16)Xcp_Ptr->config->daqList[daq_idx].maxOdt);
+    }
+
+    return total;
+}
+
+uint8 Xcp_DTOCmdDaqAllocOdt(boolean *responseExpected, const PduInfoType *pPduInfo)
+{
+    const uint8 odt_count = pPduInfo->SduDataPtr[0x04u];
+    uint16 daq_list_number;
+    uint8 error = 0x00u;
+
+    *responseExpected = TRUE;
+
+    Xcp_CopyToU16WithOrder(&pPduInfo->SduDataPtr[0x02u], &daq_list_number, Xcp_Ptr->general->byteOrder);
+
+    /* XCP part 2 - Protocol Layer Specification 1.1/1.6.4.3.1.3. The refusals below are ordered by
+     * the error matrix's own precedence -- SEQUENCE, then OUT_OF_RANGE, then MEMORY_OVERFLOW,
+     * which two independent capacity limits share -- and each asks a narrower question than the
+     * one before: the command stream, then the list named, then how much room is left. */
+    if ((Xcp_Internal.daq_alloc_state != XCP_DAQ_ALLOC_DAQ) &&
+        (Xcp_Internal.daq_alloc_state != XCP_DAQ_ALLOC_ODT))
+    {
+        /* ERR_SEQUENCE for an ALLOC_ODT that has had no ALLOC_DAQ before it, or that follows an
+         * ALLOC_ODT_ENTRY without a FREE_DAQ in between. */
+        error = XCP_E_ASAM_SEQUENCE;
+    }
+    else if (Xcp_DaqListIsValid(daq_list_number) == FALSE)
+    {
+        /* DD32: valid means allocated, not merely inside the configured pool. A list ALLOC_DAQ
+         * has not handed out is "not available", so it answers ERR_OUT_OF_RANGE. */
+        error = XCP_E_ASAM_OUT_OF_RANGE;
+    }
+    else if ((uint16)((uint16)Xcp_Ptr->config->daqList[daq_list_number].maxOdt + (uint16)odt_count) >
+             (uint16)Xcp_Ptr->general->odtCount)
+    {
+        /* The pool is rectangular (ECUC_Xcp_00054), so one list may hold odtCount ODTs and no
+         * more -- its slice of the generated ODT array is exactly that wide. odtCount is zero
+         * under a STATIC configuration, which is not a hazard here: script/source_cfg.c.jinja2
+         * refuses a STATIC configuration that enables any of the four allocation APIs, so 0xD4 is
+         * unreachable in a build where this bound would be zero. */
+        error = XCP_E_ASAM_MEMORY_OVERFLOW;
+    }
+    else if ((uint16)(Xcp_DaqAllocatedOdtCount() + (uint16)odt_count) >
+             (uint16)XCP_DAQ_ABSOLUTE_ODT_COUNT_MAX)
+    {
+        /* A second, independent ceiling: the per-list slice above says nothing about the total,
+         * and absolute ODT numbers are drawn from one PID space shared by every list. */
+        error = XCP_E_ASAM_MEMORY_OVERFLOW;
+    }
+    else
+    {
+        /* Both writes under one exclusive area, because the sampler reads them together:
+         * Xcp_TriggerEventChannel walks maxOdt and Xcp_DaqWriteIdentificationField
+         * (source/Xcp_DaqRuntime.c) computes an ABSOLUTE field's PID as firstPid + ODT number, so
+         * a trigger interleaved between the two would transmit a frame whose PID belongs to the
+         * layout that is being replaced. This is the DD14 failure class, and the reason the
+         * recompute is inside the area rather than after it -- raising maxOdt is what makes the
+         * standing firstPid values wrong.
+         *
+         * Raised, not assigned: DD28 makes a repeat naming the same list accumulate. Rejected
+         * whole above, never in part -- a partly applied allocation would leave the master
+         * unaware of how much it actually has, and would put the prefix sum out of step with what
+         * the response said. */
+        SchM_Enter_Xcp_DtoQueue();
+
+        Xcp_Ptr->config->daqList[daq_list_number].maxOdt =
+                (uint8)(Xcp_Ptr->config->daqList[daq_list_number].maxOdt + odt_count);
+
+        Xcp_DaqRecomputeFirstPids();
+
+        SchM_Exit_Xcp_DtoQueue();
+
+        Xcp_Internal.daq_alloc_state = XCP_DAQ_ALLOC_ODT;
+    }
+
+    if (error == 0x00u)
+    {
+        Xcp_Internal.cto_response.pdu_info.SduDataPtr[0x00u] = XCP_PID_RESPONSE;
+        Xcp_FinalizeResPacket(0x01u, &Xcp_Internal.cto_response.pdu_info);
+    }
+    else
+    {
+        Xcp_FillErrorPacket(error, &Xcp_Internal.cto_response.pdu_info);
+    }
+
+    return E_OK;
+}
+
 uint8 Xcp_DTOCmdDaqAllocDaq(boolean *responseExpected, const PduInfoType *pPduInfo)
 {
     uint16 daq_count;

--- a/source/Xcp_DaqRuntime.c
+++ b/source/Xcp_DaqRuntime.c
@@ -118,8 +118,10 @@ static uint8 Xcp_DaqWriteIdentificationField(Xcp_DtoFrameType *pFrame,
  * write once the entries of one ODT would sum past odtEntrySizeDaq = XCP_MAX_DTO -
  * <identification field size> bytes, and every entry that contributes at all contributes at least
  * one byte. So at most XCP_MAX_DTO - 1 entries can ever be simultaneously non-empty, regardless of
- * maxOdtEntries or which slots they occupy. The scan below therefore walks every configured slot
- * (cheap: one length comparison, no per-slot storage) but copies only the non-empty ones,
+ * maxOdtEntries or which slots they occupy. The scan below therefore walks every slot the ODT
+ * holds -- its entryCount, which is every configured slot under STATIC and exactly what
+ * ALLOC_ODT_ENTRY handed out under DYNAMIC
+ * (cheap: one length comparison, no per-slot storage) -- but copies only the non-empty ones,
  * compacted, and stops copying -- defensively; the bound above says this cannot trigger -- once
  * XCP_MAX_DTO copies have been made. This is what keeps a function that may run in an interrupt
  * from putting up to 255 (a uint8 count) full entries, or roughly 1 KB, on its stack.

--- a/source/Xcp_DaqRuntime.c
+++ b/source/Xcp_DaqRuntime.c
@@ -149,7 +149,7 @@ static Std_ReturnType Xcp_DaqSampleOdt(Xcp_DtoFrameType *pFrame, uint16 daqListN
 
     SchM_Enter_Xcp_DtoQueue();
 
-    for (idx = 0x00u; idx < Xcp_Ptr->config->daqList[daqListNumber].maxOdtEntries; idx++)
+    for (idx = 0x00u; idx < Xcp_Ptr->config->daqList[daqListNumber].odt[odtNumber].entryCount; idx++)
     {
         const Xcp_OdtEntryType *p_live =
                 &Xcp_Ptr->config->daqList[daqListNumber].odt[odtNumber].odtEntry[idx];

--- a/source/Xcp_Internal.h
+++ b/source/Xcp_Internal.h
@@ -524,22 +524,23 @@ uint8 Xcp_DTOCmdDaqClearDaqList(boolean *responseExpected, const PduInfoType *pP
 /**
  * @brief returns every DAQ list, and the dynamic allocation state with it, to power-up values.
  * @details Defined in Xcp_Daq.c, beside Xcp_DTOCmdDaqFreeDaq, whose entire body it is
- * (1.1/1.6.4.3.1.1), but declared here with external linkage because Xcp_CTOCmdStdDisconnect
- * (Xcp_Std.c) calls it too -- the same arrangement, and for the same kind of reason, as
- * Xcp_DaqListClearEntries just above.
+ * (1.1/1.6.4.3.1.1), but declared here with external linkage because two other places need the
+ * same unwind -- the same arrangement, and for the same kind of reason, as Xcp_DaqListClearEntries
+ * just above. The three callers are:
  *
- * XCP part 1 - Overview 1.0/2.3: in DISCONNECTED state "the session status, all DAQ lists and the
- * protection status bits are reset". Nothing did that: Xcp_CTOCmdStdDisconnect reset only
- * connection_status, CONNECT reset nothing, and Xcp_Init was the module's only session-state
- * reset path. Under a DYNAMIC configuration that is not merely untidy. The allocation state
- * machine's initial state is XCP_DAQ_ALLOC_FREE and accepts ALLOC_DAQ with no preceding FREE_DAQ
- * (DD28), and repeated ALLOC_DAQ accumulates, so a master that allocated and then disconnected
- * without sending FREE_DAQ left the allocation standing -- and the next master's ALLOC_DAQ added
- * to it, handing that master more lists than it asked for, carrying the previous session's ODT
- * entries.
- * @note DISCONNECT calls this in a STATIC build too, where it frees nothing (there is no dynamic
- * allocation to release) but still stops every list and clears every ODT entry, which is what
- * 1.0/2.3 asks for and what the master's next CONNECT is entitled to assume.
+ * - Xcp_DTOCmdDaqFreeDaq (Xcp_Daq.c), for which this is the whole command;
+ * - Xcp_Init (Xcp.c), which has to establish the same invariant at start-up, and whose
+ *   open-coded loop used to leave the descriptor's maxOdt, firstPid and per-ODT entryCount
+ *   standing -- so a re-initialised DYNAMIC module reported nothing allocated while the
+ *   descriptor still described the previous session's lists;
+ * - Xcp_CTOCmdStdDisconnect (Xcp_Std.c), under DYNAMIC only. The allocation state machine starts
+ *   in XCP_DAQ_ALLOC_FREE and accepts ALLOC_DAQ with no preceding FREE_DAQ (DD28), and repeats
+ *   accumulate, so an allocation a master leaves standing at DISCONNECT is one the next master's
+ *   ALLOC_DAQ adds to -- handing it more lists than it asked for, carrying the previous session's
+ *   ODT entries.
+ * @note the DISCONNECT caller is gated on DAQ_DYNAMIC. A STATIC configuration has no allocation
+ * to release, and clearing its generated DAQ entries on disconnect would be a behaviour change to
+ * the static model that SP2d is required not to make (DD25).
  */
 void Xcp_DaqFreeAll(void);
 

--- a/source/Xcp_Internal.h
+++ b/source/Xcp_Internal.h
@@ -560,6 +560,27 @@ uint8 Xcp_DTOCmdDaqClearDaqList(boolean *responseExpected, const PduInfoType *pP
 void Xcp_DaqFreeAll(void);
 
 /**
+ * @brief ALLOC_ODT_ENTRY, XCP part 2 - Protocol Layer Specification 1.1/1.6.4.3.1.4.
+ * @details Defined in Xcp_Daq.c, immediately before Xcp_DTOCmdDaqAllocOdt: 0xD3 precedes 0xD4 in
+ * the PID table, and the allocation commands are kept together in that order.
+ * @note DD34: raises Xcp_OdtType.entryCount (interface/Xcp_Types.h), the per-ODT field that lets
+ * two ODTs of one list hold different numbers of entries -- daqList[n].maxOdtEntries cannot
+ * express that, and keeps its own DYNAMIC meaning unchanged: the cap any one ODT may reach
+ * (odt_entries_count).
+ * @note DD28: like its three siblings, a repeat naming the same ODT accumulates onto its
+ * entryCount rather than replacing it -- the specification forbids ALLOC_ODT_ENTRY only after
+ * FREE and DAQ, so a repeat from ODT or ODT_ENTRY is permitted, and a permitted repeat that
+ * merely replaced the previous grant would be indistinguishable from one that was refused.
+ * @note this is the step that closes the running-list FIRST_PID safety argument: starting a list
+ * (Xcp_DTOCmdDaqStartStopDaqList) requires Xcp_DaqListIsConfigured, which requires an ODT entry
+ * of non-zero length, which requires entryCount > 0 -- the field only this command raises under
+ * DYNAMIC. This command also leaves the state at XCP_DAQ_ALLOC_ODT_ENTRY, from which
+ * Xcp_DTOCmdDaqAllocOdt answers ERR_SEQUENCE, so once a list has an entry, only FREE_DAQ (which
+ * stops every running list first, DD30) can move its maxOdt, and so its FIRST_PID, again.
+ */
+uint8 Xcp_DTOCmdDaqAllocOdtEntry(boolean *responseExpected, const PduInfoType *pPduInfo);
+
+/**
  * @brief ALLOC_ODT, XCP part 2 - Protocol Layer Specification 1.1/1.6.4.3.1.3.
  * @details Defined in Xcp_Daq.c, immediately before Xcp_DTOCmdDaqAllocDaq: 0xD4 precedes 0xD5 in
  * the PID table, and the allocation commands are kept together in that order.

--- a/source/Xcp_Internal.h
+++ b/source/Xcp_Internal.h
@@ -255,6 +255,22 @@ typedef enum {
     XCP_CONNECTION_STATE_RESUME
 } Xcp_ConnectionState;
 
+/**
+ * @brief where a dynamic DAQ list configuration sequence has got to.
+ * @details XCP part 2 - Protocol Layer Specification 1.1/1.6.4.3.1 enumerates six ERR_SEQUENCE
+ * cases, which reduce to these four states and the transition table in Xcp_Daq.c. The initial
+ * value is XCP_DAQ_ALLOC_FREE: §1.6.4.3.1.1 requires the master to send FREE_DAQ first, but that
+ * is a requirement on the master and the slave's enumerated refusals do not include an ALLOC_DAQ
+ * with no preceding command -- nothing is allocated at that point, so accepting it is defined.
+ * @note explicitly 0, since it may live in a cleared memory section.
+ */
+typedef enum {
+    XCP_DAQ_ALLOC_FREE = 0x00u,
+    XCP_DAQ_ALLOC_DAQ,
+    XCP_DAQ_ALLOC_ODT,
+    XCP_DAQ_ALLOC_ODT_ENTRY
+} Xcp_DaqAllocStateType;
+
 typedef struct {
     uint8 connect_mode;
     Xcp_ConnectionState connection_status;
@@ -325,6 +341,15 @@ typedef struct {
         uint8 odtEntryNumber;
         boolean valid;
     } daq_pointer;
+
+    Xcp_DaqAllocStateType daq_alloc_state;
+
+    /**
+     * @brief DAQ lists currently available to the master.
+     * @details Equals Xcp_Ptr->general->daqCount under a STATIC configuration and is raised from
+     * zero by ALLOC_DAQ under a DYNAMIC one, so Xcp_DaqListIsValid serves both models unchanged.
+     */
+    uint16 allocated_daq_count;
     uint8 internal_buffer[0x08u];
 } Xcp_InternalType;
 

--- a/source/Xcp_Internal.h
+++ b/source/Xcp_Internal.h
@@ -520,6 +520,37 @@ uint8 Xcp_DTOCmdDaqReadDaq(boolean *responseExpected, const PduInfoType *pPduInf
  */
 void Xcp_DaqListClearEntries(uint16 daqListNumber);
 uint8 Xcp_DTOCmdDaqClearDaqList(boolean *responseExpected, const PduInfoType *pPduInfo);
+
+/**
+ * @brief returns every DAQ list, and the dynamic allocation state with it, to power-up values.
+ * @details Defined in Xcp_Daq.c, beside Xcp_DTOCmdDaqFreeDaq, whose entire body it is
+ * (1.1/1.6.4.3.1.1), but declared here with external linkage because Xcp_CTOCmdStdDisconnect
+ * (Xcp_Std.c) calls it too -- the same arrangement, and for the same kind of reason, as
+ * Xcp_DaqListClearEntries just above.
+ *
+ * XCP part 1 - Overview 1.0/2.3: in DISCONNECTED state "the session status, all DAQ lists and the
+ * protection status bits are reset". Nothing did that: Xcp_CTOCmdStdDisconnect reset only
+ * connection_status, CONNECT reset nothing, and Xcp_Init was the module's only session-state
+ * reset path. Under a DYNAMIC configuration that is not merely untidy. The allocation state
+ * machine's initial state is XCP_DAQ_ALLOC_FREE and accepts ALLOC_DAQ with no preceding FREE_DAQ
+ * (DD28), and repeated ALLOC_DAQ accumulates, so a master that allocated and then disconnected
+ * without sending FREE_DAQ left the allocation standing -- and the next master's ALLOC_DAQ added
+ * to it, handing that master more lists than it asked for, carrying the previous session's ODT
+ * entries.
+ * @note DISCONNECT calls this in a STATIC build too, where it frees nothing (there is no dynamic
+ * allocation to release) but still stops every list and clears every ODT entry, which is what
+ * 1.0/2.3 asks for and what the master's next CONNECT is entitled to assume.
+ */
+void Xcp_DaqFreeAll(void);
+
+/**
+ * @brief FREE_DAQ, XCP part 2 - Protocol Layer Specification 1.1/1.6.4.3.1.1.
+ * @details Defined in Xcp_Daq.c, immediately after Xcp_DTOCmdDaqClearDaqList: the two are the
+ * module's two reset commands and share Xcp_DaqListReset, differing in scope -- CLEAR_DAQ_LIST
+ * resets one list and keeps its allocation, FREE_DAQ resets every list and releases the
+ * allocation as well.
+ */
+uint8 Xcp_DTOCmdDaqFreeDaq(boolean *responseExpected, const PduInfoType *pPduInfo);
 uint8 Xcp_DTOCmdDaqSetDaqListMode(boolean *responseExpected, const PduInfoType *pPduInfo);
 uint8 Xcp_DTOCmdDaqGetDaqListMode(boolean *responseExpected, const PduInfoType *pPduInfo);
 

--- a/source/Xcp_Internal.h
+++ b/source/Xcp_Internal.h
@@ -545,6 +545,18 @@ uint8 Xcp_DTOCmdDaqClearDaqList(boolean *responseExpected, const PduInfoType *pP
 void Xcp_DaqFreeAll(void);
 
 /**
+ * @brief ALLOC_DAQ, XCP part 2 - Protocol Layer Specification 1.1/1.6.4.3.1.2.
+ * @details Defined in Xcp_Daq.c, immediately before Xcp_DTOCmdDaqFreeDaq: 0xD5 precedes 0xD6 in
+ * the PID table, and the two are the allocation state machine's grant and release halves.
+ * @note DD28: repeated ALLOC_DAQ calls accumulate onto Xcp_Internal.allocated_daq_count rather
+ * than replacing it -- the specification's ERR_SEQUENCE cases forbid ALLOC_DAQ only after
+ * ALLOC_ODT and ALLOC_ODT_ENTRY, so a repeat from FREE or DAQ is permitted, and a permitted
+ * repeat that merely replaced the previous grant would be indistinguishable from one that was
+ * refused.
+ */
+uint8 Xcp_DTOCmdDaqAllocDaq(boolean *responseExpected, const PduInfoType *pPduInfo);
+
+/**
  * @brief FREE_DAQ, XCP part 2 - Protocol Layer Specification 1.1/1.6.4.3.1.1.
  * @details Defined in Xcp_Daq.c, immediately after Xcp_DTOCmdDaqClearDaqList: the two are the
  * module's two reset commands and share Xcp_DaqListReset, differing in scope -- CLEAR_DAQ_LIST

--- a/source/Xcp_Internal.h
+++ b/source/Xcp_Internal.h
@@ -126,6 +126,21 @@ extern "C" {
 #define XCP_SESSION_STATUS_MASK_CLEAR_DAQ_REQ (0x01u << 0x03u)
 #define XCP_SESSION_STATUS_MASK_DAQ_RUNNING (0x01u << 0x06u)
 
+/**
+ * @brief how many absolute ODT numbers exist, across every DAQ list together.
+ * @details An absolute ODT number IS the PID a DAQ DTO carries in an ABSOLUTE identification
+ * field (XCP part 2 - Protocol Layer Specification 1.1/1.1.4.1), so it is bounded by the PID
+ * space rather than by any configured dimension. The four highest slave-to-master PIDs are taken:
+ * 0xFC is SERV, 0xFD is EV (XCP_PID_EVENT), 0xFE is ERR (XCP_PID_ERROR) and 0xFF is RES
+ * (XCP_PID_RESPONSE). That leaves 0x00..0xFB, so the count is 0xFC -- the value below is both the
+ * number of usable absolute ODT numbers and the first PID that is not one.
+ * @note ALLOC_ODT enforces this at runtime, against what a master has actually allocated. The
+ * generator deliberately does NOT guard daq_count x odt_count against it for a DAQ_DYNAMIC
+ * configuration (DD31, script/source_cfg.c.jinja2): the pool's rectangle is an upper bound a
+ * master rarely reaches, so guarding it there would refuse configurations that work.
+ */
+#define XCP_DAQ_ABSOLUTE_ODT_COUNT_MAX (0xFCu)
+
 /* SET_DAQ_LIST_MODE mode byte, XCP part 2 - Protocol Layer Specification 1.1/1.6.4.1.1.3.
  * Read off the specification's own bit table, which is identical in 1.0 and 1.1 except that 1.1
  * fills bit 0, which 1.0 left don't-care:
@@ -543,6 +558,20 @@ uint8 Xcp_DTOCmdDaqClearDaqList(boolean *responseExpected, const PduInfoType *pP
  * the static model that SP2d is required not to make (DD25).
  */
 void Xcp_DaqFreeAll(void);
+
+/**
+ * @brief ALLOC_ODT, XCP part 2 - Protocol Layer Specification 1.1/1.6.4.3.1.3.
+ * @details Defined in Xcp_Daq.c, immediately before Xcp_DTOCmdDaqAllocDaq: 0xD4 precedes 0xD5 in
+ * the PID table, and the allocation commands are kept together in that order.
+ * @note DD28: like ALLOC_DAQ, repeated calls naming the same DAQ list accumulate onto its maxOdt
+ * rather than replacing it -- the specification forbids ALLOC_ODT only after ALLOC_ODT_ENTRY, so
+ * a repeat from DAQ or ODT is permitted, and a permitted repeat that merely replaced the previous
+ * grant would be indistinguishable from one that was refused.
+ * @note DD31: this is the command that assigns FIRST_PID, and it assigns every list's, not just
+ * the addressed one's. See Xcp_DaqRecomputeFirstPids beside the definition for why a prefix sum
+ * over list index is the only assignment that survives the accumulate rule above.
+ */
+uint8 Xcp_DTOCmdDaqAllocOdt(boolean *responseExpected, const PduInfoType *pPduInfo);
 
 /**
  * @brief ALLOC_DAQ, XCP part 2 - Protocol Layer Specification 1.1/1.6.4.3.1.2.

--- a/source/Xcp_Std.c
+++ b/source/Xcp_Std.c
@@ -1101,6 +1101,12 @@ uint8 Xcp_CTOCmdStdDisconnect(boolean *responseExpected, const PduInfoType *pPdu
 
     Xcp_Internal.connection_status = XCP_CONNECTION_STATE_DISCONNECTED;
 
+    /* XCP part 1 - Overview 1.0/2.3: in "DISCONNECTED" state "the session status, all DAQ lists
+     * and the protection status bits are reset, which means that DAQ list transfer is inactive".
+     * The same unwind FREE_DAQ performs, and for the same reasons -- see Xcp_DaqFreeAll's
+     * declaration in Xcp_Internal.h for what a DYNAMIC configuration inherited without it. */
+    Xcp_DaqFreeAll();
+
     return E_OK;
 }
 

--- a/source/Xcp_Std.c
+++ b/source/Xcp_Std.c
@@ -1101,11 +1101,23 @@ uint8 Xcp_CTOCmdStdDisconnect(boolean *responseExpected, const PduInfoType *pPdu
 
     Xcp_Internal.connection_status = XCP_CONNECTION_STATE_DISCONNECTED;
 
-    /* XCP part 1 - Overview 1.0/2.3: in "DISCONNECTED" state "the session status, all DAQ lists
-     * and the protection status bits are reset, which means that DAQ list transfer is inactive".
-     * The same unwind FREE_DAQ performs, and for the same reasons -- see Xcp_DaqFreeAll's
-     * declaration in Xcp_Internal.h for what a DYNAMIC configuration inherited without it. */
-    Xcp_DaqFreeAll();
+    /* Release a dynamic allocation the disconnecting master never freed, so it cannot leak into
+     * the next session. DYNAMIC only, and deliberately so: the gap being closed is that the
+     * allocation state machine starts in XCP_DAQ_ALLOC_FREE and accepts ALLOC_DAQ with no
+     * preceding FREE_DAQ (DD28), and repeated ALLOC_DAQ accumulates -- so an allocation left
+     * standing at DISCONNECT is one the NEXT master's ALLOC_DAQ adds to, handing it more lists
+     * than it asked for, carrying the previous session's ODT entries. A STATIC configuration has
+     * no allocation to leak: its lists are generated, not allocated, so there is nothing here for
+     * it to release.
+     *
+     * This therefore does not touch a static build's configured DAQ entries. Whether DISCONNECT
+     * ought to clear those as well is a separate question about XCP part 1 - Overview 2.3 and is
+     * not settled here; changing it would be a behaviour change to the static model, which SP2d
+     * is required to leave byte-for-byte as it is (DD25). */
+    if (Xcp_Ptr->general->daqConfigType == DAQ_DYNAMIC)
+    {
+        Xcp_DaqFreeAll();
+    }
 
     return E_OK;
 }

--- a/test.sh
+++ b/test.sh
@@ -18,7 +18,22 @@ cd build || exit 1
 # modules are keyed by a content digest and rebuilt on demand (test/conftest.py's MockGen), so
 # removing them is safe. This cannot move to the end of the script instead: the coverage merge
 # below depends on the modules THIS run creates still being present once ctest finishes.
-rm -rf _cffi_xcp_*
+#
+# libcffi_xcp_rt_*.so is pruned for the identical reason and used not to be. The _cffi_xcp_* glob
+# already catches the configuration modules, whose compiled objects are named _cffi_xcp_cfg_*.so,
+# but the generated RUNTIME is linked as a library and so is named libcffi_xcp_rt_*.so -- outside
+# that glob, and therefore accumulating without bound exactly as the module directories did (41
+# had built up when this was found, against 573 .so files in total). They are keyed by the same
+# content digest and rebuilt on demand, so removing them is as safe as removing the directories.
+#
+# One thing pruning does NOT fix, so that a future reader does not conclude it should have: the
+# transient failures above still occur, and were reproduced on a clean build/ directory and on an
+# unmodified source tree. Raising the container's file-descriptor soft limit --
+# `docker run --ulimit nofile=65536:524288 ...`, against a 524288 hard limit -- measurably helps
+# and is not sufficient either. It is left to the caller rather than wired in here, because this
+# script does not control how it is invoked. A run that stops short with a pycparser/PLY, Jinja2
+# or CFFI error is not a result; re-run it.
+rm -rf _cffi_xcp_* libcffi_xcp_rt_*.so
 
 # A configure or build failure has to fail this script, and so does an empty test run: a branch
 # that does not compile must not report a green build having run nothing. --no-tests=error makes

--- a/test/alloc_daq_test.py
+++ b/test/alloc_daq_test.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import pytest
+
+from .parameter import *
+from .conftest import XcpTest
+from .download_test import connect
+
+
+def dynamic_handle(**kwargs):
+    handle = XcpTest(dynamic_config(**kwargs))
+    connect(handle)
+    return handle
+
+
+def exchange(handle, request, length=8):
+    handle.lib.Xcp_CanIfRxIndication(0x0001, handle.get_pdu_info(request))
+    handle.lib.Xcp_MainFunction()
+    handle.lib.Xcp_CanIfTxConfirmation(0x0002, handle.define('E_OK'))
+    return tuple(handle.can_if_transmit.call_args[0][1].SduDataPtr[0:length])
+
+
+def test_alloc_daq_makes_lists_available():
+    handle = dynamic_handle(daq_count=4)
+    assert exchange(handle, (0xD5, 0x00, 0x02, 0x00))[0] == 0xFF
+    assert exchange(handle, (0xE3, 0x00, 0x01, 0x00))[0] == 0xFF          # list 1 available
+    assert exchange(handle, (0xE3, 0x00, 0x02, 0x00))[0:2] == (0xFE, 0x22)  # list 2 is not
+
+
+def test_alloc_daq_accumulates_across_repeated_calls():
+    """DD28. The specification forbids ALLOC_DAQ only after ALLOC_ODT and ALLOC_ODT_ENTRY, so a
+    repeat from FREE or DAQ is permitted -- and each call therefore adds to what is allocated.
+    Treating a repeat as a replacement would make the permitted repeat meaningless."""
+    handle = dynamic_handle(daq_count=4)
+    exchange(handle, (0xD5, 0x00, 0x01, 0x00))
+    exchange(handle, (0xD5, 0x00, 0x02, 0x00))
+    assert exchange(handle, (0xE3, 0x00, 0x02, 0x00))[0] == 0xFF          # three allocated
+    assert exchange(handle, (0xE3, 0x00, 0x03, 0x00))[0:2] == (0xFE, 0x22)
+
+
+def test_alloc_daq_refuses_more_lists_than_the_pool_holds():
+    handle = dynamic_handle(daq_count=4)
+    assert exchange(handle, (0xD5, 0x00, 0x05, 0x00))[0:2] == (0xFE, 0x30)
+    # The rejected request left nothing allocated.
+    assert exchange(handle, (0xE3, 0x00, 0x00, 0x00))[0:2] == (0xFE, 0x22)

--- a/test/alloc_daq_test.py
+++ b/test/alloc_daq_test.py
@@ -44,3 +44,29 @@ def test_alloc_daq_refuses_more_lists_than_the_pool_holds():
     assert exchange(handle, (0xD5, 0x00, 0x05, 0x00))[0:2] == (0xFE, 0x30)
     # The rejected request left nothing allocated.
     assert exchange(handle, (0xE3, 0x00, 0x00, 0x00))[0:2] == (0xFE, 0x22)
+
+
+def test_alloc_daq_refusal_leaves_the_allocation_state_unadvanced():
+    """The sibling of test_alloc_odt_entry_refusal_leaves_the_allocation_state_unadvanced, for
+    0xD5. Nothing else pins that a refused ALLOC_DAQ leaves daq_alloc_state where it found it: a
+    mutant that moves the `Xcp_Internal.daq_alloc_state = XCP_DAQ_ALLOC_DAQ` assignment out of the
+    else and after the if/else chain survives the whole rest of the suite -- the refusal above
+    already asserts nothing was allocated, but says nothing about the state.
+
+    Observed through ALLOC_ODT's *error code*, not through acceptance, because both states this
+    has to tell apart refuse the command. ALLOC_ODT checks its refusals in the error matrix's own
+    precedence -- SEQUENCE, then OUT_OF_RANGE (source/Xcp_Daq.c) -- so from XCP_DAQ_ALLOC_FREE,
+    where the state must still be, it answers ERR_SEQUENCE; from XCP_DAQ_ALLOC_DAQ, where the
+    mutant would have put it, the sequence check passes and it falls through to ERR_OUT_OF_RANGE
+    for a list ALLOC_DAQ never handed out. The two codes are what separates the correct module
+    from the mutant."""
+    handle = dynamic_handle(daq_count=4)
+
+    assert exchange(handle, (0xD5, 0x00, 0x05, 0x00))[0:2] == (0xFE, 0x30)
+    assert exchange(handle, (0xD4, 0x00, 0x00, 0x00, 0x01))[0:2] == (0xFE, 0x29), \
+        'the refused ALLOC_DAQ advanced the state out of XCP_DAQ_ALLOC_FREE'
+
+    # And the state really is still the one ALLOC_DAQ is accepted from, rather than some third
+    # thing: a well-formed request from here still succeeds.
+    assert exchange(handle, (0xD5, 0x00, 0x01, 0x00))[0] == 0xFF
+    assert exchange(handle, (0xD4, 0x00, 0x00, 0x00, 0x01))[0] == 0xFF

--- a/test/alloc_odt_entry_test.py
+++ b/test/alloc_odt_entry_test.py
@@ -111,3 +111,22 @@ def test_alloc_odt_entry_refusal_leaves_the_allocation_state_unadvanced():
     exchange(handle, (0xD4, 0x00, 0x00, 0x00, 0x01))
     assert exchange(handle, (0xD3, 0x00, 0x00, 0x00, 0x01, 0x01))[0:2] == (0xFE, 0x22)
     assert exchange(handle, (0xD4, 0x00, 0x00, 0x00, 0x01))[0] == 0xFF
+
+
+def test_alloc_odt_entry_refused_memory_overflow_leaves_entrycount_unchanged():
+    """The sibling of test_alloc_odt_entry_refusal_leaves_the_allocation_state_unadvanced, for
+    entryCount rather than daq_alloc_state: a refused request must leave entryCount exactly where
+    it found it, not just the response bytes ERR_MEMORY_OVERFLOW already pins. This is the case
+    that matters most for entryCount specifically -- MEMORY_OVERFLOW is the one check whose entire
+    purpose is to keep entryCount from exceeding odt_entries_count, the actual width of that ODT's
+    slice of the generated entry pool (script/source_cfg.c.jinja2). A write hoisted above the
+    error chain would still run here: 2 (already granted by the first call below) + 3 (requested
+    by the refused second call) = 5, which already exceeds the odt_entries_count = 4 cap this
+    refusal exists to enforce -- precisely the out-of-bounds shape DD14/DD30 prevent elsewhere in
+    this design."""
+    handle = dynamic_handle(daq_count=1, odt_count=1, odt_entries_count=4)
+    exchange(handle, (0xD5, 0x00, 0x01, 0x00))
+    exchange(handle, (0xD4, 0x00, 0x00, 0x00, 0x01))
+    exchange(handle, (0xD3, 0x00, 0x00, 0x00, 0x00, 0x02))
+    assert exchange(handle, (0xD3, 0x00, 0x00, 0x00, 0x00, 0x03))[0:2] == (0xFE, 0x30)
+    assert handle.lib.Xcp_Ptr.config.daqList[0].odt[0].entryCount == 2

--- a/test/alloc_odt_entry_test.py
+++ b/test/alloc_odt_entry_test.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import pytest
+
+from .parameter import *
+from .conftest import XcpTest
+from .download_test import connect
+
+
+def dynamic_handle(**kwargs):
+    handle = XcpTest(dynamic_config(**kwargs))
+    connect(handle)
+    return handle
+
+
+def exchange(handle, request, length=8):
+    handle.lib.Xcp_CanIfRxIndication(0x0001, handle.get_pdu_info(request))
+    handle.lib.Xcp_MainFunction()
+    handle.lib.Xcp_CanIfTxConfirmation(0x0002, handle.define('E_OK'))
+    return tuple(handle.can_if_transmit.call_args[0][1].SduDataPtr[0:length])
+
+
+def test_alloc_odt_entry_gives_each_odt_its_own_count():
+    """DD34. This is what the per-ODT entryCount exists for: the per-list maxOdtEntries cannot
+    express one ODT holding four entries and another two."""
+    handle = dynamic_handle(daq_count=1, odt_count=2, odt_entries_count=4)
+    exchange(handle, (0xD5, 0x00, 0x01, 0x00))
+    exchange(handle, (0xD4, 0x00, 0x00, 0x00, 0x02))
+    assert exchange(handle, (0xD3, 0x00, 0x00, 0x00, 0x00, 0x04))[0] == 0xFF
+    assert exchange(handle, (0xD3, 0x00, 0x00, 0x00, 0x01, 0x02))[0] == 0xFF
+    daq_list = handle.lib.Xcp_Ptr.config.daqList[0]
+    assert (daq_list.odt[0].entryCount, daq_list.odt[1].entryCount) == (4, 2)
+
+
+def test_alloc_odt_entry_accumulates_across_repeated_calls_to_the_same_odt():
+    """DD28. The specification forbids ALLOC_ODT_ENTRY only after FREE and DAQ, so a repeat from
+    ODT or ODT_ENTRY naming the same ODT is permitted -- and each call therefore adds to what is
+    allocated, the same as ALLOC_DAQ and ALLOC_ODT. Distinct from
+    test_alloc_odt_entry_gives_each_odt_its_own_count: that test names two different ODTs, both
+    starting from zero, so it cannot tell an accumulate from a replace -- only a second call
+    naming the same ODT can. Treating a repeat as a replacement would make the permitted repeat
+    meaningless."""
+    handle = dynamic_handle(daq_count=1, odt_count=1, odt_entries_count=8)
+    exchange(handle, (0xD5, 0x00, 0x01, 0x00))
+    exchange(handle, (0xD4, 0x00, 0x00, 0x00, 0x01))
+    exchange(handle, (0xD3, 0x00, 0x00, 0x00, 0x00, 0x03))
+    assert exchange(handle, (0xD3, 0x00, 0x00, 0x00, 0x00, 0x02))[0] == 0xFF
+    assert handle.lib.Xcp_Ptr.config.daqList[0].odt[0].entryCount == 5
+
+
+def test_alloc_odt_entry_refuses_an_odt_the_list_does_not_have():
+    handle = dynamic_handle(daq_count=1, odt_count=4, odt_entries_count=4)
+    exchange(handle, (0xD5, 0x00, 0x01, 0x00))
+    exchange(handle, (0xD4, 0x00, 0x00, 0x00, 0x02))
+    assert exchange(handle, (0xD3, 0x00, 0x00, 0x00, 0x02, 0x01))[0:2] == (0xFE, 0x22)
+
+
+def test_alloc_odt_entry_refuses_more_entries_than_one_odt_may_hold():
+    handle = dynamic_handle(daq_count=1, odt_count=1, odt_entries_count=4)
+    exchange(handle, (0xD5, 0x00, 0x01, 0x00))
+    exchange(handle, (0xD4, 0x00, 0x00, 0x00, 0x01))
+    assert exchange(handle, (0xD3, 0x00, 0x00, 0x00, 0x00, 0x05))[0:2] == (0xFE, 0x30)
+
+
+def test_alloc_odt_entry_refuses_a_list_that_was_never_allocated():
+    """The DD32 rule ALLOC_ODT and ALLOC_DAQ already answer to: valid means allocated, not merely
+    inside the configured pool. List 1 is inside the pool but ALLOC_DAQ only handed out list 0."""
+    handle = dynamic_handle(daq_count=4, odt_count=4)
+    exchange(handle, (0xD5, 0x00, 0x01, 0x00))
+    exchange(handle, (0xD4, 0x00, 0x00, 0x00, 0x01))
+    assert exchange(handle, (0xD3, 0x00, 0x01, 0x00, 0x00, 0x01))[0:2] == (0xFE, 0x22)
+
+
+def test_alloc_odt_entry_before_any_alloc_odt_is_a_sequence_error():
+    """Unlike ALLOC_ODT, which accepts a bare ALLOC_DAQ, ALLOC_ODT_ENTRY is accepted only from
+    XCP_DAQ_ALLOC_ODT or XCP_DAQ_ALLOC_ODT_ENTRY (1.1/1.6.4.3.1.4) -- so both FREE and DAQ answer
+    ERR_SEQUENCE."""
+    handle = dynamic_handle(daq_count=1, odt_count=1)
+    assert exchange(handle, (0xD3, 0x00, 0x00, 0x00, 0x00, 0x01))[0:2] == (0xFE, 0x29)
+    exchange(handle, (0xD5, 0x00, 0x01, 0x00))
+    assert exchange(handle, (0xD3, 0x00, 0x00, 0x00, 0x00, 0x01))[0:2] == (0xFE, 0x29)
+
+
+def test_alloc_odt_entry_blocks_alloc_odt_once_reached():
+    """The closing step of the running-list FIRST_PID safety argument: once the state has reached
+    XCP_DAQ_ALLOC_ODT_ENTRY, ALLOC_ODT answers ERR_SEQUENCE, and FREE_DAQ is the only way back --
+    so no master can grow a list's maxOdt, and with it its FIRST_PID prefix sum, once that list
+    has an ODT entry."""
+    handle = dynamic_handle(daq_count=1, odt_count=2, odt_entries_count=4)
+    exchange(handle, (0xD5, 0x00, 0x01, 0x00))
+    exchange(handle, (0xD4, 0x00, 0x00, 0x00, 0x01))
+    assert exchange(handle, (0xD3, 0x00, 0x00, 0x00, 0x00, 0x01))[0] == 0xFF
+    assert exchange(handle, (0xD4, 0x00, 0x00, 0x00, 0x01))[0:2] == (0xFE, 0x29)
+    # FREE_DAQ is the only way back.
+    exchange(handle, (0xD6,))
+    exchange(handle, (0xD5, 0x00, 0x01, 0x00))
+    assert exchange(handle, (0xD4, 0x00, 0x00, 0x00, 0x01))[0] == 0xFF
+
+
+def test_alloc_odt_entry_refusal_leaves_the_allocation_state_unadvanced():
+    """Nothing otherwise pins that a refused request leaves the allocation state where it found
+    it -- a mutant that hoists the state assignment above the error chain survives the rest of the
+    suite. Observed indirectly through ALLOC_ODT (0xD4), which is accepted from
+    XCP_DAQ_ALLOC_ODT but answers ERR_SEQUENCE from XCP_DAQ_ALLOC_ODT_ENTRY: if the
+    ERR_OUT_OF_RANGE refusal below had actually advanced the state, the ALLOC_ODT after it would
+    answer ERR_SEQUENCE instead of succeeding. odt_count leaves room for two ODTs, not one, so
+    that follow-up ALLOC_ODT succeeding turns on the state alone, not on any pool capacity left."""
+    handle = dynamic_handle(daq_count=1, odt_count=2, odt_entries_count=4)
+    exchange(handle, (0xD5, 0x00, 0x01, 0x00))
+    exchange(handle, (0xD4, 0x00, 0x00, 0x00, 0x01))
+    assert exchange(handle, (0xD3, 0x00, 0x00, 0x00, 0x01, 0x01))[0:2] == (0xFE, 0x22)
+    assert exchange(handle, (0xD4, 0x00, 0x00, 0x00, 0x01))[0] == 0xFF

--- a/test/alloc_odt_test.py
+++ b/test/alloc_odt_test.py
@@ -54,20 +54,76 @@ def test_alloc_odt_first_pid_blocks_never_overlap_read_back_through_the_protocol
 
     assert first_pids == [(0xFF, 0), (0xFF, 3), (0xFF, 6)]
 
-    # Spelt out as the property the numbers above stand for: each list's block of absolute ODT
-    # numbers is firstPid .. firstPid + maxOdt - 1, and no two blocks may share a number.
-    blocks = [set(range(pid, pid + odt_count))
-              for (_, pid), odt_count in zip(first_pids, (3, 3, 0))]
+    # Spelt out as the property the three numbers above stand for: each list's block of absolute
+    # ODT numbers is FIRST_PID .. FIRST_PID + MAX_ODT - 1, and no two blocks may share a number.
+    #
+    # MAX_ODT is read back through GET_DAQ_LIST_INFO (0xD8) rather than taken from the literal ODT
+    # counts the requests above used. Taken from the literals, every line below would be arithmetic
+    # on the line above -- blocks[2] would be set(range(6, 6)), empty for any FIRST_PID at all --
+    # and could not fail. Read back, this is a second and independent statement: that the MAX_ODT
+    # 0xD8 reports and the FIRST_PID 0xDE reports describe one allocation, so it fails if ALLOC_ODT
+    # ever moves one without the other.
+    max_odts = [exchange(handle, (0xD8, 0x00, daq, 0x00))[2] for daq in range(3)]
+    blocks = [set(range(pid, pid + max_odt))
+              for (_, pid), max_odt in zip(first_pids, max_odts)]
     assert blocks[0] == {0, 1, 2}
     assert blocks[1] == {3, 4, 5}
-    assert (blocks[0] & blocks[1]) == set()
-    assert blocks[2] == set()
+    assert blocks[2] == set(), 'list 2 is allocated but empty, so it owns no absolute ODT number'
 
 
 def test_alloc_odt_refuses_a_list_that_was_never_allocated():
     handle = dynamic_handle(daq_count=4, odt_count=4)
     exchange(handle, (0xD5, 0x00, 0x01, 0x00))
     assert exchange(handle, (0xD4, 0x00, 0x01, 0x00, 0x01))[0:2] == (0xFE, 0x22)
+
+
+def test_alloc_odt_refusal_leaves_the_allocation_state_unadvanced():
+    """The sibling of test_alloc_odt_entry_refusal_leaves_the_allocation_state_unadvanced, for
+    0xD4. Nothing else pins that a refused ALLOC_ODT leaves daq_alloc_state where it found it: a
+    mutant that moves the `Xcp_Internal.daq_alloc_state = XCP_DAQ_ALLOC_ODT` assignment out of the
+    else and after the if/else chain survives the whole rest of the suite, because every refusal
+    still answers with the same error byte.
+
+    Observed indirectly through ALLOC_DAQ (0xD5), which is accepted from XCP_DAQ_ALLOC_FREE and
+    XCP_DAQ_ALLOC_DAQ but answers ERR_SEQUENCE from XCP_DAQ_ALLOC_ODT (1.1/1.6.4.3.1.2). If the
+    ERR_OUT_OF_RANGE refusal below had advanced the state to ODT, the ALLOC_DAQ after it would
+    answer ERR_SEQUENCE instead of succeeding. daq_count leaves three lists unhanded-out, so that
+    follow-up ALLOC_DAQ succeeding turns on the state alone and not on any pool capacity left."""
+    handle = dynamic_handle(daq_count=4, odt_count=4)
+    exchange(handle, (0xD5, 0x00, 0x01, 0x00))
+    assert exchange(handle, (0xD4, 0x00, 0x01, 0x00, 0x01))[0:2] == (0xFE, 0x22)
+    assert exchange(handle, (0xD5, 0x00, 0x01, 0x00))[0] == 0xFF
+
+
+def test_alloc_odt_refused_by_sequence_does_not_reopen_the_odt_state():
+    """Design §9, precondition 1 of the running-list FIRST_PID argument, stated as a test.
+
+    That argument says a running list's FIRST_PID cannot move because Xcp_DaqRecomputeFirstPids
+    runs only from ALLOC_ODT, and ALLOC_ODT answers ERR_SEQUENCE from XCP_DAQ_ALLOC_ODT_ENTRY --
+    the state every list carrying an entry has passed through. It holds only while the refusal
+    itself leaves the state alone.
+
+    This is the exact sequence the argument breaks under: from ODT_ENTRY, a refused ALLOC_ODT that
+    nevertheless set the state to ODT would make the *next* ALLOC_ODT succeed, raise maxOdt, and
+    move FIRST_PID under a list that is already transmitting. The second ALLOC_ODT below is what
+    test_alloc_odt_entry_blocks_alloc_odt_once_reached stops short of sending, which is why that
+    test does not cover this and this one is not redundant with it. Only FREE_DAQ may reopen the
+    state, and the tail asserts it still does."""
+    handle = dynamic_handle(daq_count=1, odt_count=4, odt_entries_count=4)
+    exchange(handle, (0xD5, 0x00, 0x01, 0x00))
+    exchange(handle, (0xD4, 0x00, 0x00, 0x00, 0x01))
+    assert exchange(handle, (0xD3, 0x00, 0x00, 0x00, 0x00, 0x01))[0] == 0xFF
+
+    assert exchange(handle, (0xD4, 0x00, 0x00, 0x00, 0x01))[0:2] == (0xFE, 0x29)
+    assert exchange(handle, (0xD4, 0x00, 0x00, 0x00, 0x01))[0:2] == (0xFE, 0x29), \
+        'the refused ALLOC_ODT put the state back into XCP_DAQ_ALLOC_ODT'
+    assert handle.lib.Xcp_Ptr.config.daqList[0].maxOdt == 1, 'a refused ALLOC_ODT raised maxOdt'
+
+    # FREE_DAQ is still the only way back, so the refusals above are the state machine holding and
+    # not the command having become permanently unusable.
+    exchange(handle, (0xD6,))
+    exchange(handle, (0xD5, 0x00, 0x01, 0x00))
+    assert exchange(handle, (0xD4, 0x00, 0x00, 0x00, 0x01))[0] == 0xFF
 
 
 def test_alloc_odt_refuses_more_odts_than_one_list_may_hold():

--- a/test/alloc_odt_test.py
+++ b/test/alloc_odt_test.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import pytest
+
+from .parameter import *
+from .conftest import XcpTest
+from .download_test import connect
+
+
+def dynamic_handle(**kwargs):
+    handle = XcpTest(dynamic_config(**kwargs))
+    connect(handle)
+    return handle
+
+
+def exchange(handle, request, length=8):
+    handle.lib.Xcp_CanIfRxIndication(0x0001, handle.get_pdu_info(request))
+    handle.lib.Xcp_MainFunction()
+    handle.lib.Xcp_CanIfTxConfirmation(0x0002, handle.define('E_OK'))
+    return tuple(handle.can_if_transmit.call_args[0][1].SduDataPtr[0:length])
+
+
+def test_alloc_odt_assigns_contiguous_first_pids_whatever_the_allocation_order():
+    """DD31. Assigning PIDs in call order breaks under DD28's accumulate rule: ALLOC_ODT(0, 2),
+    ALLOC_ODT(1, 3), ALLOC_ODT(0, 1) leaves list 0 needing three contiguous PIDs when list 1
+    already owns 2..4. The absolute ODT number is firstPid + relative, so contiguity is required.
+    firstPid is therefore a prefix sum over list index, recomputed whenever an ODT count changes --
+    the same rule the generator applies to static lists."""
+    handle = dynamic_handle(daq_count=2, odt_count=4)
+    exchange(handle, (0xD5, 0x00, 0x02, 0x00))
+    exchange(handle, (0xD4, 0x00, 0x00, 0x00, 0x02))   # list 0 gets 2 ODTs
+    exchange(handle, (0xD4, 0x00, 0x01, 0x00, 0x03))   # list 1 gets 3
+    exchange(handle, (0xD4, 0x00, 0x00, 0x00, 0x01))   # list 0 gets 1 more, now 3
+    assert handle.lib.Xcp_Ptr.config.daqList[0].firstPid == 0
+    assert handle.lib.Xcp_Ptr.config.daqList[1].firstPid == 3   # not 2
+
+
+def test_alloc_odt_first_pid_blocks_never_overlap_read_back_through_the_protocol():
+    """DD31, the regression that rules out call-order assignment. ODTs are allocated to list 1
+    before list 0, and list 0 is then extended, so every call-order scheme -- handing out PIDs as
+    the requests arrive, or appending only the increment -- puts list 0's third ODT on top of a PID
+    list 1 already owns. START_STOP_DAQ_LIST is how a master reads FIRST_PID back
+    (1.1/1.6.4.1.1.4), so the assertion is made there rather than against the descriptor: mode STOP
+    reports it without requiring the list to be configured. List 2 is allocated but empty, and its
+    FIRST_PID is still the prefix sum -- it names where its first ODT would begin."""
+    handle = dynamic_handle(daq_count=3, odt_count=4)
+    exchange(handle, (0xD5, 0x00, 0x03, 0x00))
+    exchange(handle, (0xD4, 0x00, 0x01, 0x00, 0x03))   # list 1 first, 3 ODTs
+    exchange(handle, (0xD4, 0x00, 0x00, 0x00, 0x02))   # then list 0, 2 ODTs
+    exchange(handle, (0xD4, 0x00, 0x00, 0x00, 0x01))   # then list 0 again, now 3
+
+    first_pids = [exchange(handle, (0xDE, 0x00, daq, 0x00))[0:2] for daq in range(3)]
+
+    assert first_pids == [(0xFF, 0), (0xFF, 3), (0xFF, 6)]
+
+    # Spelt out as the property the numbers above stand for: each list's block of absolute ODT
+    # numbers is firstPid .. firstPid + maxOdt - 1, and no two blocks may share a number.
+    blocks = [set(range(pid, pid + odt_count))
+              for (_, pid), odt_count in zip(first_pids, (3, 3, 0))]
+    assert blocks[0] == {0, 1, 2}
+    assert blocks[1] == {3, 4, 5}
+    assert (blocks[0] & blocks[1]) == set()
+    assert blocks[2] == set()
+
+
+def test_alloc_odt_refuses_a_list_that_was_never_allocated():
+    handle = dynamic_handle(daq_count=4, odt_count=4)
+    exchange(handle, (0xD5, 0x00, 0x01, 0x00))
+    assert exchange(handle, (0xD4, 0x00, 0x01, 0x00, 0x01))[0:2] == (0xFE, 0x22)
+
+
+def test_alloc_odt_refuses_more_odts_than_one_list_may_hold():
+    handle = dynamic_handle(daq_count=1, odt_count=4)
+    exchange(handle, (0xD5, 0x00, 0x01, 0x00))
+    assert exchange(handle, (0xD4, 0x00, 0x00, 0x00, 0x05))[0:2] == (0xFE, 0x30)
+
+
+def test_alloc_odt_refuses_to_exhaust_the_pid_space():
+    """DD31. Slave-to-master PIDs 0xFC..0xFF are SERV, EV, ERR and RES, leaving 0x00..0xFB -- 252
+    absolute ODT numbers. Checked at runtime rather than at generation: guarding
+    daq_count * odt_count <= 252 in the template would reject configurations a master can use
+    perfectly well, since it rarely allocates the whole rectangle."""
+    handle = dynamic_handle(daq_count=2, odt_count=252)
+    exchange(handle, (0xD5, 0x00, 0x02, 0x00))
+    assert exchange(handle, (0xD4, 0x00, 0x00, 0x00, 0xFC))[0] == 0xFF     # 252 exactly
+    assert exchange(handle, (0xD4, 0x00, 0x01, 0x00, 0x01))[0:2] == (0xFE, 0x30)
+    assert handle.lib.Xcp_Ptr.config.daqList[0].maxOdt == 252               # unchanged
+
+
+def test_alloc_odt_ceiling_holds_where_a_uint8_total_would_wrap():
+    """DD31, and why the running total is accumulated in a uint16 rather than in the uint8 the ODT
+    counts themselves live in. With 252 ODTs already out, a second request for 252 clears the
+    per-list check -- odtCount is 252, and this list holds none yet -- and totals 504, which is 248
+    in a uint8: comfortably under the very ceiling it is being compared against. The request would
+    be admitted and the absolute ODT numbers it hands out would run through SERV, EV, ERR and RES.
+    The per-list check cannot stand in for this one; it is what makes the wrap reachable."""
+    handle = dynamic_handle(daq_count=2, odt_count=252)
+    exchange(handle, (0xD5, 0x00, 0x02, 0x00))
+    assert exchange(handle, (0xD4, 0x00, 0x00, 0x00, 0xFC))[0] == 0xFF
+    assert exchange(handle, (0xD4, 0x00, 0x01, 0x00, 0xFC))[0:2] == (0xFE, 0x30)
+    assert handle.lib.Xcp_Ptr.config.daqList[1].maxOdt == 0
+
+
+def test_alloc_odt_before_any_alloc_daq_is_a_sequence_error():
+    """DD28. ALLOC_ODT is accepted only from XCP_DAQ_ALLOC_DAQ or XCP_DAQ_ALLOC_ODT
+    (1.1/1.6.4.3.1.3). Nothing is allocated in the FREE state either, so ERR_OUT_OF_RANGE would
+    also be true of this request -- ERR_SEQUENCE wins because it is a statement about the command
+    stream rather than about this command's parameters."""
+    handle = dynamic_handle(daq_count=4, odt_count=4)
+    assert exchange(handle, (0xD4, 0x00, 0x00, 0x00, 0x01))[0:2] == (0xFE, 0x29)
+
+
+def test_alloc_daq_after_alloc_odt_is_a_sequence_error():
+    """DD28, and the half of Xcp_DTOCmdDaqAllocDaq's ERR_SEQUENCE branch nothing could reach until
+    ALLOC_ODT existed: XCP_DAQ_ALLOC_ODT is the first non-FREE, non-DAQ state the module can be
+    driven into. 1.1/1.6.4.3.1.2 lists an ALLOC_DAQ after an ALLOC_ODT among its ERR_SEQUENCE
+    cases; the master has to send FREE_DAQ before starting over."""
+    handle = dynamic_handle(daq_count=4, odt_count=4)
+    exchange(handle, (0xD5, 0x00, 0x02, 0x00))
+    exchange(handle, (0xD4, 0x00, 0x00, 0x00, 0x01))
+    assert exchange(handle, (0xD5, 0x00, 0x01, 0x00))[0:2] == (0xFE, 0x29)
+    # FREE_DAQ returns the state machine to FREE, so ALLOC_DAQ is accepted again.
+    exchange(handle, (0xD6,))
+    assert exchange(handle, (0xD5, 0x00, 0x01, 0x00))[0] == 0xFF
+
+
+def test_alloc_odt_restarts_the_prefix_sum_after_free_daq():
+    """FREE_DAQ zeroes maxOdt and firstPid across the pool (1.1/1.6.4.3.1.1), so a master that
+    starts over gets PIDs from 0 again rather than continuing the previous session's prefix sum.
+    A prefix sum recomputed from the descriptor is what makes that come out right without
+    FREE_DAQ having to know anything about PIDs."""
+    handle = dynamic_handle(daq_count=2, odt_count=4)
+    exchange(handle, (0xD5, 0x00, 0x02, 0x00))
+    exchange(handle, (0xD4, 0x00, 0x00, 0x00, 0x02))
+    exchange(handle, (0xD4, 0x00, 0x01, 0x00, 0x02))
+    assert handle.lib.Xcp_Ptr.config.daqList[1].firstPid == 2, 'the first session did not allocate'
+
+    exchange(handle, (0xD6,))
+    exchange(handle, (0xD5, 0x00, 0x02, 0x00))
+    exchange(handle, (0xD4, 0x00, 0x01, 0x00, 0x01))
+    assert handle.lib.Xcp_Ptr.config.daqList[0].maxOdt == 0
+    assert handle.lib.Xcp_Ptr.config.daqList[0].firstPid == 0
+    assert handle.lib.Xcp_Ptr.config.daqList[1].maxOdt == 1
+    assert handle.lib.Xcp_Ptr.config.daqList[1].firstPid == 0

--- a/test/cmd_unknown_test.py
+++ b/test/cmd_unknown_test.py
@@ -8,6 +8,19 @@ from .conftest import XcpTest
 from .download_test import connect
 
 
+def dynamic_handle(**kwargs):
+    handle = XcpTest(dynamic_config(**kwargs))
+    connect(handle)
+    return handle
+
+
+def exchange(handle, request, length=8):
+    handle.lib.Xcp_CanIfRxIndication(0x0001, handle.get_pdu_info(request))
+    handle.lib.Xcp_MainFunction()
+    handle.lib.Xcp_CanIfTxConfirmation(0x0002, handle.define('E_OK'))
+    return tuple(handle.can_if_transmit.call_args[0][1].SduDataPtr[0:length])
+
+
 @pytest.mark.parametrize('pid', tuple(pid for pid in range(0xC0, 0xE4) if pid not in (0xD7, 0xD8, 0xD9, 0xDA, 0xDB, 0xDD, 0xDE, 0xDF, 0xE0, 0xE1, 0xE2, 0xE3)))
 def test_unimplemented_commands_return_err_cmd_unknown(pid):
     """XCP part 2 - Protocol Layer Specification 1.0/1.4: an attempt to execute a not implemented
@@ -41,6 +54,15 @@ def test_unimplemented_commands_return_err_cmd_unknown(pid):
 
     assert handle.can_if_transmit.call_count == 1
     assert tuple(handle.can_if_transmit.call_args[0][1].SduDataPtr[0:2]) == (0xFE, 0x20)
+
+
+@pytest.mark.parametrize('pid', (0xD3, 0xD4, 0xD5, 0xD6))
+def test_the_dynamic_allocation_commands_are_known_in_a_dynamic_build(pid):
+    """The four are optional and answer ERR_CMD_UNKNOWN under a STATIC configuration, which the
+    test above pins. Under DYNAMIC they must not: a dynamic build with no way to allocate is what
+    the generator's own guard refuses."""
+    handle = dynamic_handle()
+    assert exchange(handle, (pid, 0x00, 0x00, 0x00, 0x00, 0x00))[0:2] != (0xFE, 0x20)
 
 
 @pytest.mark.parametrize('pid, flag', ((0xEF, 'xcp_download_next_api_enable'),

--- a/test/configuration_schema_test.py
+++ b/test/configuration_schema_test.py
@@ -95,3 +95,33 @@ def test_an_event_name_containing_a_quote_is_rejected(schema):
     source at worst -- so the schema has to refuse it before generation ever sees it."""
     with pytest.raises(jsonschema.ValidationError):
         validate(DefaultConfig(events=(event(name='EVT"10MS', triggered_daq_list_ref=['DAQ1']),)), schema)
+
+
+def test_a_dynamic_configuration_is_valid(schema):
+    """The DAQ_DYNAMIC half of the schema is reached by no other test here: every configuration
+    above is DAQ_STATIC, and the harness drives BSWCodeGen directly, so nothing would otherwise
+    check that the daq_dynamic block an integrator has to write is one the schema accepts."""
+    validate(dynamic_config(), schema)
+
+
+def test_a_dynamic_configuration_may_not_also_declare_daq_lists(schema):
+    """`daqs` is required by a static configuration and refused by a dynamic one, which is why it
+    is pinned by the schema's if/then/else rather than by the unconditional required list. The
+    generator refuses the same pair -- this is the half an integrator hits before generation."""
+    configuration = dynamic_config()
+    configuration['configurations'][0]['daqs'] = [daq()]
+
+    with pytest.raises(jsonschema.ValidationError):
+        validate(configuration, schema)
+
+
+def test_a_static_configuration_may_not_declare_a_dynamic_pool(schema):
+    """The mirror: a daq_dynamic block under DAQ_STATIC configures a pool nothing allocates from."""
+    configuration = DefaultConfig()
+    configuration['configurations'][0]['daq_dynamic'] = {"daq_count": 4,
+                                                         "odt_count": 8,
+                                                         "odt_entries_count": 16,
+                                                         "pdu_mapping": "XCP_PDU_ID_TRANSMIT"}
+
+    with pytest.raises(jsonschema.ValidationError):
+        validate(configuration, schema)

--- a/test/daq_configuration_test.py
+++ b/test/daq_configuration_test.py
@@ -206,7 +206,14 @@ def test_a_dynamic_pool_is_reserved_empty_and_sliced_per_list_and_per_odt():
     maxOdt is 0, not odt_count: an unallocated list must fail the bounds checks that already
     exist, which is what lets SP2d add none of its own (see the plan's global constraints).
     maxOdtEntries is the rectangle's width because that is the per-list cap the allocator may
-    never exceed, and nothing raises it at runtime."""
+    never exceed, and nothing raises it at runtime.
+
+    `number` is the exception to "starts empty": it is slot i's own index, seeded at build time
+    exactly as a static list's is, because ALLOC_DAQ hands out the first N slots of this pool in
+    order and so slot i is list number i whether or not it has been handed out. It used to be
+    zero here, which made every slot claim to be list 0 and broke GET_DAQ_ID's scan over this
+    field -- see
+    test/transport_layer_cmd_test.py::test_get_daq_id_answers_each_allocated_dynamic_list_by_its_own_number."""
     handle = XcpTest(dynamic_config(daq_count=3, odt_count=2, odt_entries_count=4))
     config = handle.config.lib.Xcp[0].config
     first_odt = config.daqList[0].odt
@@ -215,7 +222,7 @@ def test_a_dynamic_pool_is_reserved_empty_and_sliced_per_list_and_per_odt():
     assert config.daqListCount == 3
     for i in range(3):
         daq_list = config.daqList[i]
-        assert daq_list.number == 0
+        assert daq_list.number == i
         assert daq_list.firstPid == 0
         assert daq_list.maxOdt == 0
         assert daq_list.maxOdtEntries == 4

--- a/test/daq_configuration_test.py
+++ b/test/daq_configuration_test.py
@@ -629,6 +629,20 @@ def test_generation_fails_when_an_event_has_an_empty_triggered_daq_list_ref():
                               events=(event(name='EVT1', triggered_daq_list_ref=[]),)))
 
 
+def test_generation_fails_when_a_dynamic_pool_holds_no_daq_lists():
+    """The DAQ_DYNAMIC half of the guard above, which is one guard on daq_list_ref_count rather
+    than two. daq_count's schema minimum is 0 and every event channel references the whole pool,
+    so daq_count 0 emits the same zero-length Xcp_EventChannelDaqListRef0000[0x00u] that an empty
+    triggered_daq_list_ref does under DAQ_STATIC.
+
+    Not about the ODT and ODT-entry arrays, which daq_count 0 also makes zero-length: `max_odt: 0`
+    has always been allowed to do that, and source/Xcp_Daq.c documents it above Xcp_OdtUsedBytes
+    as tolerated. This asserts only the event-channel array, which the static configuration has
+    always been refused for."""
+    with pytest.raises(UndefinedError):
+        XcpTest(dynamic_config(daq_count=0))
+
+
 def test_generation_fails_when_write_daq_multiple_is_enabled_with_max_cto_below_ten():
     """1.6.4.1.2.1: 'If the optional command WRITE_DAQ_MULTIPLE is used, the requirement
     MAX_CTO >= 10 has to be fulfilled.' A single element is 8 bytes after a 2-byte header, so a

--- a/test/daq_configuration_test.py
+++ b/test/daq_configuration_test.py
@@ -162,6 +162,18 @@ def test_odt_entries_start_with_a_cleared_address_extension():
     assert handle.config.lib.Xcp[0].config.daqList[0].odt[0].odtEntry[1].addressExtension == 0
 
 
+def test_each_odt_carries_its_own_entry_count_seeded_from_the_list_cap():
+    """DD34. ALLOC_ODT_ENTRY assigns entries to one ODT, so a per-ODT count is needed; the
+    per-list maxOdtEntries cannot express one ODT holding four entries and another two. Under
+    STATIC every ODT is seeded with the list's max_odt_entries, which is what keeps the six
+    relocated bound checks comparing against the value they compared against before."""
+    handle = XcpTest(DefaultConfig(daqs=(daq(name='DAQ1', max_odt=3, max_odt_entries=9),)))
+    daq_list = handle.config.lib.Xcp[0].config.daqList[0]
+    assert daq_list.maxOdtEntries == 9
+    for odt in range(3):
+        assert daq_list.odt[odt].entryCount == 9
+
+
 def test_event_channels_are_generated_rather_than_left_null():
     handle = XcpTest(DefaultConfig(daqs=(daq(name='DAQ1', max_odt=1), daq(name='DAQ2', max_odt=1))))
 

--- a/test/daq_configuration_test.py
+++ b/test/daq_configuration_test.py
@@ -49,12 +49,34 @@ def test_prescaler_support_comes_from_the_configuration():
     assert XcpTest(DefaultConfig(prescaler_supported=False)).config.lib.Xcp[0].general.prescalerSupported == 0
 
 
-def test_odt_counts_are_summed_over_every_daq_list():
-    handle = XcpTest(DefaultConfig(daqs=(daq(name='DAQ1', max_odt=3, max_odt_entries=9),
-                                         daq(name='DAQ2', max_odt=5, max_odt_entries=10))))
+def test_a_dynamic_configuration_reports_its_pool_through_the_autosar_parameters():
+    """DD26. XcpDaqCount (ECUC_Xcp_00012) is the number of allocatable lists, XcpOdtCount
+    (ECUC_Xcp_00054) the ODTs of a DAQ list, XcpOdtEntriesCount (ECUC_Xcp_00059) the entries into
+    an ODT. All three are defined only for DAQ_DYNAMIC."""
+    handle = XcpTest(dynamic_config(daq_count=4, odt_count=8, odt_entries_count=16))
+    general = handle.config.lib.Xcp[0].general
 
-    assert handle.config.lib.Xcp[0].general.odtCount == 3 + 5
-    assert handle.config.lib.Xcp[0].general.odtEntriesCount == (3 * 9) + (5 * 10)
+    # handle.lib, not handle.define: DAQ_DYNAMIC and DAQ_STATIC are Xcp_DaqConfigTypeType
+    # enumerators (interface/Xcp_Types.h), not preprocessor names, and handle.define only ever
+    # sees literal `#define`s -- see test.conftest.Preprocessor.on_directive_handle.
+    assert general.daqConfigType == handle.lib.DAQ_DYNAMIC
+    assert general.daqCount == 4
+    assert general.odtCount == 8
+    assert general.odtEntriesCount == 16
+
+
+def test_a_static_configuration_leaves_the_dynamic_only_parameters_at_zero():
+    """AUTOSAR defines XcpOdtCount and XcpOdtEntriesCount only for DAQ_DYNAMIC. The generator
+    previously emitted aggregate sums here -- the total ODTs across all lists, and the grand total
+    of entries -- which is neither field's meaning. No .c file read either one, so this corrects a
+    latent wrong value rather than changing behaviour."""
+    handle = XcpTest(DefaultConfig(daqs=(daq(name='DAQ1', max_odt=3, max_odt_entries=9),)))
+    general = handle.config.lib.Xcp[0].general
+
+    assert general.daqConfigType == handle.lib.DAQ_STATIC
+    assert general.daqCount == 1
+    assert general.odtCount == 0
+    assert general.odtEntriesCount == 0
 
 
 def test_min_daq_is_zero_because_no_daq_list_is_predefined():
@@ -172,6 +194,120 @@ def test_each_odt_carries_its_own_entry_count_seeded_from_the_list_cap():
     assert daq_list.maxOdtEntries == 9
     for odt in range(3):
         assert daq_list.odt[odt].entryCount == 9
+
+
+def test_a_dynamic_pool_is_reserved_empty_and_sliced_per_list_and_per_odt():
+    """DD26. The rectangle -- daq_count x odt_count x odt_entries_count -- is reserved in full at
+    build time and handed out by the allocator, so every descriptor starts empty while the slices
+    ALLOC_ODT and ALLOC_ODT_ENTRY will fill are already wired: list i owns the ODTs
+    [i*odt_count, (i+1)*odt_count) of one flat array, and ODT k owns the entries
+    [k*odt_entries_count, (k+1)*odt_entries_count) of another.
+
+    maxOdt is 0, not odt_count: an unallocated list must fail the bounds checks that already
+    exist, which is what lets SP2d add none of its own (see the plan's global constraints).
+    maxOdtEntries is the rectangle's width because that is the per-list cap the allocator may
+    never exceed, and nothing raises it at runtime."""
+    handle = XcpTest(dynamic_config(daq_count=3, odt_count=2, odt_entries_count=4))
+    config = handle.config.lib.Xcp[0].config
+    first_odt = config.daqList[0].odt
+    first_entry = config.daqList[0].odt[0].odtEntry
+
+    assert config.daqListCount == 3
+    for i in range(3):
+        daq_list = config.daqList[i]
+        assert daq_list.number == 0
+        assert daq_list.firstPid == 0
+        assert daq_list.maxOdt == 0
+        assert daq_list.maxOdtEntries == 4
+        assert daq_list.type == handle.lib.DAQ
+        assert daq_list.odt == first_odt + (i * 2)
+        for j in range(2):
+            odt = daq_list.odt[j]
+            assert odt.odtNumber == 0
+            assert odt.entryCount == 0
+            # max_dto 8 less the 1-byte ABSOLUTE identification field, DefaultConfig's own defaults.
+            assert odt.odtEntryMaxSize == 7
+            assert odt.odtEntry == first_entry + ((((i * 2) + j) * 4))
+
+
+def test_a_dynamic_pool_shares_one_dto_across_every_list_in_it():
+    """Every list in the pool transmits on the one pdu_mapping the daq_dynamic block names -- the
+    master picks which lists it allocates, not which PDU they leave on -- so one Xcp_DtoType
+    serves them all. dtoCount stays 1 rather than 0 because Xcp_Std.c guards its read of dto[0]
+    with `dtoCount > 0` and Xcp_DaqRuntime.c reads dto[0] to address the frame."""
+    handle = XcpTest(dynamic_config(daq_count=3))
+    config = handle.config.lib.Xcp[0].config
+
+    for i in range(3):
+        assert config.daqList[i].dtoCount == 1
+        assert config.daqList[i].dto == config.daqList[0].dto
+
+
+def _generated_source(config):
+    """The Xcp_Cfg.c `config` generates, as text. Which MemMap section a declaration sits in is
+    invisible to the compiled harness -- Xcp_MemMap.h expands to nothing here -- so the generated
+    source is the only place it can be observed."""
+    return BSWCodeGen(config, os.environ['script_directory']).source_cfg
+
+
+def _generated_runtime(config):
+    """The Xcp_Rt.c `config` generates, as text."""
+    return BSWCodeGen(config, os.environ['script_directory']).source_rt
+
+
+def _memmap_section_of(source, declaration):
+    """The Xcp_START_SEC_... section `declaration` is emitted inside, or None if it is absent."""
+    section = None
+    for line in source.splitlines():
+        if line.startswith('#define Xcp_START_SEC_'):
+            section = line.split()[1]
+        elif declaration in line:
+            return section
+    return None
+
+
+def test_a_dynamic_pool_is_emitted_into_a_writable_memmap_section():
+    """ALLOC_DAQ, ALLOC_ODT and ALLOC_ODT_ENTRY write the Xcp_DaqListType and Xcp_OdtType arrays
+    at runtime, so under DAQ_DYNAMIC they cannot sit in Xcp_START_SEC_CONST_UNSPECIFIED -- that is
+    the section that puts them in flash on a target, and the `const` keyword the arrays lack is
+    not what places them (see the note above Xcp_DaqListType in interface/Xcp_Types.h)."""
+    source = _generated_source(dynamic_config())
+
+    assert _memmap_section_of(source, 'static Xcp_DaqListType Xcp_DaqListConfig00[') == \
+        'Xcp_START_SEC_VAR_FAST_POWER_ON_INIT_UNSPECIFIED'
+    assert _memmap_section_of(source, 'static Xcp_OdtType Xcp_OdtConfig00[') == \
+        'Xcp_START_SEC_VAR_FAST_POWER_ON_INIT_UNSPECIFIED'
+
+
+@pytest.mark.parametrize('config, expected', (
+    pytest.param(lambda: dynamic_config(daq_count=7), 'Xcp_DaqListRt00[0x07u];', id='DYNAMIC pool of 7'),
+    pytest.param(lambda: DefaultConfig(daqs=(daq(name='DAQ1'), daq(name='DAQ2'))),
+                 'Xcp_DaqListRt00[0x02u];', id='STATIC, two lists'),
+))
+def test_the_runtime_daq_list_array_is_sized_for_every_list_the_configuration_can_present(config,
+                                                                                          expected):
+    """Xcp_Init and Xcp_TriggerEventChannel both index Xcp_Rt[...].daqList by daqCount
+    (source/Xcp.c, source/Xcp_DaqRuntime.c), which under DAQ_DYNAMIC is the pool size and not the
+    number of lists declared under `daqs` -- of which a dynamic configuration has none. An array
+    sized from `daqs` is therefore written past its end by Xcp_Init before the master has
+    allocated anything.
+
+    Asserted against the generated text rather than through a running module because the array is
+    a file-scope static: nothing in the harness can reach it to bound-check it, and the
+    out-of-bounds write it would take to expose the bug is silent unless the suite is run under
+    XCP_ASAN=1, which it is not by default (test/conftest.py's _asan_flags)."""
+    assert expected in _generated_runtime(config())
+
+
+def test_a_static_configuration_keeps_its_descriptors_in_the_const_section():
+    """The other half of the test above: nothing writes a STATIC configuration's descriptors, so
+    they must stay in flash exactly as they are today."""
+    source = _generated_source(DefaultConfig())
+
+    assert _memmap_section_of(source, 'static Xcp_DaqListType Xcp_DaqListConfig00[') == \
+        'Xcp_START_SEC_CONST_UNSPECIFIED'
+    assert _memmap_section_of(source, 'static Xcp_OdtType Xcp_OdtConfig00Daq00[') == \
+        'Xcp_START_SEC_CONST_UNSPECIFIED'
 
 
 def test_event_channels_are_generated_rather_than_left_null():
@@ -508,3 +644,83 @@ def test_generation_fails_when_publish_names_is_set_but_an_event_has_no_name():
     inventing a name that would paper over a real integrator misconfiguration."""
     with pytest.raises(UndefinedError):
         XcpTest(DefaultConfig(publish_names=True, events=(event(triggered_daq_list_ref=['DAQ1']),)))
+
+
+@pytest.mark.parametrize('config, why', (
+    pytest.param(lambda: dynamic_config(daq_count=256, odt_count=1, odt_entries_count=1),
+                 'daq_count above the uint8 MAX_DAQ_LIST field',
+                 id='daq_count = 256'),
+    pytest.param(lambda: DefaultConfig(xcp_free_daq_api_enable=True),
+                 'FREE_DAQ enabled under a STATIC configuration',
+                 id='FREE_DAQ under STATIC'),
+    pytest.param(lambda: DefaultConfig(daq_config_type='DYNAMIC',
+                                       xcp_free_daq_api_enable=True,
+                                       xcp_alloc_daq_api_enable=False,
+                                       xcp_alloc_odt_api_enable=True,
+                                       xcp_alloc_odt_entry_api_enable=True),
+                 'ALLOC_DAQ disabled under DYNAMIC',
+                 id='ALLOC_DAQ disabled under DYNAMIC'),
+))
+def test_generation_refuses_incoherent_dynamic_configurations(config, why):
+    """The guard messages are documentation, not output: raise() is not a registered Jinja global
+    in bsw_code_gen, so referencing it aborts rendering with UndefinedError and the string never
+    reaches the caller. These assert that generation fails, never that a message matches -- the
+    same reasoning as the cluster of guard tests above, whose comment explains why UndefinedError
+    is still worth naming instead of a bare Exception.
+
+    The first row goes through dynamic_config so that daq_count is the *only* thing wrong with it:
+    built from a bare DefaultConfig it would trip the ALLOC-APIs-disabled guard as well, and pass
+    for a reason that has nothing to do with the ceiling it is named after. The other two rows are
+    the opposite case -- what is wrong with them is which API flags are set, so they have to set
+    those flags themselves rather than let the helper supply a coherent set."""
+    with pytest.raises(UndefinedError):
+        XcpTest(config())
+
+
+def test_generation_accepts_the_largest_dynamic_pool_the_uint8_max_daq_list_field_can_hold():
+    """The boundary above, from the accepting side: 255 lists are representable in the uint8
+    MAX_DAQ_LIST byte GET_DAQ_EVENT_INFO transmits, so the guard is `> 255` and not `>= 255`."""
+    handle = XcpTest(dynamic_config(daq_count=255, odt_count=1, odt_entries_count=1))
+
+    assert handle.config.lib.Xcp[0].general.daqCount == 255
+    assert handle.config.lib.Xcp[0].config.daqListCount == 255
+    assert handle.config.lib.Xcp[0].config.eventChannel[0].maxDaqList == 255
+
+
+@pytest.mark.parametrize('count', (8, 16))
+def test_the_daq_list_count_is_emitted_as_a_hexadecimal_literal(count):
+    """script/source_cfg.c.jinja2 emitted daqListCount as '%04Xu' -- with no 0x -- which makes a
+    leading-zero literal OCTAL. One and two DAQ lists are the same number in octal as in hex, and
+    no configuration in the suite had ever declared more, so nothing showed it: 8 is not a valid
+    octal constant at all (the build fails), and 16 emits 0010u, which is octal 8 -- a module that
+    silently reports half its DAQ lists to the GET_DAQ_ID scan in source/Xcp_Std.c, the one place
+    that reads this field. A 255-list dynamic pool emitted 00FFu and would not compile, which is
+    what found it; both counts here are pinned because the two failure modes are different."""
+    handle = XcpTest(DefaultConfig(daqs=tuple(daq(name='DAQ{}'.format(i)) for i in range(count)),
+                                   events=(event(name='EVT1', triggered_daq_list_ref=['DAQ0']),)))
+
+    assert handle.config.lib.Xcp[0].config.daqListCount == count
+
+
+def test_generation_refuses_daq_lists_declared_alongside_a_dynamic_pool():
+    """A DAQ_DYNAMIC configuration declares no lists -- the master allocates them out of the pool
+    -- so a `daqs` entry is an integrator saying two incompatible things at once. Silently
+    ignoring it would leave them believing they had configured a list that will never exist."""
+    config = dynamic_config()
+    config['configurations'][0]['daqs'] = [daq(name='DAQ1')]
+
+    with pytest.raises(UndefinedError):
+        XcpTest(config)
+
+
+def test_generation_refuses_a_dynamic_pool_declared_under_a_static_configuration():
+    """The mirror of the test above. A `daq_dynamic` block under DAQ_STATIC configures a pool
+    nothing will ever allocate from, and its dimensions would silently go nowhere."""
+    config = DefaultConfig()
+    config['configurations'][0]['daq_dynamic'] = {"daq_count": 4,
+                                                  "odt_count": 8,
+                                                  "odt_entries_count": 16,
+                                                  "pdu_mapping": "XCP_PDU_ID_TRANSMIT"}
+
+    with pytest.raises(UndefinedError):
+        XcpTest(config)

--- a/test/daq_dynamic_acceptance_test.py
+++ b/test/daq_dynamic_acceptance_test.py
@@ -21,6 +21,57 @@ def exchange(handle, request, length=8):
     return tuple(handle.can_if_transmit.call_args[0][1].SduDataPtr[0:length])
 
 
+def queued_frames(handle):
+    """Every frame currently in the ring, oldest first, as bytes. See
+    test/daq_identification_field_test.py and test/daq_concurrency_test.py for why reading
+    Xcp_Rt[...].dtoQueue directly needs no test-only surface in the module under test."""
+    queue = handle.lib.Xcp_Rt[handle.lib.Xcp_Ptr.xcpRtRef].dtoQueue
+    frames = list()
+    index = queue.read
+    for _ in range(queue.count):
+        frame = queue.frame[index]
+        frames.append(bytes(frame.data[0:frame.length]))
+        index = (index + 1) % queue.depth
+    return frames
+
+
+#: One canonical request per allocation command, reused by both the state-reaching helper below
+#: and the sweep it feeds. Each names list 0 (and, for ALLOC_ODT_ENTRY, ODT 0) and asks for
+#: exactly one more unit than it already holds, so the same literal works whether it is the request
+#: that reaches a state or the request the sweep fires from it -- accumulating by one is what DD28
+#: permits from every state a command is accepted from.
+_ALLOC_REQUEST = {
+    'FREE_DAQ': (0xD6,),
+    'ALLOC_DAQ': (0xD5, 0x00, 0x01, 0x00),
+    'ALLOC_ODT': (0xD4, 0x00, 0x00, 0x00, 0x01),
+    'ALLOC_ODT_ENTRY': (0xD3, 0x00, 0x00, 0x00, 0x00, 0x01),
+}
+
+
+def reach_state(handle, state):
+    """Drives the allocation state machine to `state` through the protocol alone, exactly as a
+    real master would: FREE is FREE_DAQ; DAQ is FREE then ALLOC_DAQ; ODT is DAQ then ALLOC_ODT;
+    ODT_ENTRY is ODT then ALLOC_ODT_ENTRY. Xcp_Internal.daq_alloc_state itself has no test-reachable
+    surface -- Xcp_Internal is declared in source/Xcp_Internal.h, which interface/Xcp.h does not
+    include (see test/free_daq_test.py's allocate_directly for the same limitation) -- so walking
+    the commands is the only way to reach a given cell of the sweep below.
+
+    Each step asserts its own success rather than trusting the next command's response to reveal a
+    broken setup indirectly: a transition that silently failed here would otherwise misreport as a
+    failure of a *different*, unrelated cell three states later."""
+    assert exchange(handle, _ALLOC_REQUEST['FREE_DAQ'])[0] == 0xFF
+    if state == 'FREE':
+        return
+    assert exchange(handle, _ALLOC_REQUEST['ALLOC_DAQ'])[0] == 0xFF
+    if state == 'DAQ':
+        return
+    assert exchange(handle, _ALLOC_REQUEST['ALLOC_ODT'])[0] == 0xFF
+    if state == 'ODT':
+        return
+    assert exchange(handle, _ALLOC_REQUEST['ALLOC_ODT_ENTRY'])[0] == 0xFF
+    assert state == 'ODT_ENTRY', 'unknown state {!r}'.format(state)
+
+
 def test_a_dynamic_build_has_no_valid_daq_lists_until_alloc_daq():
     """DD32. The spec's ALLOC_ODT range [MIN_DAQ, MIN_DAQ+DAQ_COUNT-1] is over what ALLOC_DAQ
     allocated, not over the configured pool, so a list inside the pool but not yet allocated is
@@ -29,3 +80,143 @@ def test_a_dynamic_build_has_no_valid_daq_lists_until_alloc_daq():
     handle = dynamic_handle(daq_count=4)
     # CLEAR_DAQ_LIST on list 0, which the pool has room for but nothing has allocated.
     assert exchange(handle, (0xE3, 0x00, 0x00, 0x00))[0:2] == (0xFE, 0x22)
+
+
+# Four states (FREE, DAQ, ODT, ODT_ENTRY) times four commands (FREE_DAQ, ALLOC_DAQ, ALLOC_ODT,
+# ALLOC_ODT_ENTRY). Ten cells are accepted (0xFF); the six the specification enumerates as
+# ERR_SEQUENCE answer 0x29 (XCP_E_ASAM_SEQUENCE) -- no more, no fewer. `ids=lambda v: str(v)`
+# stringifies state, command and expected individually and joins them, so a failing case names
+# itself as e.g. "ODT-ALLOC_DAQ-41" rather than a bare parametrize index.
+@pytest.mark.parametrize('state, command, expected', (
+    ('FREE',      'FREE_DAQ',        0xFF), ('FREE',      'ALLOC_DAQ',       0xFF),
+    ('FREE',      'ALLOC_ODT',       0x29), ('FREE',      'ALLOC_ODT_ENTRY', 0x29),
+    ('DAQ',       'FREE_DAQ',        0xFF), ('DAQ',       'ALLOC_DAQ',       0xFF),
+    ('DAQ',       'ALLOC_ODT',       0xFF), ('DAQ',       'ALLOC_ODT_ENTRY', 0x29),
+    ('ODT',       'FREE_DAQ',        0xFF), ('ODT',       'ALLOC_DAQ',       0x29),
+    ('ODT',       'ALLOC_ODT',       0xFF), ('ODT',       'ALLOC_ODT_ENTRY', 0xFF),
+    ('ODT_ENTRY', 'FREE_DAQ',        0xFF), ('ODT_ENTRY', 'ALLOC_DAQ',       0x29),
+    ('ODT_ENTRY', 'ALLOC_ODT',       0x29), ('ODT_ENTRY', 'ALLOC_ODT_ENTRY', 0xFF),
+), ids=lambda v: str(v))
+def test_the_allocation_sequence_refuses_exactly_what_the_specification_enumerates(state, command,
+                                                                                   expected):
+    """DD28. 1.1/1.6.4.3.1 enumerates six ERR_SEQUENCE cases and no others. The initial state is
+    FREE: §1.6.4.3.1.1 requires the master to send FREE_DAQ first, but that is a requirement on
+    the master, and a refusal absent from the enumerated list is not the slave's to invent.
+
+    The pool (4 DAQ lists, 4 ODTs, 4 ODT entries) is sized generously above what any single cell
+    needs: reach_state grants at most one DAQ list, one ODT and one ODT entry, and the most any
+    accepted command adds on top of that is one more of the same -- so every accepted cell here
+    genuinely succeeds (asserted as response[0] == 0xFF, not merely as "not ERR_SEQUENCE"; an
+    accepted cell that actually hit ERR_MEMORY_OVERFLOW because the pool ran out would still be a
+    broken test even though 0x30 != 0x29)."""
+    handle = dynamic_handle(daq_count=4, odt_count=4, odt_entries_count=4)
+    reach_state(handle, state)
+
+    response = exchange(handle, _ALLOC_REQUEST[command])
+
+    if expected == 0xFF:
+        assert response[0] == 0xFF
+    else:
+        assert response[0:2] == (0xFE, expected)
+
+
+def test_the_allocation_sequence_end_to_end_reaches_a_sampled_frame():
+    """The round trip a real master relies on, and what no other test proves: alloc_daq_test.py,
+    alloc_odt_test.py and alloc_odt_entry_test.py each prove their own command in isolation, but
+    none of them shows the pool they allocate out of is actually usable end to end. FREE_DAQ,
+    ALLOC_DAQ, ALLOC_ODT and ALLOC_ODT_ENTRY build one list with one ODT and one entry; SET_DAQ_PTR
+    and WRITE_DAQ configure that entry; SET_DAQ_LIST_MODE and START_STOP_DAQ_LIST bring the list
+    into data transfer mode; a trigger samples it. If any one of those steps did not genuinely work
+    the way its own dedicated test says it does, this is the test that would notice."""
+    handle = dynamic_handle(daq_count=1, odt_count=1, odt_entries_count=1)
+    handle.xcp_read_slave_memory_u8.side_effect = lambda a, e, b: b.__setitem__(0, 0xA5)
+
+    assert exchange(handle, (0xD6,))[0] == 0xFF                             # FREE_DAQ
+    assert exchange(handle, (0xD5, 0x00, 0x01, 0x00))[0] == 0xFF            # ALLOC_DAQ(1)
+    assert exchange(handle, (0xD4, 0x00, 0x00, 0x00, 0x01))[0] == 0xFF      # ALLOC_ODT(list 0, 1)
+    assert exchange(handle, (0xD3, 0x00, 0x00, 0x00, 0x00, 0x01))[0] == 0xFF  # ALLOC_ODT_ENTRY(list 0, odt 0, 1)
+    assert exchange(handle, (0xE2, 0x00, 0x00, 0x00, 0x00, 0x00))[0] == 0xFF  # SET_DAQ_PTR(list 0, odt 0, entry 0)
+    assert exchange(handle, (0xE1, 0xFF, 0x01, 0x00) +
+                    tuple(u32_to_array(0x1000, 'LITTLE_ENDIAN')))[0] == 0xFF  # WRITE_DAQ(1 byte)
+    # SET_DAQ_LIST_MODE(list 0, event channel 0, prescaler 1, priority 0).
+    assert exchange(handle, (0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00))[0] == 0xFF
+    assert exchange(handle, (0xDE, 0x01, 0x00, 0x00))[0] == 0xFF            # START_STOP_DAQ_LIST(START, list 0)
+
+    handle.lib.Xcp_TriggerEventChannel(0)
+
+    frames = queued_frames(handle)
+    assert len(frames) == 1, 'one non-empty ODT samples to exactly one frame'
+    first_pid = handle.lib.Xcp_Ptr.config.daqList[0].firstPid
+    assert frames[0][0] == first_pid, 'absolute ODT number: FIRST_PID + relative ODT 0'
+    assert frames[0][1] == 0xA5, 'the sampled payload'
+
+    assert exchange(handle, (0xDE, 0x00, 0x00, 0x00))[0] == 0xFF            # START_STOP_DAQ_LIST(STOP, list 0)
+
+
+def test_clear_daq_list_clears_entries_without_releasing_the_allocation():
+    """Spec §6: CLEAR_DAQ_LIST and FREE_DAQ stay distinct. CLEAR_DAQ_LIST clears one list's
+    entries and keeps its allocation; only FREE_DAQ releases it. Both call Xcp_DaqListReset, so
+    this is what stops that shared helper from being given FREE_DAQ's deallocation as well.
+
+    An entry is actually written before the clear, and its power-up-reset is asserted alongside
+    the surviving allocation: the docstring's own name promises both halves ("clears entries"
+    *and* "without releasing the allocation"), and a version that only checked the second half
+    would not notice CLEAR_DAQ_LIST silently stopping short of Xcp_DaqListClearEntries."""
+    handle = dynamic_handle(daq_count=1, odt_count=1, odt_entries_count=1)
+    exchange(handle, (0xD5, 0x00, 0x01, 0x00))
+    exchange(handle, (0xD4, 0x00, 0x00, 0x00, 0x01))
+    exchange(handle, (0xD3, 0x00, 0x00, 0x00, 0x00, 0x01))
+    assert exchange(handle, (0xE2, 0x00, 0x00, 0x00, 0x00, 0x00))[0] == 0xFF
+    assert exchange(handle, (0xE1, 0xFF, 0x01, 0x00) +
+                    tuple(u32_to_array(0xDEADBEEF, 'LITTLE_ENDIAN')))[0] == 0xFF
+
+    assert exchange(handle, (0xE3, 0x00, 0x00, 0x00))[0] == 0xFF
+
+    # The entry is back to its power-up state ...
+    entry = handle.lib.Xcp_Ptr.config.daqList[0].odt[0].odtEntry[0]
+    assert entry.address == handle.ffi.NULL
+    assert entry.length == 0
+    # ... but the allocation itself -- the list is still valid and still has its ODT and entry
+    # slot -- survived.
+    assert handle.lib.Xcp_Ptr.config.daqList[0].maxOdt == 1
+    assert handle.lib.Xcp_Ptr.config.daqList[0].odt[0].entryCount == 1
+    assert exchange(handle, (0xE3, 0x00, 0x00, 0x00))[0] == 0xFF
+
+
+def test_set_daq_ptr_is_refused_on_a_list_the_master_never_allocated():
+    """Spec §6 and DD32: no new bounds check was added for this. maxOdt is zero until ALLOC_ODT,
+    so the check already in SET_DAQ_PTR refuses it."""
+    handle = dynamic_handle(daq_count=2, odt_count=2, odt_entries_count=2)
+    exchange(handle, (0xD5, 0x00, 0x01, 0x00))
+    assert exchange(handle, (0xE2, 0x00, 0x00, 0x00, 0x00, 0x00))[0:2] == (0xFE, 0x22)
+
+
+def test_get_daq_list_info_reports_the_allocated_shape_not_the_configured_one():
+    """Spec §6: GET_DAQ_LIST_INFO reads the descriptor, so it reports runtime MAX_ODT with no
+    change. Before ALLOC_ODT the list holds no ODTs, and that is what it must say."""
+    handle = dynamic_handle(daq_count=1, odt_count=8, odt_entries_count=4)
+    exchange(handle, (0xD5, 0x00, 0x01, 0x00))
+    assert exchange(handle, (0xD8, 0x00, 0x00, 0x00))[2] == 0x00
+    exchange(handle, (0xD4, 0x00, 0x00, 0x00, 0x03))
+    assert exchange(handle, (0xD8, 0x00, 0x00, 0x00))[2] == 0x03
+
+
+@pytest.mark.parametrize('daq_count, accepted', ((1, True), (2, False)))
+def test_pid_off_under_dynamic_follows_the_shared_tx_pdu_rule(daq_count, accepted):
+    """Spec §6. script/source_cfg.c.jinja2 gives an entire dynamic pool exactly one DTO/PDU
+    mapping ("One DTO for the whole dynamic pool, not one per list ... every list in the pool
+    shares this element"), so SP2b's rule, Xcp_DaqListTxPduIsExclusive, applies unchanged but its
+    loop walks the *configured* pool (Xcp_Ptr->general->daqCount) rather than the allocated count
+    -- every pool slot, allocated or not, already carries the one shared mapping. The
+    discriminator this test sweeps is therefore the pool's own size, not how many lists ALLOC_DAQ
+    has handed out: a lone list in a one-list pool is exclusive by construction, while a second,
+    even unallocated, slot in a two-list pool already shares the PDU. With one CAN-ID and several
+    lists, §1.1.2.1 identification genuinely cannot be recovered without a PID, so refusing it is
+    honest rather than restrictive."""
+    handle = dynamic_handle(daq_count=daq_count, odt_count=1, odt_entries_count=1,
+                            identification_field_type='ABSOLUTE')
+    exchange(handle, (0xD5, 0x00, 0x01, 0x00))
+    exchange(handle, (0xD4, 0x00, 0x00, 0x00, 0x01))
+    # SET_DAQ_LIST_MODE with PID_OFF (bit 5) on list 0, event channel 0, prescaler 1, priority 0.
+    result = exchange(handle, (0xE0, 0x20, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00))
+    assert (result[0] == 0xFF) == accepted

--- a/test/daq_dynamic_acceptance_test.py
+++ b/test/daq_dynamic_acceptance_test.py
@@ -146,8 +146,11 @@ def test_the_allocation_sequence_end_to_end_reaches_a_sampled_frame():
 
     frames = queued_frames(handle)
     assert len(frames) == 1, 'one non-empty ODT samples to exactly one frame'
-    first_pid = handle.lib.Xcp_Ptr.config.daqList[0].firstPid
-    assert frames[0][0] == first_pid, 'absolute ODT number: FIRST_PID + relative ODT 0'
+    # 0, not the descriptor's firstPid: the sampler computes this byte from that very field, so
+    # comparing the two could not tell a correct FIRST_PID from a wrong one. The literal is what
+    # pins the prefix sum -- the first and only allocated list starts the PID space at 0, and its
+    # relative ODT 0 is therefore absolute ODT 0.
+    assert frames[0][0] == 0x00, 'absolute ODT number: FIRST_PID + relative ODT 0'
     assert frames[0][1] == 0xA5, 'the sampled payload'
 
     assert exchange(handle, (0xDE, 0x00, 0x00, 0x00))[0] == 0xFF            # START_STOP_DAQ_LIST(STOP, list 0)
@@ -177,18 +180,36 @@ def test_clear_daq_list_clears_entries_without_releasing_the_allocation():
     assert entry.address == handle.ffi.NULL
     assert entry.length == 0
     # ... but the allocation itself -- the list is still valid and still has its ODT and entry
-    # slot -- survived.
+    # slot -- survived. A repeat of the CLEAR_DAQ_LIST above used to close this test; it was
+    # byte-identical to that line and implied by the two assertions here, so it is gone.
     assert handle.lib.Xcp_Ptr.config.daqList[0].maxOdt == 1
     assert handle.lib.Xcp_Ptr.config.daqList[0].odt[0].entryCount == 1
-    assert exchange(handle, (0xE3, 0x00, 0x00, 0x00))[0] == 0xFF
 
 
 def test_set_daq_ptr_is_refused_on_a_list_the_master_never_allocated():
-    """Spec §6 and DD32: no new bounds check was added for this. maxOdt is zero until ALLOC_ODT,
-    so the check already in SET_DAQ_PTR refuses it."""
+    """Spec §6 and DD32: no new bounds check was added for this. SET_DAQ_PTR is refused before any
+    ALLOC_DAQ and again after ALLOC_DAQ but before ALLOC_ODT, and both are asserted below.
+
+    The first is the case this test is named for, and an earlier version did not reach it: it sent
+    ALLOC_DAQ before the request, so the only thing it ever exercised was the second case.
+
+    What the wire says and does not say. Both cases answer ERR_OUT_OF_RANGE (1.1/1.6.4.1.1.1, "If
+    the specified list is not available") and SET_DAQ_PTR has two checks that produce it -- the
+    Xcp_DaqListIsValid gate and `odt_number >= maxOdt` three branches later -- so the response does
+    not identify which one fired, and this test does not claim to. It claims the outcome: neither
+    an unallocated list nor an allocated list with no ODTs may be pointed at. Which branch answers
+    the first case is pinned separately, by
+    test_a_dynamic_build_has_no_valid_daq_lists_until_alloc_daq above, through CLEAR_DAQ_LIST --
+    a command that has the validity gate and no maxOdt bound behind it."""
     handle = dynamic_handle(daq_count=2, odt_count=2, odt_entries_count=2)
+
+    assert exchange(handle, (0xE2, 0x00, 0x00, 0x00, 0x00, 0x00))[0:2] == (0xFE, 0x22), \
+        'a list the master never allocated was pointed at'
+
     exchange(handle, (0xD5, 0x00, 0x01, 0x00))
-    assert exchange(handle, (0xE2, 0x00, 0x00, 0x00, 0x00, 0x00))[0:2] == (0xFE, 0x22)
+
+    assert exchange(handle, (0xE2, 0x00, 0x00, 0x00, 0x00, 0x00))[0:2] == (0xFE, 0x22), \
+        'a list allocated but holding no ODTs was pointed at'
 
 
 def test_get_daq_list_info_reports_the_allocated_shape_not_the_configured_one():
@@ -219,4 +240,12 @@ def test_pid_off_under_dynamic_follows_the_shared_tx_pdu_rule(daq_count, accepte
     exchange(handle, (0xD4, 0x00, 0x00, 0x00, 0x01))
     # SET_DAQ_LIST_MODE with PID_OFF (bit 5) on list 0, event channel 0, prescaler 1, priority 0.
     result = exchange(handle, (0xE0, 0x20, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00))
-    assert (result[0] == 0xFF) == accepted
+    # The refused case pins ERR_MODE_NOT_VALID specifically rather than "some error": SET_DAQ_LIST_
+    # MODE has four other refusals (OUT_OF_RANGE for the list, the event channel and the prescaler,
+    # SEQUENCE for a running list), so `result[0] == 0xFF` being False would be satisfied by the
+    # refusal migrating to any of them -- including ones that would refuse this request whether or
+    # not the shared-TX-PDU rule existed at all.
+    if accepted:
+        assert result[0] == 0xFF
+    else:
+        assert result[0:2] == (0xFE, 0x27)

--- a/test/daq_dynamic_acceptance_test.py
+++ b/test/daq_dynamic_acceptance_test.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import pytest
+
+from .parameter import *
+from .conftest import XcpTest
+from .download_test import connect
+
+
+def dynamic_handle(**kwargs):
+    handle = XcpTest(dynamic_config(**kwargs))
+    connect(handle)
+    return handle
+
+
+def exchange(handle, request, length=8):
+    handle.lib.Xcp_CanIfRxIndication(0x0001, handle.get_pdu_info(request))
+    handle.lib.Xcp_MainFunction()
+    handle.lib.Xcp_CanIfTxConfirmation(0x0002, handle.define('E_OK'))
+    return tuple(handle.can_if_transmit.call_args[0][1].SduDataPtr[0:length])
+
+
+def test_a_dynamic_build_has_no_valid_daq_lists_until_alloc_daq():
+    """DD32. The spec's ALLOC_ODT range [MIN_DAQ, MIN_DAQ+DAQ_COUNT-1] is over what ALLOC_DAQ
+    allocated, not over the configured pool, so a list inside the pool but not yet allocated is
+    "not available" and answers ERR_OUT_OF_RANGE. One runtime count gives both models the right
+    answer: it starts at daqCount under STATIC and at zero under DYNAMIC."""
+    handle = dynamic_handle(daq_count=4)
+    # CLEAR_DAQ_LIST on list 0, which the pool has room for but nothing has allocated.
+    assert exchange(handle, (0xE3, 0x00, 0x00, 0x00))[0:2] == (0xFE, 0x22)

--- a/test/free_daq_test.py
+++ b/test/free_daq_test.py
@@ -1,0 +1,412 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import pytest
+
+from .parameter import *
+from .conftest import XcpTest
+from .download_test import connect
+
+
+def dynamic_handle(**kwargs):
+    handle = XcpTest(dynamic_config(**kwargs))
+    connect(handle)
+    return handle
+
+
+def exchange(handle, request, length=8):
+    handle.lib.Xcp_CanIfRxIndication(0x0001, handle.get_pdu_info(request))
+    handle.lib.Xcp_MainFunction()
+    handle.lib.Xcp_CanIfTxConfirmation(0x0002, handle.define('E_OK'))
+    return tuple(handle.can_if_transmit.call_args[0][1].SduDataPtr[0:length])
+
+
+def rt(handle):
+    return handle.lib.Xcp_Rt[handle.lib.Xcp_Ptr.xcpRtRef]
+
+
+def queued_frames(handle):
+    """Every frame currently in the ring, oldest first, as bytes. See
+    test/daq_identification_field_test.py for why reading Xcp_Rt[...].dtoQueue directly needs no
+    test-only surface in the module under test."""
+    queue = rt(handle).dtoQueue
+    frames = list()
+    index = queue.read
+    for _ in range(queue.count):
+        frame = queue.frame[index]
+        frames.append(bytes(frame.data[0:frame.length]))
+        index = (index + 1) % queue.depth
+    return frames
+
+
+def reset_descriptor(handle):
+    """Returns the generated DAQ list descriptor to its unallocated state.
+
+    Xcp_Init resets Xcp_Internal (including allocated_daq_count and daq_alloc_state) and every
+    Xcp_DaqListRt, and it clears the ODT entries -- but it never resets the descriptor's own
+    maxOdt, firstPid or per-ODT entryCount. Under DYNAMIC those three ARE the allocation, so a
+    re-initialised module reports nothing allocated while the descriptor still describes the
+    previous session's lists. See the Task 4 report: this is Task 2's carried note ("Xcp_Init
+    never clears the pool's ODT entries") one level up, and it is left as a finding rather than
+    fixed here.
+
+    It has to be compensated for in the tests because the generated descriptor arrays are
+    module-level statics shared by every XcpTest that compiles the same configuration
+    (test/conftest.py caches by configuration id), so without this a test inherits whatever
+    allocation the previous test planted -- which, since allocate_directly accumulates the way
+    ALLOC_ODT does, walks maxOdt past the pool's generated ODT array and reads out of bounds."""
+    for daq_idx in range(handle.lib.Xcp_Ptr.general.daqCount):
+        descriptor = handle.lib.Xcp_Ptr.config.daqList[daq_idx]
+        descriptor.maxOdt = 0
+        descriptor.firstPid = 0
+
+        for odt_idx in range(handle.lib.Xcp_Ptr.general.odtCount):
+            descriptor.odt[odt_idx].entryCount = 0
+
+            for entry_idx in range(handle.lib.Xcp_Ptr.general.odtEntriesCount):
+                entry = descriptor.odt[odt_idx].odtEntry[entry_idx]
+                entry.address = handle.ffi.NULL
+                entry.addressExtension = 0x00
+                entry.length = 0x00
+                entry.bitOffset = 0xFF
+
+
+def allocate_directly(handle, daq_list_count=1, odt_count=1, entry_count=1, address=0x1000):
+    """What ALLOC_ODT, ALLOC_ODT_ENTRY and WRITE_DAQ will leave behind, written into the descriptor
+    from the test instead of driven through the protocol.
+
+    ALLOC_DAQ (0xD5), ALLOC_ODT (0xD4) and ALLOC_ODT_ENTRY (0xD3) are not implemented yet -- they
+    still answer ERR_CMD_UNKNOWN -- so there is no protocol route to an allocated dynamic DAQ list
+    at the point FREE_DAQ is being written. Writing the descriptor directly is the house's existing
+    way of reaching module state a command cannot yet produce (test/daq_concurrency_test.py and
+    test/daq_identification_field_test.py both reach Xcp_Rt[...].dtoQueue the same way), and the
+    descriptor is exactly what the allocator will write: ALLOC_ODT raises maxOdt and recomputes
+    firstPid as a prefix sum (DD31), ALLOC_ODT_ENTRY raises the addressed ODT's entryCount (DD34),
+    and WRITE_DAQ fills the entries.
+
+    maxOdt is raised rather than assigned, because DD28 makes repeated ALLOC_ODT accumulate; a
+    caller that allocates twice therefore models two ALLOC_ODT requests, not one.
+
+    One thing this cannot reach: Xcp_Internal.allocated_daq_count, which ALLOC_DAQ raises.
+    Xcp_Internal is declared in source/Xcp_Internal.h, which interface/Xcp.h does not include, so
+    it is absent from the CFFI harness's cdef and unreachable from a test at all (the same
+    limitation write_daq_test.py and clear_daq_list_test.py record for the DAQ pointer). Every
+    assertion below is therefore over the descriptor, Xcp_DaqListRt and the wire, never over that
+    counter -- and the tests it makes vacuous are named where that is the case.
+    """
+    for daq_idx in range(daq_list_count):
+        descriptor = handle.lib.Xcp_Ptr.config.daqList[daq_idx]
+        first_odt = descriptor.maxOdt
+        descriptor.maxOdt = first_odt + odt_count
+
+        for odt_idx in range(first_odt, first_odt + odt_count):
+            descriptor.odt[odt_idx].entryCount = entry_count
+
+            for entry_idx in range(entry_count):
+                entry = descriptor.odt[odt_idx].odtEntry[entry_idx]
+                entry.address = handle.ffi.cast('uint32 *', address)
+                entry.addressExtension = 0x00
+                entry.length = 0x01
+                entry.bitOffset = 0xFF
+
+    # DD31: firstPid is a prefix sum over the lists' ODT counts, recomputed across the whole pool
+    # whenever any list's count changes -- not assigned in call order.
+    first_pid = 0
+    for daq_idx in range(handle.lib.Xcp_Ptr.general.daqCount):
+        handle.lib.Xcp_Ptr.config.daqList[daq_idx].firstPid = first_pid
+        first_pid += handle.lib.Xcp_Ptr.config.daqList[daq_idx].maxOdt
+
+
+def start_through_start_stop_synch(handle):
+    """Puts list 0 into data transfer mode, and DAQ_RUNNING into the session status with it.
+
+    START_STOP_DAQ_LIST is gated by Xcp_DaqListIsValid, which bounds against the allocated count
+    allocate_directly cannot raise, so it refuses every list of a dynamic build until ALLOC_DAQ
+    exists. START_STOP_SYNCH is not gated that way: it walks the configured pool and starts
+    whichever lists carry SELECTED. Planting SELECTED and sending it leaves the module itself to
+    set both the list's RUNNING bit and the session status' DAQ_RUNNING bit, so the pre-condition
+    the tests below assert against is the module's own, not the test's."""
+    rt(handle).daqList[0].mode = 0x01  # XCP_DAQ_LIST_MODE_SELECTED, source/Xcp_Internal.h
+    assert exchange(handle, (0xDD, 0x01))[0] == 0xFF, 'START_STOP_SYNCH start selected refused'
+    assert exchange(handle, (0xFD,))[1] & 0x40 == 0x40, 'the list did not actually start'
+
+
+def test_free_daq_answers_a_positive_response():
+    """XCP part 2 - Protocol Layer Specification 1.1/1.6.4.3.1.1. The request is one byte and
+    carries nothing to validate, so the only negative answers 0xD6 has are the dispatcher's own
+    (Xcp_CTOErrorMatrix gives it CMD_BUSY, PGM_ACTIVE, CMD_UNKNOWN and CMD_SYNTAX); the handler
+    itself never refuses."""
+    handle = dynamic_handle(daq_count=2, odt_count=2, odt_entries_count=2)
+    reset_descriptor(handle)
+
+    assert exchange(handle, (0xD6,))[0:1] == (0xFF,)
+
+
+def test_free_daq_releases_every_allocation():
+    """XCP part 2 - Protocol Layer Specification 1.1/1.6.4.3.1.1: "This command clears all DAQ
+    lists and frees all dynamically allocated DAQ lists, ODTs and ODT entries." Every list, not
+    the one a pointer happens to name -- so both lists below are checked, and the ODT entries with
+    them: an ODT count returned to zero while the entries it described are still populated would
+    leave a reallocated list holding the previous allocation's addresses."""
+    handle = dynamic_handle(daq_count=2, odt_count=2, odt_entries_count=2)
+    reset_descriptor(handle)
+    allocate_directly(handle, daq_list_count=2, odt_count=2, entry_count=2)
+
+    assert handle.lib.Xcp_Ptr.config.daqList[1].firstPid == 2, 'the setup itself did not allocate'
+
+    assert exchange(handle, (0xD6,))[0] == 0xFF
+
+    for daq_idx in range(2):
+        descriptor = handle.lib.Xcp_Ptr.config.daqList[daq_idx]
+
+        assert descriptor.maxOdt == 0
+        assert descriptor.firstPid == 0
+
+        for odt_idx in range(2):
+            assert descriptor.odt[odt_idx].entryCount == 0
+
+            for entry_idx in range(2):
+                entry = descriptor.odt[odt_idx].odtEntry[entry_idx]
+
+                assert entry.address == handle.ffi.NULL
+                assert entry.addressExtension == 0
+                assert entry.length == 0
+                # 1.1/1.6.4.2.1.1: "(if valid : bit_offset = 0xFF)".
+                assert entry.bitOffset == 0xFF
+
+
+def test_free_daq_stops_a_running_daq_rather_than_refusing_it():
+    """DD29. Xcp_CTOErrorMatrix gives 0xD6 only CMD_BUSY, PGM_ACTIVE, CMD_UNKNOWN and CMD_SYNTAX;
+    ERR_DAQ_ACTIVE is absent, so refusing a running slave is not authorised. FREE_DAQ therefore
+    stops every running list and clears DAQ_RUNNING."""
+    handle = dynamic_handle(daq_count=1, odt_count=1, odt_entries_count=1)
+    reset_descriptor(handle)
+    allocate_directly(handle)
+    start_through_start_stop_synch(handle)
+
+    assert exchange(handle, (0xD6,))[0] == 0xFF
+    # GET_STATUS: DAQ_RUNNING (XCP_SESSION_STATUS_MASK_DAQ_RUNNING) clear.
+    assert exchange(handle, (0xFD,))[1] & 0x40 == 0x00
+    assert rt(handle).daqList[0].mode == 0x00
+    assert handle.lib.Xcp_Ptr.config.daqList[0].maxOdt == 0
+
+
+def test_free_daq_clears_the_runtime_state_not_only_the_descriptor():
+    """DD30. Mode, prescaler, prescalerCounter, priority and eventChannelNumber live in
+    Xcp_DaqListRt, a separate array from the descriptor. A freed-then-reallocated list that
+    inherited them would start with a binding the master never set for it.
+
+    The prescaler returns to 1, not 0: 1.1/1.6.4.1.1.3 makes 1 the neutral value, and
+    Xcp_TriggerEventChannel elapses a cycle on `prescalerCounter >= prescaler`, so a zero
+    prescaler would mean every trigger elapses rather than none."""
+    handle = dynamic_handle(daq_count=1, odt_count=1, odt_entries_count=1)
+    reset_descriptor(handle)
+    allocate_directly(handle)
+
+    rt(handle).daqList[0].mode = 0x10  # XCP_DAQ_LIST_MODE_TIMESTAMP
+    rt(handle).daqList[0].eventChannelNumber = 0x0001
+    rt(handle).daqList[0].prescaler = 0x07
+    rt(handle).daqList[0].prescalerCounter = 0x03
+    rt(handle).daqList[0].priority = 0x05
+
+    assert exchange(handle, (0xD6,))[0] == 0xFF
+
+    entry = rt(handle).daqList[0]
+    assert (entry.mode, entry.eventChannelNumber, entry.prescaler,
+            entry.prescalerCounter, entry.priority) == (0x00, 0x0000, 0x01, 0x00, 0x00)
+
+
+def test_a_configured_running_list_samples_when_free_daq_does_not_run():
+    """The control for the post-condition test below: without it, a trigger that samples nothing
+    after FREE_DAQ proves nothing, because a setup that never sampled in the first place would
+    satisfy the same assertion."""
+    handle = dynamic_handle(daq_count=1, odt_count=1, odt_entries_count=1)
+    reset_descriptor(handle)
+    allocate_directly(handle)
+    start_through_start_stop_synch(handle)
+    handle.xcp_read_slave_memory_u8.reset_mock()
+
+    handle.lib.Xcp_TriggerEventChannel(0)
+
+    assert handle.xcp_read_slave_memory_u8.call_count == 1
+    assert len(queued_frames(handle)) == 1
+
+
+def test_a_trigger_after_free_daq_samples_nothing_and_queues_no_frame():
+    """DD30's outcome, stated as a post-condition rather than as an interleaving.
+
+    Xcp_TriggerEventChannel runs in interrupt context and reaches entry storage by walking maxOdt
+    and then each ODT's entryCount, so the failure this guards against is a count outliving the
+    storage it describes -- a trigger that samples through a released ODT entry. The test that
+    would exercise the race itself, driving a trigger from inside the exclusive area FREE_DAQ is
+    holding, is not written: see the Task 4 report and design §10 for why the harness cannot
+    express it. What is checked here is the outcome the race is about -- once FREE_DAQ has
+    returned, the sampler reaches nothing at all -- for the same list that
+    test_a_configured_running_list_samples_when_free_daq_does_not_run has just shown does sample
+    without it."""
+    handle = dynamic_handle(daq_count=1, odt_count=1, odt_entries_count=1)
+    reset_descriptor(handle)
+    allocate_directly(handle)
+    start_through_start_stop_synch(handle)
+
+    assert exchange(handle, (0xD6,))[0] == 0xFF
+
+    queued_before = rt(handle).dtoQueue.count
+    handle.xcp_read_slave_memory_u8.reset_mock()
+
+    handle.lib.Xcp_TriggerEventChannel(0)
+
+    handle.xcp_read_slave_memory_u8.assert_not_called()
+    assert rt(handle).dtoQueue.count == queued_before
+
+
+#: How many times Xcp_DaqFreeAll releases the DAQ exclusive area for one list holding one ODT:
+#: once at the end of Xcp_DaqListClearEntries' per-ODT critical section, and once at the end of
+#: the per-list critical section around the descriptor-count writes. Pinned by
+#: test_free_daq_holds_the_exclusive_area_exactly_once_per_odt_and_once_per_list below, so a new
+#: critical section fails that test loudly instead of silently leaving the sweep below short.
+FREE_DAQ_AREA_RELEASES = 2
+
+
+@pytest.mark.parametrize('release_index', range(FREE_DAQ_AREA_RELEASES))
+def test_a_trigger_preempting_free_daq_at_any_area_release_samples_nothing(release_index):
+    """DD30, exercised as an interleaving rather than only as a post-condition.
+
+    Xcp_TriggerEventChannel is documented to run in an interrupt, and FREE_DAQ runs in CanIf's
+    receive context, so the sampler can preempt the unwind. It cannot preempt it *anywhere*: the
+    DAQ exclusive area exists precisely to suppress that interrupt, so the points at which a
+    trigger can actually land are the points at which the area is not held. Firing the trigger
+    from SchM_Exit_Xcp_DtoQueue's side effect puts it at exactly those points, one at a time, and
+    is a legitimate preemption -- unlike firing it from SchM_Enter's, which injects a trigger into
+    a window the lock forbids and which the harness's own invariant correctly reports as a
+    double-enter (see the Task 4 report).
+
+    At every one of those points the sampler must come away with nothing: either the entries of
+    the ODT it walks have already been cleared while the counts still describe them (release 0),
+    or the counts are already zero (release 1). What it must never do is read through an entry the
+    unwind has released -- the DD14 failure class -- so the assertion is on the memory reads
+    themselves, not just on the ring."""
+    handle = dynamic_handle(daq_count=1, odt_count=1, odt_entries_count=2)
+    reset_descriptor(handle)
+    allocate_directly(handle, odt_count=1, entry_count=2)
+    start_through_start_stop_synch(handle)
+
+    original_exit = handle.sch_m_exit_xcp_dto_queue.side_effect
+    state = {'releases': 0, 'fired': False, 'reads': None}
+
+    def exit_and_preempt():
+        original_exit()
+        if (state['releases'] == release_index) and (state['fired'] is False):
+            state['fired'] = True
+            handle.xcp_read_slave_memory_u8.reset_mock()
+            handle.lib.Xcp_TriggerEventChannel(0)
+            state['reads'] = handle.xcp_read_slave_memory_u8.call_count
+        state['releases'] += 1
+
+    handle.sch_m_exit_xcp_dto_queue.side_effect = exit_and_preempt
+
+    handle.lib.Xcp_CanIfRxIndication(0x0001, handle.get_pdu_info((0xD6,)))
+
+    handle.sch_m_exit_xcp_dto_queue.side_effect = original_exit
+
+    assert state['fired'] is True, \
+        'release {} was never reached, so nothing was interleaved'.format(release_index)
+    assert state['reads'] == 0, 'the preempting trigger read slave memory through a freed entry'
+    assert len(queued_frames(handle)) == 0
+    # The injected trigger takes the area itself; that it did so without nesting is what says the
+    # release point really was outside the area rather than inside it.
+    assert handle.dto_queue_area_violations == []
+
+
+def test_free_daq_holds_the_exclusive_area_exactly_once_per_odt_and_once_per_list():
+    """Guards FREE_DAQ_AREA_RELEASES, and so the sweep above: a critical section added to the
+    unwind without extending the sweep would leave an interleaving point untested, which is the
+    one thing a sweep parametrised by a literal cannot notice by itself."""
+    handle = dynamic_handle(daq_count=1, odt_count=1, odt_entries_count=2)
+    reset_descriptor(handle)
+    allocate_directly(handle, odt_count=1, entry_count=2)
+    enter_count_before = handle.sch_m_enter_xcp_dto_queue.call_count
+
+    handle.lib.Xcp_CanIfRxIndication(0x0001, handle.get_pdu_info((0xD6,)))
+
+    assert handle.sch_m_enter_xcp_dto_queue.call_count - enter_count_before == FREE_DAQ_AREA_RELEASES
+
+
+def test_free_daq_takes_the_exclusive_area_around_the_descriptor_writes():
+    """DD30/DD14. maxOdt and entryCount are read by Xcp_TriggerEventChannel and Xcp_DaqSampleOdt,
+    which may run in an interrupt that preempts this command in CanIf's receive context, so
+    FREE_DAQ's writes to them are taken under the same exclusive area the sampler takes -- the
+    one-sided-lock bug test/daq_concurrency_test.py::test_clear_daq_list_takes_the_exclusive_area
+    catches for CLEAR_DAQ_LIST.
+
+    Exactly one entry is expected, and the count is taken around Xcp_CanIfRxIndication alone (the
+    handler runs synchronously inside it) rather than around a full exchange, whose
+    Xcp_MainFunction takes the same area to read the DTO ring. Nothing is allocated here on
+    purpose: with maxOdt at zero, Xcp_DaqListClearEntries' per-ODT loop -- which takes the area
+    once per ODT -- does not execute at all, so the single entry counted below can only be the one
+    around the descriptor-count writes."""
+    handle = dynamic_handle(daq_count=1, odt_count=1, odt_entries_count=1)
+    reset_descriptor(handle)
+    enter_count_before = handle.sch_m_enter_xcp_dto_queue.call_count
+
+    handle.lib.Xcp_CanIfRxIndication(0x0001, handle.get_pdu_info((0xD6,)))
+
+    assert handle.sch_m_enter_xcp_dto_queue.call_count - enter_count_before == 1
+
+
+def test_disconnect_frees_the_allocation_so_the_next_session_does_not_inherit_it():
+    """XCP part 1 - Overview 1.0/2.3: in "DISCONNECTED" state "the session status, all DAQ lists
+    and the protection status bits are reset". Nothing performed that reset -- Xcp_CTOCmdStdDisconnect
+    cleared only connection_status, CONNECT cleared nothing, and Xcp_Init was the module's only
+    session-state reset path.
+
+    Under DYNAMIC that is not merely untidy. The allocation state machine starts in FREE and
+    accepts ALLOC_DAQ with no preceding FREE_DAQ (DD28), and repeats accumulate, so a master that
+    allocated and then disconnected without sending FREE_DAQ left its allocation standing for the
+    next master to add to. Here the first session takes two ODTs and the second takes one: with
+    the allocation released at DISCONNECT the second session holds exactly the one ODT it asked
+    for, and ODT 1 -- the first session's -- is back to being unallocated and empty. Without it,
+    maxOdt would read three and ODT 1 would still carry the first session's entry."""
+    handle = dynamic_handle(daq_count=2, odt_count=4, odt_entries_count=2)
+    reset_descriptor(handle)
+    allocate_directly(handle, odt_count=2, address=0x1000)
+
+    assert exchange(handle, (0xFE,))[0] == 0xFF  # DISCONNECT
+
+    connect(handle)  # the next master
+    allocate_directly(handle, odt_count=1, address=0x2000)
+
+    descriptor = handle.lib.Xcp_Ptr.config.daqList[0]
+
+    assert descriptor.maxOdt == 1
+    assert descriptor.odt[1].entryCount == 0
+    assert descriptor.odt[1].odtEntry[0].address == handle.ffi.NULL
+    assert descriptor.odt[1].odtEntry[0].length == 0
+
+
+def test_disconnect_stops_and_clears_the_daq_lists_of_a_static_configuration_too():
+    """1.0/2.3 again, for the model that has no allocation to release. A STATIC build cannot enable
+    FREE_DAQ at all -- script/source_cfg.c.jinja2 refuses a configuration that does -- so DISCONNECT
+    is the only route by which Xcp_DaqFreeAll runs there, and what it has to deliver is the rest of
+    the sentence: the DAQ lists stop and their entries are reset, so a master's next CONNECT does
+    not inherit the previous session's measurement."""
+    handle = XcpTest(DefaultConfig(daqs=(daq(name='DAQ1', max_odt=1, max_odt_entries=1),)))
+    connect(handle)
+
+    exchange(handle, (0xE2, 0x00, 0x00, 0x00, 0x00, 0x00))  # SET_DAQ_PTR list 0, odt 0, entry 0
+    exchange(handle, (0xE1, 0xFF, 0x01, 0x00, 0x00, 0x10, 0x00, 0x00))  # WRITE_DAQ address 0x1000
+    exchange(handle, (0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00))  # SET_DAQ_LIST_MODE
+    assert exchange(handle, (0xDE, 0x01, 0x00, 0x00))[0] == 0xFF  # START_STOP_DAQ_LIST start
+    assert exchange(handle, (0xFD,))[1] & 0x40 == 0x40  # GET_STATUS: DAQ_RUNNING set
+
+    assert exchange(handle, (0xFE,))[0] == 0xFF  # DISCONNECT
+
+    connect(handle)
+
+    assert exchange(handle, (0xFD,))[1] & 0x40 == 0x00
+    assert rt(handle).daqList[0].mode == 0x00
+    assert handle.lib.Xcp_Ptr.config.daqList[0].odt[0].odtEntry[0].address == handle.ffi.NULL
+    assert handle.lib.Xcp_Ptr.config.daqList[0].odt[0].odtEntry[0].length == 0
+    # The allocation is not touched: a static list's ODTs are generated, not allocated, so
+    # CLEAR_DAQ_LIST on list 0 must still be answered rather than refused as out of range.
+    assert exchange(handle, (0xE3, 0x00, 0x00, 0x00))[0] == 0xFF

--- a/test/free_daq_test.py
+++ b/test/free_daq_test.py
@@ -39,38 +39,6 @@ def queued_frames(handle):
     return frames
 
 
-def reset_descriptor(handle):
-    """Returns the generated DAQ list descriptor to its unallocated state.
-
-    Xcp_Init resets Xcp_Internal (including allocated_daq_count and daq_alloc_state) and every
-    Xcp_DaqListRt, and it clears the ODT entries -- but it never resets the descriptor's own
-    maxOdt, firstPid or per-ODT entryCount. Under DYNAMIC those three ARE the allocation, so a
-    re-initialised module reports nothing allocated while the descriptor still describes the
-    previous session's lists. See the Task 4 report: this is Task 2's carried note ("Xcp_Init
-    never clears the pool's ODT entries") one level up, and it is left as a finding rather than
-    fixed here.
-
-    It has to be compensated for in the tests because the generated descriptor arrays are
-    module-level statics shared by every XcpTest that compiles the same configuration
-    (test/conftest.py caches by configuration id), so without this a test inherits whatever
-    allocation the previous test planted -- which, since allocate_directly accumulates the way
-    ALLOC_ODT does, walks maxOdt past the pool's generated ODT array and reads out of bounds."""
-    for daq_idx in range(handle.lib.Xcp_Ptr.general.daqCount):
-        descriptor = handle.lib.Xcp_Ptr.config.daqList[daq_idx]
-        descriptor.maxOdt = 0
-        descriptor.firstPid = 0
-
-        for odt_idx in range(handle.lib.Xcp_Ptr.general.odtCount):
-            descriptor.odt[odt_idx].entryCount = 0
-
-            for entry_idx in range(handle.lib.Xcp_Ptr.general.odtEntriesCount):
-                entry = descriptor.odt[odt_idx].odtEntry[entry_idx]
-                entry.address = handle.ffi.NULL
-                entry.addressExtension = 0x00
-                entry.length = 0x00
-                entry.bitOffset = 0xFF
-
-
 def allocate_directly(handle, daq_list_count=1, odt_count=1, entry_count=1, address=0x1000):
     """What ALLOC_ODT, ALLOC_ODT_ENTRY and WRITE_DAQ will leave behind, written into the descriptor
     from the test instead of driven through the protocol.
@@ -86,6 +54,14 @@ def allocate_directly(handle, daq_list_count=1, odt_count=1, entry_count=1, addr
 
     maxOdt is raised rather than assigned, because DD28 makes repeated ALLOC_ODT accumulate; a
     caller that allocates twice therefore models two ALLOC_ODT requests, not one.
+
+    Nothing resets the descriptor before this runs, and nothing needs to: the generated descriptor
+    arrays are module-level statics shared by every XcpTest compiling the same configuration
+    (test/conftest.py caches by configuration id), but Xcp_Init -- which XcpTest runs on
+    construction -- calls Xcp_DaqFreeAll, so each test starts from a genuinely unallocated pool.
+    test_initialisation_releases_an_allocation_left_by_a_previous_session pins that directly; if it
+    ever regresses, the accumulation below walks past the pool's generated ODT array rather than
+    failing cleanly, so that test failing first is not a coincidence worth ignoring.
 
     One thing this cannot reach: Xcp_Internal.allocated_daq_count, which ALLOC_DAQ raises.
     Xcp_Internal is declared in source/Xcp_Internal.h, which interface/Xcp.h does not include, so
@@ -137,7 +113,6 @@ def test_free_daq_answers_a_positive_response():
     (Xcp_CTOErrorMatrix gives it CMD_BUSY, PGM_ACTIVE, CMD_UNKNOWN and CMD_SYNTAX); the handler
     itself never refuses."""
     handle = dynamic_handle(daq_count=2, odt_count=2, odt_entries_count=2)
-    reset_descriptor(handle)
 
     assert exchange(handle, (0xD6,))[0:1] == (0xFF,)
 
@@ -149,7 +124,6 @@ def test_free_daq_releases_every_allocation():
     them: an ODT count returned to zero while the entries it described are still populated would
     leave a reallocated list holding the previous allocation's addresses."""
     handle = dynamic_handle(daq_count=2, odt_count=2, odt_entries_count=2)
-    reset_descriptor(handle)
     allocate_directly(handle, daq_list_count=2, odt_count=2, entry_count=2)
 
     assert handle.lib.Xcp_Ptr.config.daqList[1].firstPid == 2, 'the setup itself did not allocate'
@@ -180,7 +154,6 @@ def test_free_daq_stops_a_running_daq_rather_than_refusing_it():
     ERR_DAQ_ACTIVE is absent, so refusing a running slave is not authorised. FREE_DAQ therefore
     stops every running list and clears DAQ_RUNNING."""
     handle = dynamic_handle(daq_count=1, odt_count=1, odt_entries_count=1)
-    reset_descriptor(handle)
     allocate_directly(handle)
     start_through_start_stop_synch(handle)
 
@@ -200,7 +173,6 @@ def test_free_daq_clears_the_runtime_state_not_only_the_descriptor():
     Xcp_TriggerEventChannel elapses a cycle on `prescalerCounter >= prescaler`, so a zero
     prescaler would mean every trigger elapses rather than none."""
     handle = dynamic_handle(daq_count=1, odt_count=1, odt_entries_count=1)
-    reset_descriptor(handle)
     allocate_directly(handle)
 
     rt(handle).daqList[0].mode = 0x10  # XCP_DAQ_LIST_MODE_TIMESTAMP
@@ -221,7 +193,6 @@ def test_a_configured_running_list_samples_when_free_daq_does_not_run():
     after FREE_DAQ proves nothing, because a setup that never sampled in the first place would
     satisfy the same assertion."""
     handle = dynamic_handle(daq_count=1, odt_count=1, odt_entries_count=1)
-    reset_descriptor(handle)
     allocate_directly(handle)
     start_through_start_stop_synch(handle)
     handle.xcp_read_slave_memory_u8.reset_mock()
@@ -245,7 +216,6 @@ def test_a_trigger_after_free_daq_samples_nothing_and_queues_no_frame():
     test_a_configured_running_list_samples_when_free_daq_does_not_run has just shown does sample
     without it."""
     handle = dynamic_handle(daq_count=1, odt_count=1, odt_entries_count=1)
-    reset_descriptor(handle)
     allocate_directly(handle)
     start_through_start_stop_synch(handle)
 
@@ -287,7 +257,6 @@ def test_a_trigger_preempting_free_daq_at_any_area_release_samples_nothing(relea
     unwind has released -- the DD14 failure class -- so the assertion is on the memory reads
     themselves, not just on the ring."""
     handle = dynamic_handle(daq_count=1, odt_count=1, odt_entries_count=2)
-    reset_descriptor(handle)
     allocate_directly(handle, odt_count=1, entry_count=2)
     start_through_start_stop_synch(handle)
 
@@ -323,7 +292,6 @@ def test_free_daq_holds_the_exclusive_area_exactly_once_per_odt_and_once_per_lis
     unwind without extending the sweep would leave an interleaving point untested, which is the
     one thing a sweep parametrised by a literal cannot notice by itself."""
     handle = dynamic_handle(daq_count=1, odt_count=1, odt_entries_count=2)
-    reset_descriptor(handle)
     allocate_directly(handle, odt_count=1, entry_count=2)
     enter_count_before = handle.sch_m_enter_xcp_dto_queue.call_count
 
@@ -346,12 +314,49 @@ def test_free_daq_takes_the_exclusive_area_around_the_descriptor_writes():
     once per ODT -- does not execute at all, so the single entry counted below can only be the one
     around the descriptor-count writes."""
     handle = dynamic_handle(daq_count=1, odt_count=1, odt_entries_count=1)
-    reset_descriptor(handle)
     enter_count_before = handle.sch_m_enter_xcp_dto_queue.call_count
 
     handle.lib.Xcp_CanIfRxIndication(0x0001, handle.get_pdu_info((0xD6,)))
 
     assert handle.sch_m_enter_xcp_dto_queue.call_count - enter_count_before == 1
+
+
+def test_initialisation_releases_an_allocation_left_by_a_previous_session():
+    """Xcp_Init must establish the same invariant FREE_DAQ does, so it runs the same unwind.
+
+    It used to reset Xcp_Internal and every Xcp_DaqListRt and clear the ODT entries, but left the
+    descriptor's own maxOdt, firstPid and per-ODT entryCount standing -- and under DYNAMIC those
+    three ARE the allocation. A re-initialised module therefore set allocated_daq_count to 0 and
+    daq_alloc_state to FREE, reporting nothing allocated, while the descriptor still described the
+    previous session's lists: the two halves of the allocation state disagreed. The clear missed
+    the entries too, because Xcp_DaqListClearEntries is bounded by exactly the counts being left
+    behind -- which is Task 2's carried note ("Xcp_Init never clears the pool's ODT entries") seen
+    from one level up.
+
+    The generated descriptor arrays are module-level mutable statics with no initialisation of
+    their own, so this is the only thing standing between one session's allocation and the next
+    one's."""
+    handle = dynamic_handle(daq_count=2, odt_count=2, odt_entries_count=2)
+    allocate_directly(handle, daq_list_count=2, odt_count=2, entry_count=2)
+
+    assert handle.lib.Xcp_Ptr.config.daqList[1].firstPid == 2, 'the setup itself did not allocate'
+
+    handle.lib.Xcp_Init(handle.ffi.cast('const Xcp_Type *', handle.config.lib.Xcp))
+
+    for daq_idx in range(2):
+        descriptor = handle.lib.Xcp_Ptr.config.daqList[daq_idx]
+
+        assert descriptor.maxOdt == 0
+        assert descriptor.firstPid == 0
+
+        for odt_idx in range(2):
+            assert descriptor.odt[odt_idx].entryCount == 0
+
+            for entry_idx in range(2):
+                entry = descriptor.odt[odt_idx].odtEntry[entry_idx]
+
+                assert entry.address == handle.ffi.NULL
+                assert entry.length == 0
 
 
 def test_disconnect_frees_the_allocation_so_the_next_session_does_not_inherit_it():
@@ -368,7 +373,6 @@ def test_disconnect_frees_the_allocation_so_the_next_session_does_not_inherit_it
     for, and ODT 1 -- the first session's -- is back to being unallocated and empty. Without it,
     maxOdt would read three and ODT 1 would still carry the first session's entry."""
     handle = dynamic_handle(daq_count=2, odt_count=4, odt_entries_count=2)
-    reset_descriptor(handle)
     allocate_directly(handle, odt_count=2, address=0x1000)
 
     assert exchange(handle, (0xFE,))[0] == 0xFF  # DISCONNECT
@@ -384,29 +388,35 @@ def test_disconnect_frees_the_allocation_so_the_next_session_does_not_inherit_it
     assert descriptor.odt[1].odtEntry[0].length == 0
 
 
-def test_disconnect_stops_and_clears_the_daq_lists_of_a_static_configuration_too():
-    """1.0/2.3 again, for the model that has no allocation to release. A STATIC build cannot enable
-    FREE_DAQ at all -- script/source_cfg.c.jinja2 refuses a configuration that does -- so DISCONNECT
-    is the only route by which Xcp_DaqFreeAll runs there, and what it has to deliver is the rest of
-    the sentence: the DAQ lists stop and their entries are reset, so a master's next CONNECT does
-    not inherit the previous session's measurement."""
+def test_disconnect_leaves_a_static_configurations_daq_entries_alone():
+    """The counterpart of the test above, and the boundary on it: the DISCONNECT unwind is gated on
+    DAQ_DYNAMIC, so a STATIC build's configured DAQ entries survive a disconnect untouched.
+
+    A STATIC configuration has no allocation to leak -- its lists are generated, not allocated --
+    so the gap the DYNAMIC gate closes does not exist here, and clearing a master's written entries
+    on disconnect would be a behaviour change to the static model that SP2d is required not to make
+    (DD25). Pinned rather than left implicit, because Xcp_DaqFreeAll is one unguarded call away
+    from doing it.
+
+    Whether XCP part 1 - Overview 2.3 nevertheless requires a disconnecting slave to reset its DAQ
+    lists in both models is a separate question, deliberately not settled here: that document is
+    not in docs/external/, so the claim cannot be checked against a source. It is recorded as a
+    follow-up in the Task 4 report rather than implemented against an unverifiable citation."""
     handle = XcpTest(DefaultConfig(daqs=(daq(name='DAQ1', max_odt=1, max_odt_entries=1),)))
     connect(handle)
 
     exchange(handle, (0xE2, 0x00, 0x00, 0x00, 0x00, 0x00))  # SET_DAQ_PTR list 0, odt 0, entry 0
     exchange(handle, (0xE1, 0xFF, 0x01, 0x00, 0x00, 0x10, 0x00, 0x00))  # WRITE_DAQ address 0x1000
-    exchange(handle, (0xE0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00))  # SET_DAQ_LIST_MODE
-    assert exchange(handle, (0xDE, 0x01, 0x00, 0x00))[0] == 0xFF  # START_STOP_DAQ_LIST start
-    assert exchange(handle, (0xFD,))[1] & 0x40 == 0x40  # GET_STATUS: DAQ_RUNNING set
 
     assert exchange(handle, (0xFE,))[0] == 0xFF  # DISCONNECT
 
     connect(handle)
 
-    assert exchange(handle, (0xFD,))[1] & 0x40 == 0x00
-    assert rt(handle).daqList[0].mode == 0x00
-    assert handle.lib.Xcp_Ptr.config.daqList[0].odt[0].odtEntry[0].address == handle.ffi.NULL
-    assert handle.lib.Xcp_Ptr.config.daqList[0].odt[0].odtEntry[0].length == 0
-    # The allocation is not touched: a static list's ODTs are generated, not allocated, so
-    # CLEAR_DAQ_LIST on list 0 must still be answered rather than refused as out of range.
+    entry = handle.lib.Xcp_Ptr.config.daqList[0].odt[0].odtEntry[0]
+
+    assert entry.address != handle.ffi.NULL, 'DISCONNECT cleared a static build\'s ODT entry'
+    assert int(handle.ffi.cast('uint32_t', entry.address)) == 0x1000
+    assert entry.length == 1
+    # The list is still there to be cleared, as it was before: a static list's ODTs are generated,
+    # not allocated, so CLEAR_DAQ_LIST on list 0 is answered rather than refused as out of range.
     assert exchange(handle, (0xE3, 0x00, 0x00, 0x00))[0] == 0xFF

--- a/test/free_daq_test.py
+++ b/test/free_daq_test.py
@@ -43,14 +43,16 @@ def allocate_directly(handle, daq_list_count=1, odt_count=1, entry_count=1, addr
     """What ALLOC_ODT, ALLOC_ODT_ENTRY and WRITE_DAQ will leave behind, written into the descriptor
     from the test instead of driven through the protocol.
 
-    ALLOC_DAQ (0xD5), ALLOC_ODT (0xD4) and ALLOC_ODT_ENTRY (0xD3) are not implemented yet -- they
-    still answer ERR_CMD_UNKNOWN -- so there is no protocol route to an allocated dynamic DAQ list
-    at the point FREE_DAQ is being written. Writing the descriptor directly is the house's existing
-    way of reaching module state a command cannot yet produce (test/daq_concurrency_test.py and
-    test/daq_identification_field_test.py both reach Xcp_Rt[...].dtoQueue the same way), and the
-    descriptor is exactly what the allocator will write: ALLOC_ODT raises maxOdt and recomputes
-    firstPid as a prefix sum (DD31), ALLOC_ODT_ENTRY raises the addressed ODT's entryCount (DD34),
-    and WRITE_DAQ fills the entries.
+    ALLOC_ODT_ENTRY (0xD3) is not implemented yet -- it still answers ERR_CMD_UNKNOWN -- so there
+    is still no protocol route to a dynamic DAQ list carrying ODT ENTRIES, which is what these
+    tests need FREE_DAQ to release. (ALLOC_DAQ and ALLOC_ODT have since arrived, and
+    test/alloc_odt_test.py drives the part of this that can now be driven; there is no reason to
+    rewrite the helper for half a sequence.) Writing the descriptor directly is the house's
+    existing way of reaching module state a command cannot yet produce
+    (test/daq_concurrency_test.py and test/daq_identification_field_test.py both reach
+    Xcp_Rt[...].dtoQueue the same way), and the descriptor is exactly what the allocator writes:
+    ALLOC_ODT raises maxOdt and recomputes firstPid as a prefix sum (DD31), ALLOC_ODT_ENTRY raises
+    the addressed ODT's entryCount (DD34), and WRITE_DAQ fills the entries.
 
     maxOdt is raised rather than assigned, because DD28 makes repeated ALLOC_ODT accumulate; a
     caller that allocates twice therefore models two ALLOC_ODT requests, not one.

--- a/test/free_daq_test.py
+++ b/test/free_daq_test.py
@@ -43,16 +43,15 @@ def allocate_directly(handle, daq_list_count=1, odt_count=1, entry_count=1, addr
     """What ALLOC_ODT, ALLOC_ODT_ENTRY and WRITE_DAQ will leave behind, written into the descriptor
     from the test instead of driven through the protocol.
 
-    ALLOC_ODT_ENTRY (0xD3) is not implemented yet -- it still answers ERR_CMD_UNKNOWN -- so there
-    is still no protocol route to a dynamic DAQ list carrying ODT ENTRIES, which is what these
-    tests need FREE_DAQ to release. (ALLOC_DAQ and ALLOC_ODT have since arrived, and
-    test/alloc_odt_test.py drives the part of this that can now be driven; there is no reason to
-    rewrite the helper for half a sequence.) Writing the descriptor directly is the house's
-    existing way of reaching module state a command cannot yet produce
-    (test/daq_concurrency_test.py and test/daq_identification_field_test.py both reach
-    Xcp_Rt[...].dtoQueue the same way), and the descriptor is exactly what the allocator writes:
-    ALLOC_ODT raises maxOdt and recomputes firstPid as a prefix sum (DD31), ALLOC_ODT_ENTRY raises
-    the addressed ODT's entryCount (DD34), and WRITE_DAQ fills the entries.
+    All four allocation commands are implemented now, so the protocol route these tests once
+    lacked exists; the helper is kept because it reaches the descriptor in one call and the tests
+    written against it are about FREE_DAQ, not about the allocator. Writing the descriptor directly
+    is the house's existing way of reaching module state (test/daq_concurrency_test.py and
+    test/daq_identification_field_test.py both reach Xcp_Rt[...].dtoQueue the same way), and the
+    descriptor is exactly what the allocator writes: ALLOC_ODT raises maxOdt and recomputes
+    firstPid as a prefix sum (DD31), ALLOC_ODT_ENTRY raises the addressed ODT's entryCount (DD34),
+    and WRITE_DAQ fills the entries. test/daq_dynamic_acceptance_test.py drives the whole sequence
+    through the protocol instead, and is where an end-to-end claim belongs.
 
     maxOdt is raised rather than assigned, because DD28 makes repeated ALLOC_ODT accumulate; a
     caller that allocates twice therefore models two ALLOC_ODT requests, not one.
@@ -65,12 +64,28 @@ def allocate_directly(handle, daq_list_count=1, odt_count=1, entry_count=1, addr
     ever regresses, the accumulation below walks past the pool's generated ODT array rather than
     failing cleanly, so that test failing first is not a coincidence worth ignoring.
 
+    That overrun is a property of this helper alone, not of the module: it raises maxOdt with no
+    check at all, where ALLOC_ODT caps maxOdt at odtCount, the exact width of the list's slice of
+    the generated ODT array. No sequence of protocol commands can walk off that slice. Do not read
+    the sentence above as a statement about the allocator.
+
     One thing this cannot reach: Xcp_Internal.allocated_daq_count, which ALLOC_DAQ raises.
     Xcp_Internal is declared in source/Xcp_Internal.h, which interface/Xcp.h does not include, so
     it is absent from the CFFI harness's cdef and unreachable from a test at all (the same
     limitation write_daq_test.py and clear_daq_list_test.py record for the DAQ pointer). Every
     assertion below is therefore over the descriptor, Xcp_DaqListRt and the wire, never over that
     counter -- and the tests it makes vacuous are named where that is the case.
+
+    What that limitation costs, stated plainly: every test using this helper runs with
+    allocated_daq_count == 0 while maxOdt, entryCount and populated ODT entries all say otherwise.
+    No master can reach that state -- ALLOC_ODT refuses a list the allocated count does not cover,
+    so a real dynamic session always has the two halves agreeing. The consequence is that anything
+    gated on Xcp_DaqListIsValid is refused for these tests' lists: START_STOP_DAQ_LIST is, which is
+    why start_through_start_stop_synch below goes through START_STOP_SYNCH instead, and
+    CLEAR_DAQ_LIST would be too. The tests here are about the unwind reaching descriptor and entry
+    storage, which this state reaches faithfully; a claim that depends on the allocated count
+    agreeing belongs in a test that drives ALLOC_DAQ, i.e. in test/alloc_daq_test.py or
+    test/daq_dynamic_acceptance_test.py.
     """
     for daq_idx in range(daq_list_count):
         descriptor = handle.lib.Xcp_Ptr.config.daqList[daq_idx]
@@ -124,11 +139,24 @@ def test_free_daq_releases_every_allocation():
     lists and frees all dynamically allocated DAQ lists, ODTs and ODT entries." Every list, not
     the one a pointer happens to name -- so both lists below are checked, and the ODT entries with
     them: an ODT count returned to zero while the entries it described are still populated would
-    leave a reallocated list holding the previous allocation's addresses."""
+    leave a reallocated list holding the previous allocation's addresses.
+
+    addressExtension and bitOffset are seeded away from their reset values before the free.
+    allocate_directly leaves them at 0x00 and 0xFF, which are exactly what the reset produces, so
+    without this the two assertions on them below could not fail whatever FREE_DAQ did. Both
+    seeded values are states WRITE_DAQ can genuinely reach: it takes the extension from the
+    request and a bit offset of 0x00..0x1F selects a bit rather than whole bytes."""
     handle = dynamic_handle(daq_count=2, odt_count=2, odt_entries_count=2)
     allocate_directly(handle, daq_list_count=2, odt_count=2, entry_count=2)
 
     assert handle.lib.Xcp_Ptr.config.daqList[1].firstPid == 2, 'the setup itself did not allocate'
+
+    for daq_idx in range(2):
+        for odt_idx in range(2):
+            for entry_idx in range(2):
+                seeded = handle.lib.Xcp_Ptr.config.daqList[daq_idx].odt[odt_idx].odtEntry[entry_idx]
+                seeded.addressExtension = 0x02
+                seeded.bitOffset = 0x03
 
     assert exchange(handle, (0xD6,))[0] == 0xFF
 
@@ -253,11 +281,28 @@ def test_a_trigger_preempting_free_daq_at_any_area_release_samples_nothing(relea
     a window the lock forbids and which the harness's own invariant correctly reports as a
     double-enter (see the Task 4 report).
 
-    At every one of those points the sampler must come away with nothing: either the entries of
-    the ODT it walks have already been cleared while the counts still describe them (release 0),
-    or the counts are already zero (release 1). What it must never do is read through an entry the
-    unwind has released -- the DD14 failure class -- so the assertion is on the memory reads
-    themselves, not just on the ring."""
+    At every one of those points the sampler must come away with nothing. What it must never do is
+    read through an entry the unwind has released -- the DD14 failure class -- so the assertion is
+    on the memory reads themselves, not just on the ring.
+
+    The two cells do not prove the same thing, and only release 0 exercises the failure class the
+    name points at:
+
+    * **release 0** is the exit of Xcp_DaqListClearEntries' per-ODT critical section, reached from
+      inside Xcp_DaqListReset and therefore *before* it lowers mode. The list is still RUNNING and
+      its maxOdt and entryCount still describe the ODT, so the preempting trigger really does walk
+      maxOdt, read entryCount and reach the entry array -- and finds every entry already cleared to
+      length 0. `reads == 0` here is the interleaving assertion. This is the real cell.
+    * **release 1** is the exit of the count-zeroing critical section, which runs in
+      Xcp_DaqFreeAll's second loop, after Xcp_DaqListReset has already set mode to 0. The trigger
+      returns at Xcp_TriggerEventChannel's RUNNING gate without ever reading maxOdt or entryCount,
+      so `reads == 0` holds there for a reason unrelated to entry storage. What that cell still
+      carries is `fired is True` -- the release point exists and is reachable, which is what guards
+      FREE_DAQ_AREA_RELEASES from silently naming a point the unwind no longer has -- and the
+      area-nesting check, which says the release really was outside the area.
+
+    Both cells share the nesting and ring assertions; the memory-read assertion is load-bearing
+    only for release 0."""
     handle = dynamic_handle(daq_count=1, odt_count=1, odt_entries_count=2)
     allocate_directly(handle, odt_count=1, entry_count=2)
     start_through_start_stop_synch(handle)
@@ -330,10 +375,15 @@ def test_initialisation_releases_an_allocation_left_by_a_previous_session():
     descriptor's own maxOdt, firstPid and per-ODT entryCount standing -- and under DYNAMIC those
     three ARE the allocation. A re-initialised module therefore set allocated_daq_count to 0 and
     daq_alloc_state to FREE, reporting nothing allocated, while the descriptor still described the
-    previous session's lists: the two halves of the allocation state disagreed. The clear missed
-    the entries too, because Xcp_DaqListClearEntries is bounded by exactly the counts being left
-    behind -- which is Task 2's carried note ("Xcp_Init never clears the pool's ODT entries") seen
-    from one level up.
+    previous session's lists: the two halves of the allocation state disagreed. The surviving
+    entryCounts also break the argument that a running list's FIRST_PID cannot move (design §9),
+    which needs initialisation to zero them.
+
+    The entries themselves were not the problem, and an earlier version of this docstring had that
+    backwards. Xcp_DaqListClearEntries is bounded by maxOdt and each ODT's entryCount, so counts
+    surviving is precisely the condition under which the clear reaches every allocated entry. It is
+    the counts, not the entries, that the old loop left behind -- which is what the assertions below
+    are ordered around: maxOdt, firstPid and entryCount first, the entries after them.
 
     The generated descriptor arrays are module-level mutable statics with no initialisation of
     their own, so this is the only thing standing between one session's allocation and the next
@@ -362,10 +412,9 @@ def test_initialisation_releases_an_allocation_left_by_a_previous_session():
 
 
 def test_disconnect_frees_the_allocation_so_the_next_session_does_not_inherit_it():
-    """XCP part 1 - Overview 1.0/2.3: in "DISCONNECTED" state "the session status, all DAQ lists
-    and the protection status bits are reset". Nothing performed that reset -- Xcp_CTOCmdStdDisconnect
-    cleared only connection_status, CONNECT cleared nothing, and Xcp_Init was the module's only
-    session-state reset path.
+    """Nothing reset the DAQ configuration at DISCONNECT -- Xcp_CTOCmdStdDisconnect cleared only
+    connection_status, CONNECT cleared nothing, and Xcp_Init was the module's only session-state
+    reset path.
 
     Under DYNAMIC that is not merely untidy. The allocation state machine starts in FREE and
     accepts ALLOC_DAQ with no preceding FREE_DAQ (DD28), and repeats accumulate, so a master that
@@ -373,9 +422,20 @@ def test_disconnect_frees_the_allocation_so_the_next_session_does_not_inherit_it
     next master to add to. Here the first session takes two ODTs and the second takes one: with
     the allocation released at DISCONNECT the second session holds exactly the one ODT it asked
     for, and ODT 1 -- the first session's -- is back to being unallocated and empty. Without it,
-    maxOdt would read three and ODT 1 would still carry the first session's entry."""
+    maxOdt would read three and ODT 1 would still carry the first session's entry.
+
+    Whether a slave is *required* to reset its DAQ lists at DISCONNECT in both models is a separate
+    question this test deliberately does not answer. The claim usually cited for it -- XCP part 1 -
+    Overview 2.3, that in "DISCONNECTED" state the session status, all DAQ lists and the protection
+    status bits are reset -- is not verifiable here: that document is not in docs/external/. The
+    justification above stands on cross-session contamination under DYNAMIC alone, which is
+    observable from the protocol and is what this test pins;
+    test_disconnect_leaves_a_static_configurations_daq_entries_alone records the same caveat for
+    the other half."""
     handle = dynamic_handle(daq_count=2, odt_count=4, odt_entries_count=2)
     allocate_directly(handle, odt_count=2, address=0x1000)
+
+    assert handle.lib.Xcp_Ptr.config.daqList[0].maxOdt == 2, 'the setup itself did not allocate'
 
     assert exchange(handle, (0xFE,))[0] == 0xFF  # DISCONNECT
 
@@ -416,9 +476,14 @@ def test_disconnect_leaves_a_static_configurations_daq_entries_alone():
 
     entry = handle.lib.Xcp_Ptr.config.daqList[0].odt[0].odtEntry[0]
 
+    # These three are what discriminate: remove the DAQ_DYNAMIC gate in Xcp_CTOCmdStdDisconnect and
+    # Xcp_DaqFreeAll's first loop -- Xcp_DaqListReset over every list, which is NOT itself gated --
+    # clears this entry, so all three fail.
+    #
+    # A fourth assertion, that CLEAR_DAQ_LIST on list 0 is still answered rather than refused as out
+    # of range, used to stand here and has been removed: it could not fail. Xcp_DaqFreeAll's only
+    # write to allocated_daq_count is inside its own DAQ_DYNAMIC branch, so under STATIC the count
+    # stays at daqCount and Xcp_DaqListIsValid keeps accepting list 0 with or without the gate.
     assert entry.address != handle.ffi.NULL, 'DISCONNECT cleared a static build\'s ODT entry'
     assert int(handle.ffi.cast('uint32_t', entry.address)) == 0x1000
     assert entry.length == 1
-    # The list is still there to be cleared, as it was before: a static list's ODTs are generated,
-    # not allocated, so CLEAR_DAQ_LIST on list 0 is answered rather than refused as out of range.
-    assert exchange(handle, (0xE3, 0x00, 0x00, 0x00))[0] == 0xFF

--- a/test/get_daq_event_info_test.py
+++ b/test/get_daq_event_info_test.py
@@ -17,6 +17,19 @@ def daq_event_info(handle, event_channel_number=0, byte_order='LITTLE_ENDIAN'):
     return handle.can_if_transmit.call_args[0][1].SduDataPtr
 
 
+def dynamic_handle(**kwargs):
+    handle = XcpTest(dynamic_config(**kwargs))
+    connect(handle)
+    return handle
+
+
+def exchange(handle, request, length=8):
+    handle.lib.Xcp_CanIfRxIndication(0x0001, handle.get_pdu_info(request))
+    handle.lib.Xcp_MainFunction()
+    handle.lib.Xcp_CanIfTxConfirmation(0x0002, handle.define('E_OK'))
+    return tuple(handle.can_if_transmit.call_args[0][1].SduDataPtr[0:length])
+
+
 def read_through_to_real_memory(handle):
     """A mock side_effect that genuinely dereferences the address the slave hands it, rather than
     fabricating a value the way the block-transfer tests elsewhere in this suite do (they only
@@ -256,3 +269,9 @@ def test_get_daq_event_info_is_refused_when_disabled():
     frame = daq_event_info(handle)
 
     assert tuple(frame[0:2]) == (0xFE, handle.define('XCP_E_ASAM_CMD_UNKNOWN'))
+
+
+def test_get_daq_event_info_reports_the_pool_as_max_daq_list_under_dynamic():
+    """Any allocated list may bind to any event channel, so the pool size is the honest answer."""
+    handle = dynamic_handle(daq_count=4)
+    assert exchange(handle, (0xD7, 0x00, 0x00, 0x00))[2] == 0x04

--- a/test/get_daq_processor_info_test.py
+++ b/test/get_daq_processor_info_test.py
@@ -22,6 +22,19 @@ def daq_handle(**kwargs):
     return handle
 
 
+def dynamic_handle(**kwargs):
+    handle = XcpTest(dynamic_config(**kwargs))
+    connect(handle)
+    return handle
+
+
+def exchange(handle, request, length=8):
+    handle.lib.Xcp_CanIfRxIndication(0x0001, handle.get_pdu_info(request))
+    handle.lib.Xcp_MainFunction()
+    handle.lib.Xcp_CanIfTxConfirmation(0x0002, handle.define('E_OK'))
+    return tuple(handle.can_if_transmit.call_args[0][1].SduDataPtr[0:length])
+
+
 def test_daq_properties_report_what_this_phase_implements():
     """XCP part 2 - Protocol Layer Specification 1.1/1.6.4.1.2.4. DAQ_CONFIG_TYPE static (bit 0
     clear), PRESCALER_SUPPORTED set (bit 1), RESUME/BIT_STIM clear (bits 2-3), TIMESTAMP_SUPPORTED
@@ -128,3 +141,16 @@ def test_timestamp_supported_is_clear_without_a_clock():
     handle = daq_handle()
 
     assert (info(handle)[1] & 0x10) == 0x00
+
+
+def test_get_daq_processor_info_reports_dynamic_configuration_and_the_whole_pool():
+    """DD33. MAX_DAQ is the configured pool, constant across allocation: ECUC_Xcp_00164's
+    dependency is MAX_DAQ = MIN_DAQ + DAQ_COUNT with minDaq 0, and the allocated count would tell
+    a master nothing before it allocates -- which is exactly when it needs to know how much it may
+    ask for."""
+    handle = dynamic_handle(daq_count=4)
+    response = exchange(handle, (0xDA,))
+    assert response[1] & 0b00000001 == 0b00000001      # DAQ_CONFIG_TYPE set
+    assert response[2:4] == (0x04, 0x00)               # MAX_DAQ, little endian
+    exchange(handle, (0xD5, 0x00, 0x02, 0x00))
+    assert exchange(handle, (0xDA,))[2:4] == (0x04, 0x00)   # still the pool, not the 2 allocated

--- a/test/parameter.py
+++ b/test/parameter.py
@@ -206,6 +206,13 @@ class DefaultConfig(dict):
                          }
                      ]
                  },),
+                 daq_config_type='STATIC',
+                 # Read only when daq_config_type is 'DYNAMIC'. A STATIC configuration emits no
+                 # daq_dynamic block at all -- the generator refuses one, since a pool nothing can
+                 # ever allocate from is an integrator saying two incompatible things at once.
+                 daq_count=4,
+                 odt_count=8,
+                 odt_entries_count=16,
                  segments=(),
                  freeze_supported=False,
                  xcp_set_request_api_enable=True,
@@ -242,10 +249,16 @@ class DefaultConfig(dict):
                  xcp_get_daq_resolution_info_api_enable=True,
                  xcp_get_daq_list_info_api_enable=True,
                  xcp_get_daq_event_info_api_enable=True,
-                 xcp_free_daq_api_enable=True,
-                 xcp_alloc_daq_api_enable=True,
-                 xcp_alloc_odt_api_enable=True,
-                 xcp_alloc_odt_entry_api_enable=True,
+                 # False, not True, for the same reason as xcp_write_daq_multiple_api_enable
+                 # above: the generation guard added with SP2d rejects these four being enabled
+                 # under a STATIC configuration, and this class's own daq_config_type default is
+                 # STATIC. Defaulting them True would make DefaultConfig() itself fail to
+                 # generate. A DYNAMIC configuration must enable all four, and the guard rejects
+                 # that direction too -- dynamic_config() below is what supplies the coherent set.
+                 xcp_free_daq_api_enable=False,
+                 xcp_alloc_daq_api_enable=False,
+                 xcp_alloc_odt_api_enable=False,
+                 xcp_alloc_odt_entry_api_enable=False,
                  xcp_program_clear_api_enable=True,
                  xcp_program_api_enable=True,
                  xcp_program_max_api_enable=True,
@@ -310,10 +323,19 @@ class DefaultConfig(dict):
             "user_defined_checksum_function": user_defined_checksum_function,
             "user_cmd_function": user_cmd_function,
             "trailing_value": trailing_value,
-            'identification': identification
+            'identification': identification,
+            "daq_config_type": daq_config_type
         }
         if timestamp is not None:
             protocol_layer["timestamp"] = timestamp
+        # A DAQ_DYNAMIC configuration declares no DAQ lists -- the master allocates them out of
+        # the pool -- so "daqs" is dropped entirely rather than left empty, and with no list to
+        # name, every event's triggered_daq_list_ref goes with it. Both are what the generator's
+        # own coherence guards demand; leaving either in place makes generation fail.
+        events = list(events) if events is not None else [event(name='EVT1')]
+        if daq_config_type == 'DYNAMIC':
+            events = [{key: value for key, value in one.items()
+                       if key != 'triggered_daq_list_ref'} for one in events]
         super(DefaultConfig, self).__init__(configurations=[
             {
                 "communication": {
@@ -327,8 +349,9 @@ class DefaultConfig(dict):
                 # publish_names defaults to True two lines above -- so DefaultConfig's own
                 # fallback event needs a name of its own, or every test that builds DefaultConfig()
                 # without an explicit events= would trip script/source_cfg.c.jinja2's publish_names
-                # guard by accident.
-                "events": list(events) if events is not None else [event(name='EVT1')],
+                # guard by accident. That fallback is applied where `events` is normalised above,
+                # so that the DAQ_DYNAMIC branch there sees it too.
+                "events": events,
                 "apis": {
                     "xcp_set_request_api_enable": {"enabled": xcp_set_request_api_enable, "protected": False},
                     "xcp_get_id_api_enable": {"enabled": xcp_get_id_api_enable, "protected": False},
@@ -396,6 +419,17 @@ class DefaultConfig(dict):
                 "protocol_layer": protocol_layer
             }
         ])
+        if daq_config_type == 'DYNAMIC':
+            configuration = self['configurations'][0]
+            del configuration["daqs"]
+            # pdu_mapping is not a keyword argument of its own: every list the master allocates
+            # out of one pool transmits on the same PDU, and XCP_PDU_ID_TRANSMIT is the name
+            # test/conftest.py compiles a value for -- the same one daq() and the daqs default
+            # above already use.
+            configuration["daq_dynamic"] = {"daq_count": daq_count,
+                                            "odt_count": odt_count,
+                                            "odt_entries_count": odt_entries_count,
+                                            "pdu_mapping": "XCP_PDU_ID_TRANSMIT"}
 
     @property
     def get_id(self):
@@ -424,6 +458,23 @@ class DefaultConfig(dict):
     @property
     def daq_queue_size(self):
         return self._daq_queue_size
+
+
+def dynamic_config(daq_count=4, odt_count=8, odt_entries_count=16, **kwargs):
+    """A DefaultConfig with a dynamic DAQ pool. The four ALLOC APIs must all be enabled: the
+    generator refuses a DAQ_DYNAMIC configuration with any of them disabled, since that is a
+    dynamic build with no way to allocate. `daqs` is left empty because a dynamic configuration
+    declares no lists -- the master allocates them."""
+    return DefaultConfig(daq_config_type='DYNAMIC',
+                         daq_count=daq_count,
+                         odt_count=odt_count,
+                         odt_entries_count=odt_entries_count,
+                         daqs=(),
+                         xcp_free_daq_api_enable=True,
+                         xcp_alloc_daq_api_enable=True,
+                         xcp_alloc_odt_api_enable=True,
+                         xcp_alloc_odt_entry_api_enable=True,
+                         **kwargs)
 
 
 class MultiConfig(dict):

--- a/test/transport_layer_cmd_test.py
+++ b/test/transport_layer_cmd_test.py
@@ -3,6 +3,14 @@
 
 from .parameter import *
 from .conftest import XcpTest
+from .download_test import connect
+
+
+def exchange(handle, request, length=8):
+    handle.lib.Xcp_CanIfRxIndication(0x0001, handle.get_pdu_info(request))
+    handle.lib.Xcp_MainFunction()
+    handle.lib.Xcp_CanIfTxConfirmation(0x0002, handle.define('E_OK'))
+    return tuple(handle.can_if_transmit.call_args[0][1].SduDataPtr[0:length])
 
 
 @pytest.mark.parametrize('rx_pdu_ref, tx_pdu_ref', [(0x0001, 0x0002), (0xFFFE, 0xFFFF)])
@@ -77,6 +85,40 @@ def test_transport_layer_cmd_sub_command_get_daq_list_can_identifier_returns_exp
     print(u32_from_array(bytearray(raw_data[4:8]), byte_order))
     print(daq_pdu_ref)
     assert u32_from_array(bytearray(raw_data[4:8]), byte_order) == daq_pdu_ref
+
+
+def test_get_daq_id_answers_each_allocated_dynamic_list_by_its_own_number():
+    """GET_DAQ_ID scans daqList[..].number for a match (source/Xcp_Std.c), so every DAQ list has to
+    carry its own index -- including a dynamically allocated one.
+
+    The dynamic pool used to be generated with number == 0 in every slot, under a comment claiming
+    ALLOC_DAQ assigned it. Nothing did. The scan therefore matched slot 0 for daq_list_number 0 and
+    nothing at all for any other, so a master that had allocated four lists was told
+    ERR_OUT_OF_RANGE for three of them. 0xF2 is hard-enabled and unprotected, so no configuration
+    gated the failure.
+
+    List 0 alone would not have noticed: it answers correctly under both the broken and the fixed
+    generator. Every list of the pool is swept for that reason, and the out-of-pool number after it
+    pins that the scan is still bounded by daqListCount rather than answering anything at all."""
+    config = dynamic_config(daq_count=4, odt_count=2, odt_entries_count=2)
+    handle = XcpTest(config)
+    connect(handle)
+
+    assert exchange(handle, (0xD5, 0x00, 0x04, 0x00))[0] == 0xFF, 'ALLOC_DAQ(4) was refused'
+
+    for daq_list_number in range(4):
+        answer = exchange(handle, (0xF2, 0xFE) + tuple(u16_to_array(daq_list_number, 'LITTLE_ENDIAN')))
+
+        assert answer[0] == 0xFF, \
+            'GET_DAQ_ID refused allocated DAQ list {}'.format(daq_list_number)
+        # Every list of one dynamic pool shares the single pdu_mapping the daq_dynamic block names,
+        # so the identifier is the same for all four -- what differs between them is only whether
+        # the list is found at all.
+        assert u32_from_array(bytearray(answer[4:8]), 'LITTLE_ENDIAN') == \
+            config.default_daq_dto_pdu_mapping
+
+    assert exchange(handle, (0xF2, 0xFE) + tuple(u16_to_array(0x0004, 'LITTLE_ENDIAN')))[0:2] == \
+        (0xFE, 0x22), 'a list number past the pool was answered rather than refused'
 
 
 def test_transport_layer_cmd_sub_cmd_set_daq_list_can_identifier_returns_err_cmd_unknown():


### PR DESCRIPTION
A master can now allocate DAQ lists, ODTs and ODT entries at runtime, instead of being confined to whatever the generated static configuration happens to contain.

**12619 passed, 29 skipped, 0 failed.** `Xcp_Daq.c` coverage 98.43% of 445 → **98.73% of 553**.

**Spec:** [`2026-09-03-xcp-daq-sp2d-design.md`](docs/superpowers/specs/2026-09-03-xcp-daq-sp2d-design.md), DD25–DD34.

## What it does

`DAQ_CONFIG_TYPE` is one declared bit, so a slave is static or dynamic, never both. `daq_config_type` in the configuration picks which is generated. A `STATIC` build is byte-for-byte what the module produced before and pays no ROM for the dynamic path.

A `DYNAMIC` build declares a pool through the AUTOSAR parameters — `XcpDaqCount` lists × `XcpOdtCount` ODTs per list × `XcpOdtEntriesCount` entries per ODT (ECUC_Xcp_00012 / 00054 / 00059) — which the generator emits zero-initialised into a RAM section. `FREE_DAQ` (0xD6), `ALLOC_DAQ` (0xD5), `ALLOC_ODT` (0xD4) and `ALLOC_ODT_ENTRY` (0xD3) carve it up.

An earlier draft used fungible aggregate pools. That was dropped once the AUTOSAR parameters were actually read: they are per-list and per-ODT, and the module already declared the fields. The spec records why.

## Two things this branch found that it wasn't looking for

**A latent generator defect.** `Xcp_ConfigType.daqListCount` was emitted as `'%04Xu'` with no `0x` — an **octal literal**. One and two DAQ lists read identically in octal and hex, which is why it never showed; eight emit `0008u`, not a valid octal constant, and sixteen emit `0010u`, silently octal 8. It is read in the `GET_ID` DAQ scan, so a sixteen-list configuration would have scanned eight and reported success. Predates SP2d; surfaced only because a 255-list pool test wouldn't compile.

**A cross-task defect no per-task review could see.** The generator emitted `Xcp_DaqListType.number` as `0x0000u` for every pool slot with a comment claiming `ALLOC_DAQ` assigned it; `ALLOC_DAQ` never did. Since `GET_DAQ_ID` scans for `number == daq_list_number`, it answered `ERR_OUT_OF_RANGE` for every allocated dynamic list except 0. One task emitted the field, another owned the handler, and an existing test pinned the wrong value. Only the whole-branch review saw both halves.

## The safety-critical parts

**Freeing runs against a sampler in interrupt context.** `Xcp_TriggerEventChannel` reaches entry storage by walking `maxOdt`, then each ODT's `entryCount`, so a count must never outlive the storage it describes — the DD14 failure class. `FREE_DAQ` stops the lists, zeroes the counts, then resets the cursors, inside the DAQ exclusive area. The unwind is bounded by `daqCount` rather than the allocated count, deliberately: the sampler's bound and the unwind's bound are then the same number, so no list the sampler can reach lies outside what is released.

**`firstPid` is a prefix sum, recomputed on every `ALLOC_ODT`.** Call-order assignment breaks once repeated `ALLOC_ODT` calls are allowed — `ALLOC_ODT(0,2)`, `ALLOC_ODT(1,3)`, `ALLOC_ODT(0,1)` leaves list 0 needing three contiguous PIDs that list 1 already owns. `firstPid[i] = Σ maxOdt[0..i-1]` is order-independent, and it is what the generator already computes for static lists. The regression test allocates out of order and reads `FIRST_PID` back through `START_STOP_DAQ_LIST`.

**A running list's `FIRST_PID` cannot move under it.** Any `entryCount > 0` implies the state is `ODT_ENTRY`; a RUNNING list requires `entryCount > 0`; and `ALLOC_ODT` is refused from `ODT_ENTRY`. The only way back is `FREE_DAQ`, which stops every list first. Three agents verified this independently, and the spec now records its two preconditions — that a refused allocation never advances the state, and that `Xcp_Init`/DISCONNECT zero `entryCount` — because removing either silently breaks the argument.

**SP2d adds no new bounds check.** An unallocated list has `maxOdt == 0` and fails the checks that already exist. The six entry bounds moved from the per-list field to the new per-ODT `entryCount`, comparing the same values under STATIC.

## Known, and deliberate

- **`GET_DAQ_ID` answers positively for an unallocated pool slot.** The value is correct — every dynamic list shares the one configured TX PDU — so the direction is permissive rather than wrong, and a master under DYNAMIC chose its own allocation count. Gating it wants its own task.
- **`PID_OFF` is available only where the TX PDU is exclusive**, which under DYNAMIC means a single-list pool. With one CAN-ID and several lists, §1.1.2.1 identification genuinely cannot be recovered without a PID.
- **`FREE_DAQ` does not flush the DTO ring.** Frames sampled before the unwind still transmit; they were validly sampled and their PIDs match the layout at sample time.
- Three Minor residuals are parked: two inaccurate sentences in test docstrings, and a spec cross-reference that names the wrong tests.

## Verification

Nine tasks, each implemented and reviewed separately, then a whole-branch review and one fix wave. Every new test is mutation-verified — broken deliberately to confirm it fails for the reason it names. That process caught several tests that could not fail as named, including one that asserted its own expected value as its precondition, and one comparing a field against itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
