### PR TITLE
docs: correct three inaccurate claims left parked at the SP2d merge

### DIFF
--- a/docs/superpowers/specs/2026-09-03-xcp-daq-sp2d-design.md
+++ b/docs/superpowers/specs/2026-09-03-xcp-daq-sp2d-design.md
@@ -314,6 +314,19 @@ Bytes 2,3 are `DAQ_LIST_NUMBER`; byte 4 is `ODT_NUMBER`, relative within the lis
   keeps its allocation. Its behaviour is unchanged in both models.
 - **`SET_DAQ_PTR` and `WRITE_DAQ` against an unallocated list** are refused by the bounds checks
   that already exist, since `maxOdt` is zero.
+- **`GET_DAQ_ID` answers for any slot in the pool, allocated or not.** Each pool slot is generated
+  carrying its own `XcpDaqListNumber` (its index), which is what `Xcp_Std.c` scans for. Before
+  that they all carried `0x0000u`, under a comment claiming `ALLOC_DAQ` assigned it — which it
+  never did — so the command refused every allocated dynamic list except slot 0. Fixing it widens
+  a pre-existing false positive rather than closing it: a slot the master never allocated now
+  answers positively, where previously only slot 0 did.
+
+  That is deliberate. The value returned is correct, since every dynamic list shares the one
+  configured TX PDU, so the direction is permissive rather than wrong, and under DYNAMIC the
+  master chose its own allocation count. Gating it on `allocated_daq_count` is perfectly possible
+  — `Xcp_Std.c` already reaches `Xcp_Internal`, and the gate is a no-op under STATIC where
+  `allocated_daq_count` equals `daqCount` — but it is a new refusal on a command SP2d otherwise
+  does not touch, so it belongs in its own task with its own test.
 - **`PID_OFF` under DYNAMIC is available only in a pool configured with exactly one list.** All
   dynamic lists share the configured `pdu_mapping`, so SP2b's rule applies unchanged:
   `Xcp_DaqListTxPduIsExclusive` is true only while no other list shares that PDU. The
@@ -415,7 +428,10 @@ strings are documentation for whoever reads the template.
      be accepted, and `FIRST_PID` would move under a list that is already running. Pinned by
      `test_alloc_odt_entry_refusal_leaves_the_allocation_state_unadvanced` and its two siblings for
      `ALLOC_ODT` and `ALLOC_DAQ`; all three exist for this reason and are not redundant with each
-     other.
+     other. Those three catch the state moving. What the moved state then *permits* — the second
+     `ALLOC_ODT`, the one that would be wrongly accepted — is pinned only by
+     `test_alloc_odt_refused_by_sequence_does_not_reopen_the_odt_state`, which is the sole test
+     that sends it.
   2. **`Xcp_Init` and `DISCONNECT` must zero every ODT's `entryCount`.** The state machine's memory
      of "this list has entries" is `daq_alloc_state`, which both paths reset to `FREE`. If the
      counts survived while the state did not, a list would re-enter `ALLOC_ODT` carrying entries

--- a/test/daq_dynamic_acceptance_test.py
+++ b/test/daq_dynamic_acceptance_test.py
@@ -194,9 +194,10 @@ def test_set_daq_ptr_is_refused_on_a_list_the_master_never_allocated():
     ALLOC_DAQ before the request, so the only thing it ever exercised was the second case.
 
     What the wire says and does not say. Both cases answer ERR_OUT_OF_RANGE (1.1/1.6.4.1.1.1, "If
-    the specified list is not available") and SET_DAQ_PTR has two checks that produce it -- the
-    Xcp_DaqListIsValid gate and `odt_number >= maxOdt` three branches later -- so the response does
-    not identify which one fired, and this test does not claim to. It claims the outcome: neither
+    the specified list is not available") and SET_DAQ_PTR has three checks that produce it -- the
+    Xcp_DaqListIsValid gate, `odt_number >= maxOdt` two branches later (the RUNNING check sits
+    between them and answers a different code), and `odt_entry_number >= entryCount` after that --
+    so the response does not identify which one fired, and this test does not claim to. It claims the outcome: neither
     an unallocated list nor an allocated list with no ODTs may be pointed at. Which branch answers
     the first case is pinned separately, by
     test_a_dynamic_build_has_no_valid_daq_lists_until_alloc_daq above, through CLEAR_DAQ_LIST --
@@ -240,11 +241,19 @@ def test_pid_off_under_dynamic_follows_the_shared_tx_pdu_rule(daq_count, accepte
     exchange(handle, (0xD4, 0x00, 0x00, 0x00, 0x01))
     # SET_DAQ_LIST_MODE with PID_OFF (bit 5) on list 0, event channel 0, prescaler 1, priority 0.
     result = exchange(handle, (0xE0, 0x20, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00))
-    # The refused case pins ERR_MODE_NOT_VALID specifically rather than "some error": SET_DAQ_LIST_
-    # MODE has four other refusals (OUT_OF_RANGE for the list, the event channel and the prescaler,
-    # SEQUENCE for a running list), so `result[0] == 0xFF` being False would be satisfied by the
-    # refusal migrating to any of them -- including ones that would refuse this request whether or
-    # not the shared-TX-PDU rule existed at all.
+    # The refused case pins ERR_MODE_NOT_VALID rather than "some error": SET_DAQ_LIST_MODE refuses
+    # in nine places, eight of them other than the shared-TX-PDU rule -- five ERR_OUT_OF_RANGE (the
+    # list, the event channel, and three on the prescaler and priority), one ERR_DAQ_ACTIVE for a
+    # running list, and two more ERR_MODE_NOT_VALID (an unsupported mode bit, and TIMESTAMP where
+    # the configuration declares no clock). So `result[0] == 0xFF` being False would be satisfied
+    # by the refusal migrating to any of them, including ones that would refuse this request
+    # whether or not the shared-TX-PDU rule existed.
+    #
+    # Pinning 0x27 therefore narrows the field to three branches rather than isolating one. It is
+    # still worth pinning: the mode byte here is PID_OFF alone, so neither of the other two can
+    # fire -- an unsupported bit needs DIRECTION or ALTERNATING set, and the TIMESTAMP branch needs
+    # bit 4 -- which makes 0x27 unambiguous for this request specifically. A wider sweep over mode
+    # bytes would need to distinguish them some other way.
     if accepted:
         assert result[0] == 0xFF
     else:


### PR DESCRIPTION
The three residuals parked at SP2d's merge, plus the `GET_DAQ_ID` note §6 was missing. **12619 passed, 29 skipped.** No functional change — two test docstrings and the design document.

I parked these on the grounds that a second fix wave costs more than three sentences. That doesn't survive the observation that all three are the same defect class this branch spent effort eliminating: **a confident claim about control flow that nobody checked against the control flow.** Each was verified against the source before being rewritten.

## What was wrong

**`SET_DAQ_PTR`** — the docstring claimed two checks produce `ERR_OUT_OF_RANGE`, and that the `maxOdt` bound sits three branches past the validity gate. There are **three** producers (validity gate, `maxOdt`, `entryCount`), and `maxOdt` is **two** branches later — the RUNNING check sits between them and answers a different code.

**`PID_OFF`** — the docstring claimed `SET_DAQ_LIST_MODE` has four other refusals, one being `ERR_SEQUENCE` for a running list. It refuses in **nine** places, eight other than the shared-TX-PDU rule, and a running list answers **`ERR_DAQ_ACTIVE`**.

The substantive part: **two of those eight also answer `ERR_MODE_NOT_VALID`**, so pinning `0x27` narrows the field to three branches rather than isolating one, which is what the docstring's own rationale claimed it did. The pin is still worth having — the mode byte here is `PID_OFF` alone, and neither other branch can fire without `DIRECTION`, `ALTERNATING` or bit 4 set — but that's the reason, and it's now the reason given. A wider sweep over mode bytes would need to distinguish them some other way.

**Design §9, precondition 1** — it spelled out the scenario the `FIRST_PID` argument breaks under (the *second* `ALLOC_ODT`, the one a wrongly advanced state would accept) and then credited three tests that stop short of sending it. The test that does send it went uncredited. The siblings catch the state moving; `test_alloc_odt_refused_by_sequence_does_not_reopen_the_odt_state` catches what the moved state permits.

## The `GET_DAQ_ID` residual, now recorded in §6

§6 had no `GET_DAQ_ID` entry at all, so this decision lived only in a merged PR description.

Generating each pool slot with its own list number fixed a command that refused every allocated dynamic list except slot 0. But it **widens** a pre-existing false positive rather than closing it: a slot the master never allocated now answers positively, where before only slot 0 did.

That is deliberate. The value returned is correct — every dynamic list shares the one configured TX PDU — so the direction is permissive rather than wrong, and under DYNAMIC the master chose its own allocation count. Gating it on `allocated_daq_count` is entirely possible; `Xcp_Std.c` already reaches `Xcp_Internal`, and the gate is a no-op under STATIC where the two counts are equal. It is a new refusal on a command SP2d otherwise doesn't touch, so it belongs in its own task with its own test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
