### PR TITLE
fix: answer GET_DAQ_ID only for DAQ lists the master has allocated

### DIFF
--- a/source/Xcp_Std.c
+++ b/source/Xcp_Std.c
@@ -428,7 +428,16 @@ uint8 Xcp_DTOCmdStdTransportLayerCmd(boolean *responseExpected, const PduInfoTyp
 
                 object_found = FALSE;
 
-                for (daq_list_idx = 0x00u; daq_list_idx < Xcp_Ptr->config->daqListCount; daq_list_idx ++) {
+                /* Bounded by what the master has allocated, not by the configured pool. Under a
+                 * static configuration Xcp_Init seeds allocated_daq_count from daqCount, and the
+                 * generator emits daqListCount and XcpDaqCount from one expression, so the two
+                 * bounds are the same number and this reads exactly as it always did. Under a
+                 * dynamic one they differ until ALLOC_DAQ runs, and scanning the whole pool would
+                 * answer for a slot the master never allocated -- reporting a CAN-Id for a DAQ
+                 * list that does not exist yet. Each pool slot carries its index as its number
+                 * (script/source_cfg.c.jinja2), so an unallocated slot is simply not reached and
+                 * the ERR_OUT_OF_RANGE below is what the master gets. */
+                for (daq_list_idx = 0x00u; daq_list_idx < Xcp_Internal.allocated_daq_count; daq_list_idx ++) {
                     if (Xcp_Ptr->config->daqList[daq_list_idx].number == daq_list_number) {
                         object_found = TRUE;
 
@@ -448,7 +457,14 @@ uint8 Xcp_DTOCmdStdTransportLayerCmd(boolean *responseExpected, const PduInfoTyp
 
                         Xcp_FinalizeResPacket(0x08u, &Xcp_Internal.cto_response.pdu_info);
                     } else {
-
+                        /* Unreachable for any schema-valid configuration -- config/xcp.schema.json
+                         * gives `dtos` minItems 1, so every generated DAQ list has at least one
+                         * DTO. It was an empty branch, which is worse than unreachable: it left
+                         * the response buffer holding whatever the previous command wrote while
+                         * responseExpected stayed TRUE, so the master would have read a stale
+                         * positive response. That is the defect class D2 and D7 fixed twice in
+                         * SP1; an unreachable trap is still a trap. */
+                        Xcp_FillErrorPacket(XCP_E_ASAM_OUT_OF_RANGE, &Xcp_Internal.cto_response.pdu_info);
                     }
                 } else {
                     Xcp_FillErrorPacket(XCP_E_ASAM_OUT_OF_RANGE, &Xcp_Internal.cto_response.pdu_info);

--- a/test/transport_layer_cmd_test.py
+++ b/test/transport_layer_cmd_test.py
@@ -133,3 +133,36 @@ def test_transport_layer_cmd_sub_cmd_set_daq_list_can_identifier_returns_err_cmd
     handle.lib.Xcp_MainFunction()
 
     assert tuple(handle.can_if_transmit.call_args[0][1].SduDataPtr[0:2]) == (0xFE, 0x20)
+
+
+def test_get_daq_id_refuses_a_pool_slot_the_master_never_allocated():
+    """The scan is bounded by Xcp_Internal.allocated_daq_count, not by the configured pool.
+
+    Giving every pool slot its own number fixed a scan that refused allocated lists, but it widened
+    the other half of the same defect: with the whole pool scanned, a slot inside daq_count that
+    ALLOC_DAQ had never handed out was found and answered positively -- reporting a CAN-Id for a
+    DAQ list the master does not hold. The value returned was even correct, since every dynamic
+    list shares the one configured TX PDU, which is exactly what made it easy to leave.
+
+    Allocating 2 of a 4-slot pool is what separates the two bounds: lists 0 and 1 must answer, and
+    lists 2 and 3 must not, though all four exist in the generated descriptor and carry their own
+    numbers. A scan bounded by daqListCount answers for all four and fails here.
+
+    Under a static configuration the two bounds are the same number -- Xcp_Init seeds
+    allocated_daq_count from daqCount, and the generator emits daqListCount and XcpDaqCount from a
+    single expression -- so this gate cannot change static behaviour. That is pinned by
+    test_get_daq_id_returns_the_can_id_of_a_daq_list above, which runs on a static configuration."""
+    config = dynamic_config(daq_count=4, odt_count=2, odt_entries_count=2)
+    handle = XcpTest(config)
+    connect(handle)
+
+    assert exchange(handle, (0xD5, 0x00, 0x02, 0x00))[0] == 0xFF, 'ALLOC_DAQ(2) was refused'
+
+    for daq_list_number in (0, 1):
+        assert exchange(handle, (0xF2, 0xFE) + tuple(u16_to_array(daq_list_number, 'LITTLE_ENDIAN')))[0] == 0xFF, \
+            'GET_DAQ_ID refused allocated DAQ list {}'.format(daq_list_number)
+
+    for daq_list_number in (2, 3):
+        assert exchange(handle, (0xF2, 0xFE) +
+                        tuple(u16_to_array(daq_list_number, 'LITTLE_ENDIAN')))[0:2] == (0xFE, 0x22), \
+            'GET_DAQ_ID answered for pool slot {}, which ALLOC_DAQ never handed out'.format(daq_list_number)


### PR DESCRIPTION
Closes the residual SP2d recorded in design §6 as a known limitation. **12620 passed, 29 skipped.**

## The defect

`TRANSPORT_LAYER_CMD`'s `GET_DAQ_ID` scanned the whole configured pool for a matching list number. Under a dynamic configuration a slot inside `daq_count` that `ALLOC_DAQ` had never handed out was found and **answered positively** — reporting a CAN-Id for a DAQ list the master does not hold.

The value returned was even correct, since every dynamic list shares the one configured TX PDU. That is exactly what made it easy to leave.

## Why it existed

This half was created by fixing the other half. Before SP2d's final fix wave, every pool slot carried `number == 0`, so the scan matched slot 0 and nothing else — an allocated list other than 0 was **refused**. Giving each slot its index fixed that and widened the false positive from slot 0 alone to every slot in the pool. Both halves are now closed.

## The fix

The scan is bounded by `Xcp_Internal.allocated_daq_count`.

**Static configurations are provably unaffected.** `Xcp_Init` seeds `allocated_daq_count` from `daqCount`, and [source_cfg.c.jinja2:548](script/source_cfg.c.jinja2:548) and [:620](script/source_cfg.c.jinja2:620) emit `daqListCount` and `XcpDaqCount` from one expression — so the two bounds are the same number there, and the scan reads exactly as it always did. That is pinned by the pre-existing static test, which still passes untouched.

## One adjacent fix

Three lines below sat an empty `else`: a DAQ list with `dtoCount == 0` left the response buffer holding whatever the previous command had written, while `responseExpected` stayed `TRUE` — so the master would read a **stale positive response**.

It is unreachable for any schema-valid configuration (`dtos` has `minItems: 1`), which is why it was deferred. But that is the defect class D2 and D7 each fixed in SP1, and an unreachable trap is still a trap — it becomes reachable the moment someone relaxes the schema. It now fills `ERR_OUT_OF_RANGE`.

## Verification

Mutation-verified: restoring the `daqListCount` bound fails `test_get_daq_id_refuses_a_pool_slot_the_master_never_allocated` and nothing else, across 59 transport-layer and dynamic-DAQ tests.

The new test allocates **2 of a 4-slot pool**, which is what separates the two bounds — lists 0 and 1 must answer, 2 and 3 must not, though all four exist in the generated descriptor carrying their own numbers. A scan bounded by `daqListCount` answers for all four.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
