### PR TITLE
fix: a PID_OFF list grown past one ODT is no longer transmitted

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,13 @@ does not support it is answered with `ERR_MODE_NOT_VALID`.
 - The `GET_SLAVE_ID` command (CTO = `TRANSPORT_LAYER_CMD`, sub-command = `0xFF`) returns the PDU ID of the 
   **CMD**/**STIM** communication channel rather than the CAN identifier itself, to avoid a dependency on the PDU 
   mapping table in this module.
+- `SET_DAQ_ID` (CTO = `TRANSPORT_LAYER_CMD`, sub-command = `0xFD`) is **deliberately not implemented** and
+  answers `ERR_CMD_UNKNOWN`. AUTOSAR SWS XCP R4.3.1 §4.1 *Limitations* puts it out of scope in so many words —
+  "The SET_DAQ_ID command according to the XCP CAN Transport Layer Specification is not part of the AUTOSAR XCP
+  module" — so this is conformance with the SWS this module tracks, not an unfinished feature. Implementing it
+  would also require `CanIf_SetDynamicTxId` (SWS_CANIF_00189) and an integrator guarantee that every DAQ transmit
+  PDU is configured as a *dynamic* L-PDU, neither of which this module can verify. `GET_DAQ_ID` (`0xFE`)
+  consequently reports the identifier as fixed, which is the truthful answer for a slave that cannot change it.
 - The `GET_ID` command only supports the request identification type 0 (*ASCII text*).
 - `SHORT_DOWNLOAD` can transfer no data at all when `MAX_CTO` is 8, as it is for XCP on CAN, because the command's
   own header fills the whole frame. The specification notes this. The stack still accepts the command, and rejects any
@@ -318,9 +325,10 @@ does not support it is answered with `ERR_MODE_NOT_VALID`.
   integrator who enables the API without also raising `max_cto` to at least 10 gets a code-generation failure,
   and one who raises `max_cto` to exactly 10 gets a frame no CAN network carries.
 - No `ALTERNATING` and no DAQ list prioritisation — both SP2c: a priority above 0 is refused with
-  `ERR_OUT_OF_RANGE`, which §1.6.4.1.1.3 requires of a slave that does not support it. No STIM direction (SP3).
-- DAQ list configuration is static only (SP2d). `FREE_DAQ` and the three `ALLOC_*` commands (`ALLOC_DAQ`,
-  `ALLOC_ODT`, `ALLOC_ODT_ENTRY`) answer `ERR_CMD_UNKNOWN`.
+  `ERR_OUT_OF_RANGE`, which §1.6.4.1.1.3 requires of a slave that does not support it.
+- Synchronous data stimulation is implemented (SP3), less `BIT_STIM` and `EV_STIM_TIMEOUT`, and less runtime
+  protection of the `STIM` resource — a configuration that is stimulation-capable *and* declares `STIM` protected
+  is refused at generation rather than shipped with a gate that does nothing.
 - At most one DTO frame is in flight at a time (SP2c): `Xcp_StartNextTransmission` arbitrates a single transmit
   slot across command responses, event packets and DAQ frames alike, and starts the next one only once the
   current one is confirmed. This is mandatory rather than a simplification, not merely a design choice this
@@ -340,4 +348,4 @@ does not support it is answered with `ERR_MODE_NOT_VALID`.
   transmit arbitration state (`Xcp_Internal.ongoing_transmit_type`) and the event queue are now covered by the
   exclusive area described under *Data acquisition*; everything else the module holds across contexts is not.
 - Use pre-processor to enable/disable optional APIs.
-- Implement sub-command `SET_DAQ_LIST_CAN_IDENTIFIER` for CTO `TRANSPORT_LAYER_CMD`.
+- Implement `BIT_STIM` and `EV_STIM_TIMEOUT`, and gate the `STIM` resource at runtime (all deferred from SP3).

--- a/docs/superpowers/plans/2026-09-04-xcp-stim-sp3.md
+++ b/docs/superpowers/plans/2026-09-04-xcp-stim-sp3.md
@@ -16,7 +16,7 @@
 - **Nothing is added to the CTO dispatch path** — no exclusive area, no guard on any handler reached from it. DD36 depends on this and §9 of the spec makes it an acceptance criterion.
 - **Memory is never written in receive context.** Reception copies bytes into a slot; the trigger writes memory. DD36.
 - **The payload length is written under `SchM_Enter_Xcp_StimBuffer` together with the payload.** A length paired with its data is the DD14 class. DD37.
-- **A `DAQ_STIM` list applies before it samples**, so `StimBuffer` sections close before any `DtoQueue` section opens and the two areas cannot nest. DD40.
+- ~~**A `DAQ_STIM` list applies before it samples**, so `StimBuffer` sections close before any `DtoQueue` section opens and the two areas cannot nest. DD40.~~ **Corrected after the fact, 2026-09-05:** a `DAQ_STIM` list does not do both on one trigger at all — §1.6.4.1.1.3's `DIRECTION` flag selects acquisition *or* stimulation. The passes are still ordered stimulation-first, and the areas still cannot nest, but not for this reason. See DD40 and DD37 in the design document.
 - **STIM absolute ODT numbers cap at `0xBF`**; the ceiling for a STIM-capable configuration is `0xC0`, not the `0xFC` of `XCP_DAQ_ABSOLUTE_ODT_COUNT_MAX`. DD42.
 - **A timestamp is present on ODT 0 of a timestamped list**, sized by `Xcp_TimestampWireSize(Xcp_Ptr->general->timestampType)`, and is parsed and discarded. DD44.
 - **An ODT entry with a non-zero `addressExtension` is skipped on apply and `Det`-reported** — `Xcp_WriteSlaveMemoryTable` has no parameter for it. DD45.
@@ -567,6 +567,8 @@ Per DD45, skip an entry whose `addressExtension` is non-zero and `Det`-report it
 
 Per DD40 the apply precedes the sampling loop. That ordering is load-bearing, not stylistic: it is what makes every `StimBuffer` section close before the first `DtoQueue` section opens, so the two areas cannot nest. Say so in the comment.
 
+> **Corrected after the fact, 2026-09-05.** The paragraph above is what Task 7 was asked to do and is left as written. Its premise is not: DD40 originally held that a `DAQ_STIM` list applies *and* samples on one trigger, and §1.6.4.1.1.3 says `DIRECTION` puts a list into one mode or the other. The two-pass ordering and the non-nesting conclusion both survive the correction; the reason given for them does not. The shipped comment says the corrected thing. **Do not copy this block forward.**
+
 - [ ] **Step 5: Run the tests, then the full suite.**
 - [ ] **Step 6: Mutation-verify** — clear the slot after applying (making it one-shot) and confirm the latched test fails; move the apply after the sampling loop and confirm the harness's nesting assertion catches it.
 - [ ] **Step 7: Commit**
@@ -594,6 +596,8 @@ Asserting the frame was accepted, or that the slot holds it, tests the plumbing 
 - [ ] **Step 2: Add the `DAQ_STIM` ordering test**
 
 A list that both samples and applies on one event: assert the sampled frame carries the value the stimulus just wrote, which is what DD40's apply-before-sample ordering exists to guarantee.
+
+> **Corrected after the fact, 2026-09-05.** No such list exists. §1.6.4.1.1.3's `DIRECTION` flag puts a `DAQ_STIM` list into acquisition *or* stimulation mode, never both on one trigger, so this step describes a test that cannot be written. It was caught by Task 8's reviewer before Task 9 wrote it, and the shipped suite asserts the mode partition instead. **Do not copy this block forward.**
 
 - [ ] **Step 3: Report `MAX_ODT_ENTRY_SIZE_STIM`**
 

--- a/docs/superpowers/specs/2026-08-29-xcp-part2-roadmap.md
+++ b/docs/superpowers/specs/2026-08-29-xcp-part2-roadmap.md
@@ -78,7 +78,7 @@ positive response without doing anything, which was defect D2, fixed in SP1.
 | 0xF5 | UPLOAD | done — D1 fixed in SP1 |
 | 0xF4 | SHORT_UPLOAD | done |
 | 0xF3 | BUILD_CHECKSUM | done |
-| 0xF2 | TRANSPORT_LAYER_CMD | partial — `GET_SLAVE_ID` only; `SET_DAQ_LIST_CAN_ID` absent |
+| 0xF2 | TRANSPORT_LAYER_CMD | done — `GET_SLAVE_ID` and `GET_DAQ_ID`; `SET_DAQ_ID` excluded by SWS_Xcp §4.1 |
 | 0xF1 | USER_CMD | done |
 
 ### 2.2 Calibration commands (§1.4.2, §1.6.2)
@@ -433,8 +433,17 @@ schedulable whenever flash programming becomes a requirement.
 ### SP5 — Protocol completion
 
 The residue: the interleaved communication model (§1.7.2.3), `EV_CMD_PENDING` (§1.7.2.4.2),
-RESUME mode, `GET_ID` identification types 1–4 and 128–255 (§1.6.1.2.2),
-`SET_DAQ_LIST_CAN_ID`, the remaining `EV_*` event codes and the `SERV_*` service request codes.
+RESUME mode, `GET_ID` identification types 1–4 and 128–255 (§1.6.1.2.2), the remaining `EV_*` event
+codes and the `SERV_*` service request codes.
+
+`SET_DAQ_ID` was listed here and has been **removed from the roadmap rather than deferred within
+it**. AUTOSAR SWS XCP R4.3.1 §4.1 puts it out of scope — "The SET_DAQ_ID command according to the
+XCP CAN Transport Layer Specification is not part of the AUTOSAR XCP module" — and this module
+tracks that SWS. Two things would have to be settled before revisiting it: its normative definition
+lives in the XCP CAN Transport Layer specification, which is not in `docs/external`, and changing a
+transmit identifier at runtime needs `CanIf_SetDynamicTxId` (SWS_CANIF_00189) plus an integrator
+guarantee that every DAQ transmit PDU is a dynamic L-PDU. The slave answers `ERR_CMD_UNKNOWN`,
+which §1.4 prescribes, and `GET_DAQ_ID` reports the identifier as fixed.
 
 Note that time-out handling itself is *not* here: §1.7.2 places the t1…t6 timers entirely on
 the master. `EV_CMD_PENDING` and the interleaved request queue are the slave's whole share
@@ -470,7 +479,7 @@ Three things this must get right, all of them discovered by D9:
   module's advertisement and its refusals are currently consistent; changing one without the
   others is what would make it incoherent.
 
-**Dependencies.** `SET_DAQ_LIST_CAN_ID` and SP5-NV both depend on SP2 — RESUME is a
+**Dependencies.** RESUME and SP5-NV both depend on SP2 — RESUME is a
 `SET_DAQ_LIST_MODE` bit backed by `STORE_DAQ_REQ` persistence, and the session configuration
 id is persisted and cleared through the same DAQ storage mechanism. Only the interleaved
 model, `EV_CMD_PENDING`, `GET_ID` types and the `SERV_*` codes are genuinely independent and

--- a/docs/superpowers/specs/2026-08-29-xcp-part2-roadmap.md
+++ b/docs/superpowers/specs/2026-08-29-xcp-part2-roadmap.md
@@ -148,9 +148,10 @@ triggering a DAQ event, and ECUC_Xcp_00014 states the module does not require it
 function period, so a module-driven raster could not have been built on anything the
 configuration is allowed to know.
 
-The timestamp field (§1.1.2.2) and `PID_OFF` landed in SP2b. Still absent from the runtime:
-`ALTERNATING`, DAQ list prioritisation and more than one outstanding DTO frame — all SP2c — and
-STIM reception in `Xcp_CanIfRxIndication`, which remains SP3.
+The timestamp field (§1.1.2.2) and `PID_OFF` landed in SP2b; STIM reception in
+`Xcp_CanIfRxIndication` landed in SP3. Still absent from the runtime: `ALTERNATING`, DAQ list
+prioritisation and more than one outstanding DTO frame — all SP2c — and, from SP3, `BIT_STIM` and
+`EV_STIM_TIMEOUT`.
 
 ### 2.5 Non-volatile memory programming (§1.4.5, §1.6.5)
 
@@ -391,24 +392,38 @@ then command surface, then runtime. That was rejected when the design was writte
 is independently shippable, since configured lists that never transmit have no value to a
 master.
 
-### SP3 — Synchronous data stimulation (STIM)
+### SP3 — Synchronous data stimulation (STIM) — **complete**
 
-STIM reception in `Xcp_CanIfRxIndication`, `DAQ_STIM` and `STIM` event channel types.
-Depends on SP2 for the DAQ list infrastructure it reuses wholesale.
+STIM reception in `Xcp_CanIfRxIndication`, `DAQ_STIM` and `STIM` DAQ list types. Depends on SP2 for
+the DAQ list infrastructure it reuses wholesale.
 
-**Concurrency question SP3 must answer, found in SP2b.** SWS_Xcp_00813 specifies
-`Xcp_<Lo>RxIndication` as *"Reentrant for different PduIds. Non reentrant for the same PduId."*
-Every CTO command reaches the module on one PduId — `channel_rx_pdu_ref->id` — so CanIf's own
-contract prevents a CTO from racing itself, and no exclusive area guards `cto_response`, `last_pid`
-or the protection-status clear today.
+Design: `2026-09-04-xcp-stim-sp3-design.md` (DD35–DD48).
 
-**STIM breaks that.** DAQ_STIM receive PDUs are *different* PduIds, so a stimulation indication may
-preempt a CTO command mid-dispatch. The branch that will host it already exists in
-`Xcp_CanIfRxIndication` and today only sets `valid_pdu_id`, touching nothing shared. The moment
-SP3's handler touches the response buffer, the DAQ pointer, the runtime mode bits or the DTO ring,
-the race is real and needs an exclusive area around the busy-check/dispatch/set-flag sequence —
-which affects all 256 PID entries and is a design decision, not an implementation detail.
-Settle it in SP3's design; do not discover it in review.
+**The concurrency question this sub-project had to answer, found in SP2b, and how it was answered.**
+SWS_Xcp_00813 specifies `Xcp_<Lo>RxIndication` as *"Reentrant for different PduIds. Non reentrant
+for the same PduId."* Every CTO command reaches the module on one PduId — `channel_rx_pdu_ref->id`
+— so CanIf's own contract prevents a CTO from racing itself, and no exclusive area guards
+`cto_response`, `last_pid` or the protection-status clear. DAQ_STIM receive PDUs are *different*
+PduIds, so a stimulation indication may preempt a CTO command mid-dispatch, and the fear was that
+guarding it would need an exclusive area around the whole busy-check/dispatch/set-flag sequence.
+
+It did not. **DD36** keeps the receive path off everything the dispatch touches: reception copies
+the frame into a per-ODT slot and returns, and the event trigger — not the receive context — writes
+ECU memory. The slot is guarded by its own exclusive area, `SchM_Enter_Xcp_StimBuffer` (**DD37**),
+which is disjoint from the DTO ring's. Nothing was added to the CTO dispatch path, and a DAQ-only
+build is byte-for-byte unchanged.
+
+**DD46** settled the routing that the original note did not anticipate: CTO and DTO are told apart
+by the *receiving PduId*, not by the frame's first byte. Splitting on the byte would have let a
+`PID_OFF` stimulation payload whose first byte fell in `0xC0..0xFF` be dispatched as a command —
+which, past the handler, also clears the protection status and so silently revokes a completed
+seed-and-key unlock.
+
+**Deferred out of SP3, each needing its own design:** `BIT_STIM`, `EV_STIM_TIMEOUT`, and runtime
+protection of the STIM resource (**DD41** — `Xcp_PIDToCmdGroupTable` is a per-PID mask that cannot
+express a predicate on a command's argument, and `SET_DAQ_LIST_MODE` has no `ERR_ACCESS_LOCKED` in
+its error set). Until that lands, **DD48** makes generation refuse the one configuration where the
+gap would be visible: stimulation-capable *and* declaring the STIM resource protected.
 
 ### SP4 — Non-volatile memory programming (PGM)
 

--- a/docs/superpowers/specs/2026-09-04-xcp-stim-sp3-design.md
+++ b/docs/superpowers/specs/2026-09-04-xcp-stim-sp3-design.md
@@ -241,8 +241,12 @@ check could be added to the DAQ commands alone. What actually blocks it is narro
   set". The table is the wrong shape, so the check has to move, not be re-tabulated.
 - **`SET_DAQ_LIST_MODE` has no `ERR_ACCESS_LOCKED` in its error set** (§1.7.3.2.4). A handler-side
   refusal would therefore have to answer with an error code the specification does not list for
-  that command — the same objection Task 6 honoured when it declined to invent one for `ALLOC_ODT`,
-  and it applies unchanged here.
+  that command — the same objection Task 6 honoured when it declined to invent one for `ALLOC_ODT`.
+  This is an obstacle, not a proof of impossibility, and the original wording ("it applies
+  unchanged here") overstated it: §1.7.3.2.4 lists the errors a command is *expected* to produce,
+  and a slave that adds `ERR_ACCESS_LOCKED` there is answering a request it genuinely refused
+  rather than inventing a meaning. What makes it an obstacle is that the choice deserves its own
+  argument, which is exactly why per-direction protection is deferred rather than settled here.
 
 Together those make per-direction protection its own design, not a line in this sub-project.
 

--- a/interface/Xcp.h
+++ b/interface/Xcp.h
@@ -251,6 +251,33 @@ extern "C" {
  */
 #define XCP_E_STIM_NOT_APPLIED (0x07u)
 
+/**
+ * @brief A DAQ list was not sampled because its DTOs would have reached the master unidentifiable.
+ * @details Raised by Xcp_TriggerEventChannel (source/Xcp_DaqRuntime.c) for a running list that has
+ * PID_OFF set and more than one ODT. Such a list would put several DTOs on one PDU carrying no
+ * identification field and nothing else to tell them apart, so it is skipped whole.
+ *
+ * The state is reachable only by drift. Xcp_DTOCmdDaqSetDaqListMode (source/Xcp_Daq.c) grants
+ * PID_OFF against three conditions -- ABSOLUTE identification, a single ODT, and a TX PDU no other
+ * list shares -- but a grant describes the moment the command ran. Under DAQ_DYNAMIC the master
+ * may allocate further ODTs to that list afterwards: ALLOC_ODT is legal after ALLOC_ODT and no
+ * ERR_SEQUENCE rule in XCP part 2 - Protocol Layer Specification 1.1/1.6.4.2.1.3 forbids it, so
+ * the second allocation succeeds and leaves PID_OFF set on a list of two ODTs.
+ * @note This error is not part of the specification, and Det is the only channel the skip has: the
+ * trigger is a vendor API answering no master, so there is no error packet and nobody waiting on
+ * one. The specification does not say what a slave does here. It requires only that PID_OFF go
+ * with ABSOLUTE identification, and assigns the rest to the transport -- 1.1/1.1.2.1: "If the
+ * Identification Field is not transferred in the XCP Packet, the unambiguous identification has to
+ * be done on the level of the Transport Layer", of which one CAN-Id and one ODT per list is the
+ * example it offers, not a rule it imposes. This module adopts that example as its grant rule
+ * because on CAN every ODT of a list shares one TX PDU, leaving the transport nothing to
+ * disambiguate with; skipping here keeps that self-imposed invariant true at the moment of use,
+ * rather than emitting frames whose identification the specification requires and this transport
+ * cannot supply. The master is told nothing -- no event code exists for "your configuration
+ * became unrepresentable" -- so Det is where an integrator sees it.
+ */
+#define XCP_E_DAQ_LIST_NOT_IDENTIFIABLE (0x08u)
+
 /** @} */
 
 /**

--- a/source/Xcp.c
+++ b/source/Xcp.c
@@ -129,198 +129,198 @@ static void Xcp_TransmitOneFrame(void);
 #include "Xcp_MemMap.h"
 
 static uint8 (* const Xcp_PIDTable[0x100u])(boolean *responseExpected, const PduInfoType *pPduInfo) = {
-    Xcp_DTODaqStimPacket, /* 0x00 */
-    Xcp_DTODaqStimPacket, /* 0x01 */
-    Xcp_DTODaqStimPacket, /* 0x02 */
-    Xcp_DTODaqStimPacket, /* 0x03 */
-    Xcp_DTODaqStimPacket, /* 0x04 */
-    Xcp_DTODaqStimPacket, /* 0x05 */
-    Xcp_DTODaqStimPacket, /* 0x06 */
-    Xcp_DTODaqStimPacket, /* 0x07 */
-    Xcp_DTODaqStimPacket, /* 0x08 */
-    Xcp_DTODaqStimPacket, /* 0x09 */
-    Xcp_DTODaqStimPacket, /* 0x0A */
-    Xcp_DTODaqStimPacket, /* 0x0B */
-    Xcp_DTODaqStimPacket, /* 0x0C */
-    Xcp_DTODaqStimPacket, /* 0x0D */
-    Xcp_DTODaqStimPacket, /* 0x0E */
-    Xcp_DTODaqStimPacket, /* 0x0F */
-    Xcp_DTODaqStimPacket, /* 0x10 */
-    Xcp_DTODaqStimPacket, /* 0x11 */
-    Xcp_DTODaqStimPacket, /* 0x12 */
-    Xcp_DTODaqStimPacket, /* 0x13 */
-    Xcp_DTODaqStimPacket, /* 0x14 */
-    Xcp_DTODaqStimPacket, /* 0x15 */
-    Xcp_DTODaqStimPacket, /* 0x16 */
-    Xcp_DTODaqStimPacket, /* 0x17 */
-    Xcp_DTODaqStimPacket, /* 0x18 */
-    Xcp_DTODaqStimPacket, /* 0x19 */
-    Xcp_DTODaqStimPacket, /* 0x1A */
-    Xcp_DTODaqStimPacket, /* 0x1B */
-    Xcp_DTODaqStimPacket, /* 0x1C */
-    Xcp_DTODaqStimPacket, /* 0x1D */
-    Xcp_DTODaqStimPacket, /* 0x1E */
-    Xcp_DTODaqStimPacket, /* 0x1F */
-    Xcp_DTODaqStimPacket, /* 0x20 */
-    Xcp_DTODaqStimPacket, /* 0x21 */
-    Xcp_DTODaqStimPacket, /* 0x22 */
-    Xcp_DTODaqStimPacket, /* 0x23 */
-    Xcp_DTODaqStimPacket, /* 0x24 */
-    Xcp_DTODaqStimPacket, /* 0x25 */
-    Xcp_DTODaqStimPacket, /* 0x26 */
-    Xcp_DTODaqStimPacket, /* 0x27 */
-    Xcp_DTODaqStimPacket, /* 0x28 */
-    Xcp_DTODaqStimPacket, /* 0x29 */
-    Xcp_DTODaqStimPacket, /* 0x2A */
-    Xcp_DTODaqStimPacket, /* 0x2B */
-    Xcp_DTODaqStimPacket, /* 0x2C */
-    Xcp_DTODaqStimPacket, /* 0x2D */
-    Xcp_DTODaqStimPacket, /* 0x2E */
-    Xcp_DTODaqStimPacket, /* 0x2F */
-    Xcp_DTODaqStimPacket, /* 0x30 */
-    Xcp_DTODaqStimPacket, /* 0x31 */
-    Xcp_DTODaqStimPacket, /* 0x32 */
-    Xcp_DTODaqStimPacket, /* 0x33 */
-    Xcp_DTODaqStimPacket, /* 0x34 */
-    Xcp_DTODaqStimPacket, /* 0x35 */
-    Xcp_DTODaqStimPacket, /* 0x36 */
-    Xcp_DTODaqStimPacket, /* 0x37 */
-    Xcp_DTODaqStimPacket, /* 0x38 */
-    Xcp_DTODaqStimPacket, /* 0x39 */
-    Xcp_DTODaqStimPacket, /* 0x3A */
-    Xcp_DTODaqStimPacket, /* 0x3B */
-    Xcp_DTODaqStimPacket, /* 0x3C */
-    Xcp_DTODaqStimPacket, /* 0x3D */
-    Xcp_DTODaqStimPacket, /* 0x3E */
-    Xcp_DTODaqStimPacket, /* 0x3F */
-    Xcp_DTODaqStimPacket, /* 0x40 */
-    Xcp_DTODaqStimPacket, /* 0x41 */
-    Xcp_DTODaqStimPacket, /* 0x42 */
-    Xcp_DTODaqStimPacket, /* 0x43 */
-    Xcp_DTODaqStimPacket, /* 0x44 */
-    Xcp_DTODaqStimPacket, /* 0x45 */
-    Xcp_DTODaqStimPacket, /* 0x46 */
-    Xcp_DTODaqStimPacket, /* 0x47 */
-    Xcp_DTODaqStimPacket, /* 0x48 */
-    Xcp_DTODaqStimPacket, /* 0x49 */
-    Xcp_DTODaqStimPacket, /* 0x4A */
-    Xcp_DTODaqStimPacket, /* 0x4B */
-    Xcp_DTODaqStimPacket, /* 0x4C */
-    Xcp_DTODaqStimPacket, /* 0x4D */
-    Xcp_DTODaqStimPacket, /* 0x4E */
-    Xcp_DTODaqStimPacket, /* 0x4F */
-    Xcp_DTODaqStimPacket, /* 0x50 */
-    Xcp_DTODaqStimPacket, /* 0x51 */
-    Xcp_DTODaqStimPacket, /* 0x52 */
-    Xcp_DTODaqStimPacket, /* 0x53 */
-    Xcp_DTODaqStimPacket, /* 0x54 */
-    Xcp_DTODaqStimPacket, /* 0x55 */
-    Xcp_DTODaqStimPacket, /* 0x56 */
-    Xcp_DTODaqStimPacket, /* 0x57 */
-    Xcp_DTODaqStimPacket, /* 0x58 */
-    Xcp_DTODaqStimPacket, /* 0x59 */
-    Xcp_DTODaqStimPacket, /* 0x5A */
-    Xcp_DTODaqStimPacket, /* 0x5B */
-    Xcp_DTODaqStimPacket, /* 0x5C */
-    Xcp_DTODaqStimPacket, /* 0x5D */
-    Xcp_DTODaqStimPacket, /* 0x5E */
-    Xcp_DTODaqStimPacket, /* 0x5F */
-    Xcp_DTODaqStimPacket, /* 0x60 */
-    Xcp_DTODaqStimPacket, /* 0x61 */
-    Xcp_DTODaqStimPacket, /* 0x62 */
-    Xcp_DTODaqStimPacket, /* 0x63 */
-    Xcp_DTODaqStimPacket, /* 0x64 */
-    Xcp_DTODaqStimPacket, /* 0x65 */
-    Xcp_DTODaqStimPacket, /* 0x66 */
-    Xcp_DTODaqStimPacket, /* 0x67 */
-    Xcp_DTODaqStimPacket, /* 0x68 */
-    Xcp_DTODaqStimPacket, /* 0x69 */
-    Xcp_DTODaqStimPacket, /* 0x6A */
-    Xcp_DTODaqStimPacket, /* 0x6B */
-    Xcp_DTODaqStimPacket, /* 0x6C */
-    Xcp_DTODaqStimPacket, /* 0x6D */
-    Xcp_DTODaqStimPacket, /* 0x6E */
-    Xcp_DTODaqStimPacket, /* 0x6F */
-    Xcp_DTODaqStimPacket, /* 0x70 */
-    Xcp_DTODaqStimPacket, /* 0x71 */
-    Xcp_DTODaqStimPacket, /* 0x72 */
-    Xcp_DTODaqStimPacket, /* 0x73 */
-    Xcp_DTODaqStimPacket, /* 0x74 */
-    Xcp_DTODaqStimPacket, /* 0x75 */
-    Xcp_DTODaqStimPacket, /* 0x76 */
-    Xcp_DTODaqStimPacket, /* 0x77 */
-    Xcp_DTODaqStimPacket, /* 0x78 */
-    Xcp_DTODaqStimPacket, /* 0x79 */
-    Xcp_DTODaqStimPacket, /* 0x7A */
-    Xcp_DTODaqStimPacket, /* 0x7B */
-    Xcp_DTODaqStimPacket, /* 0x7C */
-    Xcp_DTODaqStimPacket, /* 0x7D */
-    Xcp_DTODaqStimPacket, /* 0x7E */
-    Xcp_DTODaqStimPacket, /* 0x7F */
-    Xcp_DTODaqStimPacket, /* 0x80 */
-    Xcp_DTODaqStimPacket, /* 0x81 */
-    Xcp_DTODaqStimPacket, /* 0x82 */
-    Xcp_DTODaqStimPacket, /* 0x83 */
-    Xcp_DTODaqStimPacket, /* 0x84 */
-    Xcp_DTODaqStimPacket, /* 0x85 */
-    Xcp_DTODaqStimPacket, /* 0x86 */
-    Xcp_DTODaqStimPacket, /* 0x87 */
-    Xcp_DTODaqStimPacket, /* 0x88 */
-    Xcp_DTODaqStimPacket, /* 0x89 */
-    Xcp_DTODaqStimPacket, /* 0x8A */
-    Xcp_DTODaqStimPacket, /* 0x8B */
-    Xcp_DTODaqStimPacket, /* 0x8C */
-    Xcp_DTODaqStimPacket, /* 0x8D */
-    Xcp_DTODaqStimPacket, /* 0x8E */
-    Xcp_DTODaqStimPacket, /* 0x8F */
-    Xcp_DTODaqStimPacket, /* 0x90 */
-    Xcp_DTODaqStimPacket, /* 0x91 */
-    Xcp_DTODaqStimPacket, /* 0x92 */
-    Xcp_DTODaqStimPacket, /* 0x93 */
-    Xcp_DTODaqStimPacket, /* 0x94 */
-    Xcp_DTODaqStimPacket, /* 0x95 */
-    Xcp_DTODaqStimPacket, /* 0x96 */
-    Xcp_DTODaqStimPacket, /* 0x97 */
-    Xcp_DTODaqStimPacket, /* 0x98 */
-    Xcp_DTODaqStimPacket, /* 0x99 */
-    Xcp_DTODaqStimPacket, /* 0x9A */
-    Xcp_DTODaqStimPacket, /* 0x9B */
-    Xcp_DTODaqStimPacket, /* 0x9C */
-    Xcp_DTODaqStimPacket, /* 0x9D */
-    Xcp_DTODaqStimPacket, /* 0x9E */
-    Xcp_DTODaqStimPacket, /* 0x9F */
-    Xcp_DTODaqStimPacket, /* 0xA0 */
-    Xcp_DTODaqStimPacket, /* 0xA1 */
-    Xcp_DTODaqStimPacket, /* 0xA2 */
-    Xcp_DTODaqStimPacket, /* 0xA3 */
-    Xcp_DTODaqStimPacket, /* 0xA4 */
-    Xcp_DTODaqStimPacket, /* 0xA5 */
-    Xcp_DTODaqStimPacket, /* 0xA6 */
-    Xcp_DTODaqStimPacket, /* 0xA7 */
-    Xcp_DTODaqStimPacket, /* 0xA8 */
-    Xcp_DTODaqStimPacket, /* 0xA9 */
-    Xcp_DTODaqStimPacket, /* 0xAA */
-    Xcp_DTODaqStimPacket, /* 0xAB */
-    Xcp_DTODaqStimPacket, /* 0xAC */
-    Xcp_DTODaqStimPacket, /* 0xAD */
-    Xcp_DTODaqStimPacket, /* 0xAE */
-    Xcp_DTODaqStimPacket, /* 0xAF */
-    Xcp_DTODaqStimPacket, /* 0xB0 */
-    Xcp_DTODaqStimPacket, /* 0xB1 */
-    Xcp_DTODaqStimPacket, /* 0xB2 */
-    Xcp_DTODaqStimPacket, /* 0xB3 */
-    Xcp_DTODaqStimPacket, /* 0xB4 */
-    Xcp_DTODaqStimPacket, /* 0xB5 */
-    Xcp_DTODaqStimPacket, /* 0xB6 */
-    Xcp_DTODaqStimPacket, /* 0xB7 */
-    Xcp_DTODaqStimPacket, /* 0xB8 */
-    Xcp_DTODaqStimPacket, /* 0xB9 */
-    Xcp_DTODaqStimPacket, /* 0xBA */
-    Xcp_DTODaqStimPacket, /* 0xBB */
-    Xcp_DTODaqStimPacket, /* 0xBC */
-    Xcp_DTODaqStimPacket, /* 0xBD */
-    Xcp_DTODaqStimPacket, /* 0xBE */
-    Xcp_DTODaqStimPacket, /* 0xBF */
+    Xcp_CmdNotImplemented, /* 0x00 */
+    Xcp_CmdNotImplemented, /* 0x01 */
+    Xcp_CmdNotImplemented, /* 0x02 */
+    Xcp_CmdNotImplemented, /* 0x03 */
+    Xcp_CmdNotImplemented, /* 0x04 */
+    Xcp_CmdNotImplemented, /* 0x05 */
+    Xcp_CmdNotImplemented, /* 0x06 */
+    Xcp_CmdNotImplemented, /* 0x07 */
+    Xcp_CmdNotImplemented, /* 0x08 */
+    Xcp_CmdNotImplemented, /* 0x09 */
+    Xcp_CmdNotImplemented, /* 0x0A */
+    Xcp_CmdNotImplemented, /* 0x0B */
+    Xcp_CmdNotImplemented, /* 0x0C */
+    Xcp_CmdNotImplemented, /* 0x0D */
+    Xcp_CmdNotImplemented, /* 0x0E */
+    Xcp_CmdNotImplemented, /* 0x0F */
+    Xcp_CmdNotImplemented, /* 0x10 */
+    Xcp_CmdNotImplemented, /* 0x11 */
+    Xcp_CmdNotImplemented, /* 0x12 */
+    Xcp_CmdNotImplemented, /* 0x13 */
+    Xcp_CmdNotImplemented, /* 0x14 */
+    Xcp_CmdNotImplemented, /* 0x15 */
+    Xcp_CmdNotImplemented, /* 0x16 */
+    Xcp_CmdNotImplemented, /* 0x17 */
+    Xcp_CmdNotImplemented, /* 0x18 */
+    Xcp_CmdNotImplemented, /* 0x19 */
+    Xcp_CmdNotImplemented, /* 0x1A */
+    Xcp_CmdNotImplemented, /* 0x1B */
+    Xcp_CmdNotImplemented, /* 0x1C */
+    Xcp_CmdNotImplemented, /* 0x1D */
+    Xcp_CmdNotImplemented, /* 0x1E */
+    Xcp_CmdNotImplemented, /* 0x1F */
+    Xcp_CmdNotImplemented, /* 0x20 */
+    Xcp_CmdNotImplemented, /* 0x21 */
+    Xcp_CmdNotImplemented, /* 0x22 */
+    Xcp_CmdNotImplemented, /* 0x23 */
+    Xcp_CmdNotImplemented, /* 0x24 */
+    Xcp_CmdNotImplemented, /* 0x25 */
+    Xcp_CmdNotImplemented, /* 0x26 */
+    Xcp_CmdNotImplemented, /* 0x27 */
+    Xcp_CmdNotImplemented, /* 0x28 */
+    Xcp_CmdNotImplemented, /* 0x29 */
+    Xcp_CmdNotImplemented, /* 0x2A */
+    Xcp_CmdNotImplemented, /* 0x2B */
+    Xcp_CmdNotImplemented, /* 0x2C */
+    Xcp_CmdNotImplemented, /* 0x2D */
+    Xcp_CmdNotImplemented, /* 0x2E */
+    Xcp_CmdNotImplemented, /* 0x2F */
+    Xcp_CmdNotImplemented, /* 0x30 */
+    Xcp_CmdNotImplemented, /* 0x31 */
+    Xcp_CmdNotImplemented, /* 0x32 */
+    Xcp_CmdNotImplemented, /* 0x33 */
+    Xcp_CmdNotImplemented, /* 0x34 */
+    Xcp_CmdNotImplemented, /* 0x35 */
+    Xcp_CmdNotImplemented, /* 0x36 */
+    Xcp_CmdNotImplemented, /* 0x37 */
+    Xcp_CmdNotImplemented, /* 0x38 */
+    Xcp_CmdNotImplemented, /* 0x39 */
+    Xcp_CmdNotImplemented, /* 0x3A */
+    Xcp_CmdNotImplemented, /* 0x3B */
+    Xcp_CmdNotImplemented, /* 0x3C */
+    Xcp_CmdNotImplemented, /* 0x3D */
+    Xcp_CmdNotImplemented, /* 0x3E */
+    Xcp_CmdNotImplemented, /* 0x3F */
+    Xcp_CmdNotImplemented, /* 0x40 */
+    Xcp_CmdNotImplemented, /* 0x41 */
+    Xcp_CmdNotImplemented, /* 0x42 */
+    Xcp_CmdNotImplemented, /* 0x43 */
+    Xcp_CmdNotImplemented, /* 0x44 */
+    Xcp_CmdNotImplemented, /* 0x45 */
+    Xcp_CmdNotImplemented, /* 0x46 */
+    Xcp_CmdNotImplemented, /* 0x47 */
+    Xcp_CmdNotImplemented, /* 0x48 */
+    Xcp_CmdNotImplemented, /* 0x49 */
+    Xcp_CmdNotImplemented, /* 0x4A */
+    Xcp_CmdNotImplemented, /* 0x4B */
+    Xcp_CmdNotImplemented, /* 0x4C */
+    Xcp_CmdNotImplemented, /* 0x4D */
+    Xcp_CmdNotImplemented, /* 0x4E */
+    Xcp_CmdNotImplemented, /* 0x4F */
+    Xcp_CmdNotImplemented, /* 0x50 */
+    Xcp_CmdNotImplemented, /* 0x51 */
+    Xcp_CmdNotImplemented, /* 0x52 */
+    Xcp_CmdNotImplemented, /* 0x53 */
+    Xcp_CmdNotImplemented, /* 0x54 */
+    Xcp_CmdNotImplemented, /* 0x55 */
+    Xcp_CmdNotImplemented, /* 0x56 */
+    Xcp_CmdNotImplemented, /* 0x57 */
+    Xcp_CmdNotImplemented, /* 0x58 */
+    Xcp_CmdNotImplemented, /* 0x59 */
+    Xcp_CmdNotImplemented, /* 0x5A */
+    Xcp_CmdNotImplemented, /* 0x5B */
+    Xcp_CmdNotImplemented, /* 0x5C */
+    Xcp_CmdNotImplemented, /* 0x5D */
+    Xcp_CmdNotImplemented, /* 0x5E */
+    Xcp_CmdNotImplemented, /* 0x5F */
+    Xcp_CmdNotImplemented, /* 0x60 */
+    Xcp_CmdNotImplemented, /* 0x61 */
+    Xcp_CmdNotImplemented, /* 0x62 */
+    Xcp_CmdNotImplemented, /* 0x63 */
+    Xcp_CmdNotImplemented, /* 0x64 */
+    Xcp_CmdNotImplemented, /* 0x65 */
+    Xcp_CmdNotImplemented, /* 0x66 */
+    Xcp_CmdNotImplemented, /* 0x67 */
+    Xcp_CmdNotImplemented, /* 0x68 */
+    Xcp_CmdNotImplemented, /* 0x69 */
+    Xcp_CmdNotImplemented, /* 0x6A */
+    Xcp_CmdNotImplemented, /* 0x6B */
+    Xcp_CmdNotImplemented, /* 0x6C */
+    Xcp_CmdNotImplemented, /* 0x6D */
+    Xcp_CmdNotImplemented, /* 0x6E */
+    Xcp_CmdNotImplemented, /* 0x6F */
+    Xcp_CmdNotImplemented, /* 0x70 */
+    Xcp_CmdNotImplemented, /* 0x71 */
+    Xcp_CmdNotImplemented, /* 0x72 */
+    Xcp_CmdNotImplemented, /* 0x73 */
+    Xcp_CmdNotImplemented, /* 0x74 */
+    Xcp_CmdNotImplemented, /* 0x75 */
+    Xcp_CmdNotImplemented, /* 0x76 */
+    Xcp_CmdNotImplemented, /* 0x77 */
+    Xcp_CmdNotImplemented, /* 0x78 */
+    Xcp_CmdNotImplemented, /* 0x79 */
+    Xcp_CmdNotImplemented, /* 0x7A */
+    Xcp_CmdNotImplemented, /* 0x7B */
+    Xcp_CmdNotImplemented, /* 0x7C */
+    Xcp_CmdNotImplemented, /* 0x7D */
+    Xcp_CmdNotImplemented, /* 0x7E */
+    Xcp_CmdNotImplemented, /* 0x7F */
+    Xcp_CmdNotImplemented, /* 0x80 */
+    Xcp_CmdNotImplemented, /* 0x81 */
+    Xcp_CmdNotImplemented, /* 0x82 */
+    Xcp_CmdNotImplemented, /* 0x83 */
+    Xcp_CmdNotImplemented, /* 0x84 */
+    Xcp_CmdNotImplemented, /* 0x85 */
+    Xcp_CmdNotImplemented, /* 0x86 */
+    Xcp_CmdNotImplemented, /* 0x87 */
+    Xcp_CmdNotImplemented, /* 0x88 */
+    Xcp_CmdNotImplemented, /* 0x89 */
+    Xcp_CmdNotImplemented, /* 0x8A */
+    Xcp_CmdNotImplemented, /* 0x8B */
+    Xcp_CmdNotImplemented, /* 0x8C */
+    Xcp_CmdNotImplemented, /* 0x8D */
+    Xcp_CmdNotImplemented, /* 0x8E */
+    Xcp_CmdNotImplemented, /* 0x8F */
+    Xcp_CmdNotImplemented, /* 0x90 */
+    Xcp_CmdNotImplemented, /* 0x91 */
+    Xcp_CmdNotImplemented, /* 0x92 */
+    Xcp_CmdNotImplemented, /* 0x93 */
+    Xcp_CmdNotImplemented, /* 0x94 */
+    Xcp_CmdNotImplemented, /* 0x95 */
+    Xcp_CmdNotImplemented, /* 0x96 */
+    Xcp_CmdNotImplemented, /* 0x97 */
+    Xcp_CmdNotImplemented, /* 0x98 */
+    Xcp_CmdNotImplemented, /* 0x99 */
+    Xcp_CmdNotImplemented, /* 0x9A */
+    Xcp_CmdNotImplemented, /* 0x9B */
+    Xcp_CmdNotImplemented, /* 0x9C */
+    Xcp_CmdNotImplemented, /* 0x9D */
+    Xcp_CmdNotImplemented, /* 0x9E */
+    Xcp_CmdNotImplemented, /* 0x9F */
+    Xcp_CmdNotImplemented, /* 0xA0 */
+    Xcp_CmdNotImplemented, /* 0xA1 */
+    Xcp_CmdNotImplemented, /* 0xA2 */
+    Xcp_CmdNotImplemented, /* 0xA3 */
+    Xcp_CmdNotImplemented, /* 0xA4 */
+    Xcp_CmdNotImplemented, /* 0xA5 */
+    Xcp_CmdNotImplemented, /* 0xA6 */
+    Xcp_CmdNotImplemented, /* 0xA7 */
+    Xcp_CmdNotImplemented, /* 0xA8 */
+    Xcp_CmdNotImplemented, /* 0xA9 */
+    Xcp_CmdNotImplemented, /* 0xAA */
+    Xcp_CmdNotImplemented, /* 0xAB */
+    Xcp_CmdNotImplemented, /* 0xAC */
+    Xcp_CmdNotImplemented, /* 0xAD */
+    Xcp_CmdNotImplemented, /* 0xAE */
+    Xcp_CmdNotImplemented, /* 0xAF */
+    Xcp_CmdNotImplemented, /* 0xB0 */
+    Xcp_CmdNotImplemented, /* 0xB1 */
+    Xcp_CmdNotImplemented, /* 0xB2 */
+    Xcp_CmdNotImplemented, /* 0xB3 */
+    Xcp_CmdNotImplemented, /* 0xB4 */
+    Xcp_CmdNotImplemented, /* 0xB5 */
+    Xcp_CmdNotImplemented, /* 0xB6 */
+    Xcp_CmdNotImplemented, /* 0xB7 */
+    Xcp_CmdNotImplemented, /* 0xB8 */
+    Xcp_CmdNotImplemented, /* 0xB9 */
+    Xcp_CmdNotImplemented, /* 0xBA */
+    Xcp_CmdNotImplemented, /* 0xBB */
+    Xcp_CmdNotImplemented, /* 0xBC */
+    Xcp_CmdNotImplemented, /* 0xBD */
+    Xcp_CmdNotImplemented, /* 0xBE */
+    Xcp_CmdNotImplemented, /* 0xBF */
     Xcp_CmdNotImplemented, /* 0xC0 */
     Xcp_CmdNotImplemented, /* 0xC1 */
     Xcp_CmdNotImplemented, /* 0xC2 */
@@ -1460,10 +1460,11 @@ void Xcp_CanIfRxIndication(PduIdType rxPduId, const PduInfoType *pPduInfo)
                                  * in the DTO range runs the whole dispatch body -- and THREE things
                                  * happen there, not one:
                                  *
-                                 * - Xcp_PIDTable[pid] resolves to Xcp_DTODaqStimPacket, a no-op
-                                 *   returning E_OK that was dead under the old split. E_OK sets
-                                 *   successful_transmission_pending, so whatever stale bytes the
-                                 *   response buffer still held are transmitted as a response.
+                                 * - Xcp_PIDTable[pid] resolves to Xcp_CmdNotImplemented, which
+                                 *   answers ERR_CMD_UNKNOWN. Harmless in itself, and the least of
+                                 *   the three; it used to be Xcp_DTODaqStimPacket, a no-op
+                                 *   returning E_OK without filling the response buffer, which
+                                 *   transmitted whatever stale bytes that buffer still held.
                                  * - `Xcp_Internal.last_pid = pid` runs on the way out, overwriting
                                  *   the record of the previous command. Xcp_DTOCmdStdUnlock
                                  *   (source/Xcp_Std.c) admits a key only when last_pid is GET_SEED
@@ -1476,11 +1477,15 @@ void Xcp_CanIfRxIndication(PduIdType rxPduId, const PduInfoType *pPduInfo)
                                  *   next protected command is answered ERR_ACCESS_LOCKED with
                                  *   nothing to say why.
                                  *
-                                 * Re-pointing those 192 table entries at Xcp_CmdNotImplemented
-                                 * would NOT make this safe, and that is the trap worth naming: the
-                                 * last two happen after the handler returns, whatever the handler
-                                 * was, so they run either way. The routing decision is the guard;
-                                 * the table's contents are not. */
+                                 * Those 192 entries HAVE since been re-pointed at
+                                 * Xcp_CmdNotImplemented, and that did NOT make this safe -- it is
+                                 * the trap worth naming, because the change looks like a fix and
+                                 * is not one. The last two bullets happen after the handler
+                                 * returns, whatever the handler was, so they run either way. The
+                                 * routing decision is the guard; the table's contents are not.
+                                 * They were changed only to delete a dead function and to stop the
+                                 * table claiming a stimulation handler this dispatch path has not
+                                 * had since DD46 moved STIM to the DTO PduId. */
                                 if ((Xcp_Ptr->general->ctoInfo[pid] & XCP_CTO_INFO_IS_CTO_MASK) != 0x00u) {
                                     /* XCP part 2 - Protocol Layer Specification 1.0/1.7.3.1
                                      * Check if the received CTO reacts to ERR_CMD_BUSY error. If so, check if the CTO response ongoing flag is set, and

--- a/source/Xcp.c
+++ b/source/Xcp.c
@@ -1453,9 +1453,14 @@ void Xcp_CanIfRxIndication(PduIdType rxPduId, const PduInfoType *pPduInfo)
                                  *
                                  * This test is also what keeps Xcp_PIDTable's 0x00..0xBF entries
                                  * unreachable, and it is the ONLY thing that does: the generated
-                                 * ctoInfo sets `enable` for all 256 PIDs and Xcp_PIDToCmdGroupTable
-                                 * holds MASK_NONE across 0x00..0xBF, so neither the enable test
-                                 * above nor the protection gate below stops such a frame. Remove
+                                 * ctoInfo sets `enable` across the whole of 0x00..0xBF (all
+                                 * 192 entries, unconditionally -- script/source_cfg.c.jinja2) and
+                                 * Xcp_PIDToCmdGroupTable holds MASK_NONE there, so neither the
+                                 * enable test above nor the protection gate below stops such a
+                                 * frame. Said of that range rather than of all 256 PIDs, which
+                                 * would be untrue: entries in the COMMAND range are enabled
+                                 * conditionally, since an optional command a build leaves out
+                                 * generates a disabled entry. Remove
                                  * this condition and a frame on the CTO PDU whose first byte falls
                                  * in the DTO range runs the whole dispatch body -- and THREE things
                                  * happen there, not one:

--- a/source/Xcp_Daq.c
+++ b/source/Xcp_Daq.c
@@ -482,15 +482,6 @@ void Xcp_DaqFreeAll(void)
 /* command handler definitions.                                                                  */
 /*------------------------------------------------------------------------------------------------*/
 
-uint8 Xcp_DTODaqStimPacket(boolean *responseExpected, const PduInfoType *pPduInfo)
-{
-    (void)pPduInfo;
-
-    *responseExpected = TRUE;
-
-    return E_OK;
-}
-
 uint8 Xcp_DTOCmdDaqSetDaqPtr(boolean *responseExpected, const PduInfoType *pPduInfo)
 {
     const uint8 odt_number = pPduInfo->SduDataPtr[0x04u];

--- a/source/Xcp_DaqRuntime.c
+++ b/source/Xcp_DaqRuntime.c
@@ -53,17 +53,21 @@ static uint8 Xcp_DaqWriteIdentificationField(Xcp_DtoFrameType *pFrame,
      * ones, so a later ALLOC_DAQ cannot change its answer. maxOdt is the one that does. Under
      * DAQ_DYNAMIC, ALLOC_DAQ, ALLOC_ODT(list, 1), SET_DAQ_LIST_MODE(PID_OFF), ALLOC_ODT(list, 1)
      * is a legal sequence -- SET_DAQ_LIST_MODE does not touch Xcp_Internal.daq_alloc_state, and
-     * DD28 makes the repeat ACCUMULATE -- and it leaves maxOdt at 2 with PID_OFF still set.
-     * Xcp_TriggerEventChannel then samples BOTH ODTs of that list, this function returns 0x00u for
-     * each of them, and two DTOs go out on one PDU with nothing on the wire to tell them apart.
+     * DD28 makes the repeat ACCUMULATE -- and it leaves maxOdt at 2 with PID_OFF still set. Both
+     * ODTs of that list would then be sampled, this function would return 0x00u for each, and two
+     * DTOs would go out on one PDU with nothing on the wire to tell them apart.
      *
-     * Xcp_DaqReadIdentificationField, further down this file, re-checks maxOdt for precisely that
-     * sequence and refuses the frame rather than trusting the grant. **The transmit side has no
-     * such guard.** An earlier revision of this comment claimed the opposite -- that
-     * SET_DAQ_LIST_MODE "has already refused the bit for anything but an ABSOLUTE single-ODT list,
-     * so this cannot produce a frame the master is unable to identify" -- and that is the sentence
-     * the receive-side fix disproved. Do not reintroduce it, here or at any other reader of this
-     * bit: it is what stands between a maintainer and re-deriving a drop already found once.
+     * Both directions guard against that sequence, and NEITHER guard is in this function.
+     * Xcp_DaqReadIdentificationField, further down this file, re-checks maxOdt and refuses the
+     * frame rather than trusting the grant. Xcp_TriggerEventChannel, also further down, re-checks
+     * it before sampling and skips the whole list with XCP_E_DAQ_LIST_NOT_IDENTIFIABLE. This
+     * function is reached only for a list that already passed that check, which is why it may
+     * treat the bit as final -- an obligation of its caller, not a property of the bit. An earlier
+     * revision of this comment justified the same silence differently, claiming SET_DAQ_LIST_MODE
+     * "has already refused the bit for anything but an ABSOLUTE single-ODT list, so this cannot
+     * produce a frame the master is unable to identify". That sentence was false for the drifted
+     * list, and it is the one the two guards above were written to replace. Do not reintroduce it,
+     * here or at any other reader of this bit: a grant is not an invariant.
      *
      * Xcp_DaqListRt (source/Xcp_Daq.c) has file-local linkage there, so the stored mode is read
      * directly off Xcp_Rt here instead, the same way Xcp_DaqSampleOdt's own timestamp check
@@ -1135,33 +1139,73 @@ void Xcp_TriggerEventChannel(uint16 eventChannelNumber)
             if ((Xcp_DaqListElapsedOnTrigger(p_rt, eventChannelNumber, FALSE) == TRUE) &&
                 ((p_list->type == DAQ) || (p_list->type == DAQ_STIM)))
             {
-                uint8_least odt_idx;
-                uint32 timestamp = 0x00000000u;
+                /* PID_OFF plus more than one ODT is unrepresentable on this transport, so the
+                 * list is skipped whole rather than transmitted unidentifiably.
+                 *
+                 * Xcp_DTOCmdDaqSetDaqListMode (source/Xcp_Daq.c) never grants that combination --
+                 * it requires ABSOLUTE identification, a single ODT, and a TX PDU no other list
+                 * shares -- but a grant is a statement about the moment that command ran. Under
+                 * DAQ_DYNAMIC the master may allocate more ODTs afterwards: ALLOC_ODT is legal
+                 * after ALLOC_ODT (source/Xcp_Daq.c, daq_alloc_state) and 1.1/1.6.4.2.1.3's
+                 * ERR_SEQUENCE rules forbid only ALLOC_DAQ and ALLOC_ODT_ENTRY regressions, so
+                 * ALLOC_DAQ, ALLOC_ODT(list, 1), SET_DAQ_LIST_MODE(PID_OFF), ALLOC_ODT(list, 1)
+                 * is a conformant sequence that leaves maxOdt at 2 with PID_OFF still set. Without
+                 * this test the loop below samples both ODTs, Xcp_DaqWriteIdentificationField
+                 * returns 0 for each, and two DTOs go out on one PDU with nothing to tell them
+                 * apart -- the transmit-side twin of the frame Xcp_DaqStoreStim drops on receive.
+                 *
+                 * The specification does not dictate this remedy; it is this module holding its
+                 * own grant rule true at the moment of use. 1.1/1.1.2.1 requires only that PID_OFF
+                 * accompany ABSOLUTE identification and leaves the rest to the transport -- "the
+                 * unambiguous identification has to be done on the level of the Transport Layer",
+                 * of which one CAN-Id and one ODT per list is the example it gives, not a rule it
+                 * imposes. This module adopts that example because on CAN every ODT of a list
+                 * shares one TX PDU, so there is nothing for the transport to disambiguate with.
+                 *
+                 * Tested on p_list->maxOdt, the same field the sampling loop below walks, so the
+                 * skip cannot disagree with what would have been transmitted. Nested inside the
+                 * elapsed test rather than added to it as a conjunct: Xcp_DaqListElapsedOnTrigger
+                 * mutates and must run exactly once per list per trigger, and a list held back
+                 * here has still had its cycle. Pure STIM lists never reach this point and need no
+                 * report -- they transmit nothing to be misread. */
+                if (((p_rt->mode & XCP_DAQ_LIST_MODE_PID_OFF) != 0x00u) &&
+                    (p_list->maxOdt != 0x01u))
+                {
+                    /* Outside every exclusive area, as Xcp_ReportError is an external call. */
+                    Xcp_ReportError(0x00u,
+                                    XCP_TRIGGER_EVENT_CHANNEL_API_ID,
+                                    XCP_E_DAQ_LIST_NOT_IDENTIFIABLE);
+                }
+                else
+                {
+                    uint8_least odt_idx;
+                    uint32 timestamp = 0x00000000u;
 
 #if (XCP_DAQ_TIMESTAMP_SUPPORTED == STD_ON)
-                /* 1.1/1.1.2.2 Diagram 10: one clock reading per DAQ cycle, transmitted in the
-                 * first ODT. Reading per ODT would give one cycle's ODTs differing timestamps and
-                 * would call integrator code once per ODT instead of once per cycle.
-                 *
-                 * In the acquisition pass because nothing else reads it: a STIM DTO's timestamp is
-                 * the master's to send and this slave skips it without storing it (DD44), so a
-                 * stimulating list would otherwise call the integrator's clock once per cycle for
-                 * a value it then discards. */
-                if ((p_rt->mode & XCP_DAQ_LIST_MODE_TIMESTAMP) != 0x00u)
-                {
-                    timestamp = Xcp_GetDaqTimestamp();
-                }
+                    /* 1.1/1.1.2.2 Diagram 10: one clock reading per DAQ cycle, transmitted in the
+                     * first ODT. Reading per ODT would give one cycle's ODTs differing timestamps and
+                     * would call integrator code once per ODT instead of once per cycle.
+                     *
+                     * In the acquisition pass because nothing else reads it: a STIM DTO's timestamp is
+                     * the master's to send and this slave skips it without storing it (DD44), so a
+                     * stimulating list would otherwise call the integrator's clock once per cycle for
+                     * a value it then discards. */
+                    if ((p_rt->mode & XCP_DAQ_LIST_MODE_TIMESTAMP) != 0x00u)
+                    {
+                        timestamp = Xcp_GetDaqTimestamp();
+                    }
 #endif /* #if (XCP_DAQ_TIMESTAMP_SUPPORTED == STD_ON) */
 
-                for (odt_idx = 0x00u; odt_idx < p_list->maxOdt; odt_idx++)
-                {
-                    Xcp_DtoFrameType frame;
-
-                    if (Xcp_DaqSampleOdt(&frame, daq_idx, (uint8)odt_idx, timestamp) == E_OK)
+                    for (odt_idx = 0x00u; odt_idx < p_list->maxOdt; odt_idx++)
                     {
-                        if (Xcp_DaqQueuePush(&frame) != E_OK)
+                        Xcp_DtoFrameType frame;
+
+                        if (Xcp_DaqSampleOdt(&frame, daq_idx, (uint8)odt_idx, timestamp) == E_OK)
                         {
-                            overloaded = TRUE;
+                            if (Xcp_DaqQueuePush(&frame) != E_OK)
+                            {
+                                overloaded = TRUE;
+                            }
                         }
                     }
                 }

--- a/source/Xcp_Internal.h
+++ b/source/Xcp_Internal.h
@@ -604,7 +604,6 @@ Std_ReturnType Xcp_EventQueuePush(Xcp_EventQueueType *pEventQueue, uint8 packetI
 extern void(* const Xcp_ReadSlaveMemoryTable[])(void *address, uint8 extension, uint8 *pBuffer);
 extern void(* const Xcp_WriteSlaveMemoryTable[])(void *address, uint8 *pBuffer);
 
-uint8 Xcp_DTODaqStimPacket(boolean *responseExpected, const PduInfoType *pPduInfo);
 uint8 Xcp_DTOCmdCalShortDownload(boolean *responseExpected, const PduInfoType *pPduInfo);
 uint8 Xcp_DTOCmdCalDownloadMax(boolean *responseExpected, const PduInfoType *pPduInfo);
 uint8 Xcp_DTOCmdCalDownloadNext(boolean *responseExpected, const PduInfoType *pPduInfo);

--- a/source/Xcp_Std.c
+++ b/source/Xcp_Std.c
@@ -387,7 +387,6 @@ uint8 Xcp_DTOCmdStdTransportLayerCmd(boolean *responseExpected, const PduInfoTyp
     uint8 sub_command;
     uint8 mode;
     uint16 daq_list_number;
-    // uint32 can_identifier;
 
     if (pPduInfo->SduLength >= 0x02u) {
         sub_command = pPduInfo->SduDataPtr[0x01u];
@@ -448,7 +447,17 @@ uint8 Xcp_DTOCmdStdTransportLayerCmd(boolean *responseExpected, const PduInfoTyp
                 if (object_found == TRUE) {
                     if (Xcp_Ptr->config->daqList[daq_list_idx].dtoCount > 0x00u) {
                         Xcp_Internal.cto_response.pdu_info.SduDataPtr[0x00u] = XCP_PID_RESPONSE;
-                        Xcp_Internal.cto_response.pdu_info.SduDataPtr[0x01u] = 0x01u; // TODO: support configurable CAN ID...
+                        /* CAN_ID_FIXED. Reported as fixed because it is: this slave has no way to
+                         * change a DAQ list's transmit identifier, and SET_DAQ_ID below is
+                         * deliberately not implemented, so the answer is truthful rather than
+                         * provisional. It replaced a "TODO: support configurable CAN ID", which
+                         * read as an unfinished feature.
+                         *
+                         * The field's polarity -- 1 meaning fixed -- comes from the XCP CAN
+                         * Transport Layer specification, which is NOT in docs/external. Confirm it
+                         * there before relying on it for anything new; what is independently sound
+                         * is that this value must not change while SET_DAQ_ID stays unimplemented. */
+                        Xcp_Internal.cto_response.pdu_info.SduDataPtr[0x01u] = 0x01u;
                         Xcp_Internal.cto_response.pdu_info.SduDataPtr[0x02u] = 0x00u;
                         Xcp_Internal.cto_response.pdu_info.SduDataPtr[0x03u] = 0x00u;
                         Xcp_CopyFromU32WithOrder((uint32)Xcp_Ptr->config->daqList[daq_list_idx].dto[0x00u].dto2PduMapping.txPdu.id,
@@ -474,10 +483,32 @@ uint8 Xcp_DTOCmdStdTransportLayerCmd(boolean *responseExpected, const PduInfoTyp
             }
         }else if (sub_command == 0xFDu) {
             if (pPduInfo->SduLength >= 0x08u) {
-                // Xcp_CopyToU16WithOrder(&Xcp_Internal.cto_response.pdu_info.SduDataPtr[0x02u], &daq_list_number, Xcp_Ptr->general->byteOrder);
-                // Xcp_CopyToU32WithOrder(&Xcp_Internal.cto_response.pdu_info.SduDataPtr[0x04u], &can_identifier, Xcp_Ptr->general->byteOrder);
-
-                // TODO: implement this feature...
+                /* SET_DAQ_ID, and it is NOT implemented on purpose. AUTOSAR SWS XCP R4.3.1 §4.1
+                 * Limitations: "The SET_DAQ_ID command according to the XCP CAN Transport Layer
+                 * Specification is not part of the AUTOSAR XCP module". This module tracks that
+                 * SWS -- test/autosar_sws_test.py asserts against it -- so the refusal is
+                 * conformance, not an unfinished feature, and ERR_CMD_UNKNOWN is exactly what
+                 * 1.1/1.4 prescribes for an optional command a slave does not implement.
+                 *
+                 * Two further obstacles, either of which would need settling first if the decision
+                 * were ever revisited. The normative definition of this sub-command is in the XCP
+                 * CAN Transport Layer specification, which is not in docs/external, so its request
+                 * layout cannot be cited from anything held here -- only inferred from the length
+                 * check above and from GET_DAQ_ID's response shape. And changing a transmit
+                 * identifier at runtime means CanIf_SetDynamicTxId (SWS_CANIF_00189), an API this
+                 * module has never called, which additionally requires every DAQ transmit PDU to be
+                 * configured as a dynamic L-PDU -- an integrator-side guarantee this module can
+                 * neither verify nor impose.
+                 *
+                 * The length check is kept ahead of the refusal so a malformed request still gets
+                 * ERR_CMD_SYNTAX. A syntactically invalid frame is invalid whether or not the
+                 * command behind it exists, and answering ERR_CMD_UNKNOWN to a 3-byte request
+                 * would say the sub-command is unknown when what is wrong is the request.
+                 *
+                 * Two commented-out Xcp_CopyTo* calls stood here, drafting the parse. They read
+                 * from Xcp_Internal.cto_response.pdu_info -- the RESPONSE buffer -- rather than
+                 * from pPduInfo, so they would not have parsed the request at all. Removed rather
+                 * than left as a starting point for whoever picks this up. */
                 Xcp_FillErrorPacket(XCP_E_ASAM_CMD_UNKNOWN, &Xcp_Internal.cto_response.pdu_info);
             } else {
                 Xcp_FillErrorPacket(XCP_E_ASAM_CMD_SYNTAX, &Xcp_Internal.cto_response.pdu_info);

--- a/test/autosar_sws_test.py
+++ b/test/autosar_sws_test.py
@@ -103,10 +103,12 @@ class TestSWS00847:
                                                         handle.define('XCP_E_PARAM_POINTER'))
 
     @pytest.mark.parametrize('pdu_id', [0x0002] + list(range(0x0004, 0x000F)))
-    # "STIM" is absent because a pure STIM DAQ list is refused at generation -- see
-    # test_generation_fails_when_a_daq_list_is_configured_as_stim in daq_configuration_test.py.
-    # DAQ_STIM is the remaining type whose list carries an RX PDU mapping, which is what makes
-    # this parametrization about anything.
+    # "STIM" is absent because this parametrization predates SP3, when a pure STIM DAQ list was
+    # refused at generation. SP3 lifted that refusal (commit 3659d24), so the named test no longer
+    # exists.
+    # What the sweep needs is a list carrying an RX PDU mapping, which is what makes it about
+    # anything; DAQ_STIM is one such type and, since SP3, a pure STIM list is another. Either
+    # would do, and DAQ_STIM is kept because it is what this test has always used.
     @pytest.mark.parametrize('daq_type', ('DAQ_STIM',))
     def test_invalid_pdu_id_error(self, pdu_id, daq_type):
         handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001,

--- a/test/connect_test.py
+++ b/test/connect_test.py
@@ -92,8 +92,10 @@ def test_the_daq_resource_bit_clears_without_a_mandatory_daq_command():
     assert resource(handle) & 0x04 == 0
 
 
-# "STIM" is absent because a pure STIM DAQ list is refused at generation -- see
-# test_generation_fails_when_a_daq_list_is_configured_as_stim in daq_configuration_test.py.
+# "STIM" is absent because this parametrization predates SP3, when a pure STIM DAQ list was
+# refused at generation. SP3 lifted that refusal (commit 3659d24), so the named test no longer
+# exists; the sweep is left at DAQ and DAQ_STIM because those are what it needs, not because STIM
+# is unbuildable.
 # DAQ_STIM still distinguishes the bit from the DAQ case, which is all this test needs.
 @pytest.mark.parametrize('resource_stim_bit, daq_type', ((0, "DAQ"), (1, "DAQ_STIM")))
 def test_connect_sets_the_resource_stim_bit_according_to_enabled_apis(resource_stim_bit, daq_type):

--- a/test/daq_dynamic_acceptance_test.py
+++ b/test/daq_dynamic_acceptance_test.py
@@ -242,17 +242,18 @@ def test_pid_off_under_dynamic_follows_the_shared_tx_pdu_rule(daq_count, accepte
     # SET_DAQ_LIST_MODE with PID_OFF (bit 5) on list 0, event channel 0, prescaler 1, priority 0.
     result = exchange(handle, (0xE0, 0x20, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00))
     # The refused case pins ERR_MODE_NOT_VALID rather than "some error": SET_DAQ_LIST_MODE refuses
-    # in nine places, eight of them other than the shared-TX-PDU rule -- five ERR_OUT_OF_RANGE (the
+    # in ten places, nine of them other than the shared-TX-PDU rule -- five ERR_OUT_OF_RANGE (the
     # list, the event channel, and three on the prescaler and priority), one ERR_DAQ_ACTIVE for a
-    # running list, and two more ERR_MODE_NOT_VALID (an unsupported mode bit, and TIMESTAMP where
-    # the configuration declares no clock). So `result[0] == 0xFF` being False would be satisfied
-    # by the refusal migrating to any of them, including ones that would refuse this request
-    # whether or not the shared-TX-PDU rule existed.
+    # running list, and three more ERR_MODE_NOT_VALID (an unsupported mode bit, DIRECTION on a list
+    # that cannot receive, and TIMESTAMP where the configuration declares no clock). So
+    # `result[0] == 0xFF` being False would be satisfied by the refusal migrating to any of them,
+    # including ones that would refuse this request whether or not the shared-TX-PDU rule existed.
     #
-    # Pinning 0x27 therefore narrows the field to three branches rather than isolating one. It is
-    # still worth pinning: the mode byte here is PID_OFF alone, so neither of the other two can
-    # fire -- an unsupported bit needs DIRECTION or ALTERNATING set, and the TIMESTAMP branch needs
-    # bit 4 -- which makes 0x27 unambiguous for this request specifically. A wider sweep over mode
+    # Pinning 0x27 therefore narrows the field to four branches rather than isolating one. It is
+    # still worth pinning: the mode byte here is PID_OFF alone, so none of the other three can
+    # fire -- an unsupported bit and the DIRECTION branch both need DIRECTION or ALTERNATING set,
+    # and the TIMESTAMP branch needs bit 4 -- which makes 0x27 unambiguous for this request
+    # specifically. A wider sweep over mode
     # bytes would need to distinguish them some other way.
     if accepted:
         assert result[0] == 0xFF

--- a/test/daq_pid_off_test.py
+++ b/test/daq_pid_off_test.py
@@ -219,3 +219,140 @@ def test_pid_off_supported_is_advertised_only_for_absolute_identification(identi
     handle.lib.Xcp_MainFunction()
 
     assert (handle.can_if_transmit.call_args[0][1].SduDataPtr[0x01] & 0x20) == expected
+
+
+def queued_frames(handle):
+    """Every frame currently in the ring, oldest first, as bytes. Read directly out of
+    Xcp_Rt[...].dtoQueue, as test/daq_dynamic_acceptance_test.py and four other files do; the
+    transmit path is asserted here rather than through can_if_transmit because a list that must
+    not be sampled produces NO call, and `call_args` on a mock that was never called after the
+    setup commands still holds whatever the last setup response left there."""
+    queue = handle.lib.Xcp_Rt[handle.lib.Xcp_Ptr.xcpRtRef].dtoQueue
+    frames = list()
+    index = queue.read
+    for _ in range(queue.count):
+        frame = queue.frame[index]
+        frames.append(bytes(frame.data[0:frame.length]))
+        index = (index + 1) % queue.depth
+    return frames
+
+
+def not_identifiable(handle):
+    """The Det reports Xcp_TriggerEventChannel raised for lists it would not sample, filtered out
+    of whatever else the setup commands reported."""
+    return [call for call in handle.det_report_error.call_args_list
+            if call[0][3] == handle.define('XCP_E_DAQ_LIST_NOT_IDENTIFIABLE')]
+
+
+def drifted_handle(mode=0x20, entries=True):
+    """A dynamic pool of one list, granted `mode` while it held a single ODT and then grown to two.
+
+    daq_count=1 is required, not incidental: Xcp_DaqListTxPduIsExclusive walks the CONFIGURED pool,
+    so a second slot -- even unallocated -- would make SET_DAQ_LIST_MODE refuse PID_OFF outright
+    (test_pid_off_under_dynamic_follows_the_shared_tx_pdu_rule) and the drift could never be set up.
+
+    The allocations all precede the ODT entries because 1.1/1.6.4.2.1.3 answers ERR_SEQUENCE to an
+    ALLOC_ODT that follows an ALLOC_ODT_ENTRY; the second ALLOC_ODT is legal exactly where it sits,
+    after another ALLOC_ODT and after SET_DAQ_LIST_MODE, neither of which is an enumerated case."""
+    handle = XcpTest(dynamic_config(daq_count=1, odt_count=2, odt_entries_count=1,
+                                    identification_field_type='ABSOLUTE'))
+    connect(handle)
+    handle.xcp_read_slave_memory_u8.side_effect = lambda a, e, b: b.__setitem__(0, 0xA5)
+
+    assert response(handle, (0xD5, 0x00, 0x01, 0x00))[0] == 0xFF, 'ALLOC_DAQ(1)'
+    assert response(handle, (0xD4, 0x00, 0x00, 0x00, 0x01))[0] == 0xFF, 'ALLOC_ODT(list 0, 1)'
+    assert response(handle, (0xE0, mode, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00))[0] == 0xFF, \
+        'SET_DAQ_LIST_MODE is granted while the list still holds exactly one ODT'
+    assert response(handle, (0xD4, 0x00, 0x00, 0x00, 0x01))[0] == 0xFF, 'ALLOC_ODT accumulates'
+    assert handle.lib.Xcp_Ptr.config.daqList[0].maxOdt == 2, 'the list now has two ODTs'
+    assert (daq_list_mode(handle) & mode) == mode, 'and the granted mode is still set on it'
+
+    if entries:
+        for odt in (0x00, 0x01):
+            assert response(handle, (0xD3, 0x00, 0x00, 0x00, odt, 0x01))[0] == 0xFF
+            assert response(handle, (0xE2, 0x00, 0x00, 0x00, odt, 0x00))[0] == 0xFF
+            assert response(handle, (0xE1, 0xFF, 0x01, 0x00) +
+                            tuple(u32_to_array(0x1000 + odt, 'LITTLE_ENDIAN')))[0] == 0xFF
+        # Last, and only once the entries are in place: SET_DAQ_LIST_MODE answers ERR_DAQ_ACTIVE
+        # for a running list, so nothing above could follow a START. A list left stopped would make
+        # every caller below pass by sampling nothing at all, for a reason that has nothing to do
+        # with PID_OFF.
+        assert response(handle, (0xDE, 0x01, 0x00, 0x00))[0] == 0xFF, 'START_STOP_DAQ_LIST(START)'
+    return handle
+
+
+def test_a_pid_off_list_grown_past_one_odt_is_not_sampled():
+    """The transmit-side twin of stim_decode_test.py's
+    test_pid_off_is_refused_once_alloc_odt_has_grown_the_list_past_one_odt. Both directions face the
+    same drifted list; the receive side cannot attribute an arriving frame to an ODT and drops it,
+    and this side must not create the frames that would be unattributable.
+
+    Sampling this list would queue two DTOs, each with no identification field, onto the one PDU the
+    pool shares -- and 1.1/1.1.2.1 leaves the master nothing else to tell them apart with, since
+    every ODT of a list goes out on the same CAN-Id. Asserting the ring is empty rather than
+    asserting one frame is deliberate: emitting ODT 0 alone would still be wrong, because the master
+    was promised the list's whole cycle and would silently receive half of it.
+
+    The Det report is asserted as well as the silence. Without it this test would pass just as well
+    against a module that skipped the list for some unrelated reason -- a broken elapsed check, a
+    list that never actually started -- and drifted lists would vanish with no trace an integrator
+    could see."""
+    handle = drifted_handle()
+
+    handle.lib.Xcp_TriggerEventChannel(0)
+
+    assert queued_frames(handle) == [], \
+        'a PID_OFF list with two ODTs cannot be identified on the wire, so it must not be sampled'
+    assert len(not_identifiable(handle)) == 1, 'and the skip is reported once for the list'
+    assert not_identifiable(handle)[0][0][2] == \
+        handle.define('XCP_TRIGGER_EVENT_CHANNEL_API_ID')
+
+
+def test_the_same_list_transmits_both_odts_once_pid_off_is_cleared():
+    """The PID_OFF term of the skip condition, isolated. Same pool, same two ALLOC_ODTs, same
+    entries -- only the granted mode differs -- so a guard that had been written against maxOdt
+    alone, or against dynamic allocation, would fail here by refusing a perfectly ordinary two-ODT
+    list. Two frames, not merely 'some', because a guard that skipped ODT 1 while emitting ODT 0
+    would satisfy a weaker assertion.
+
+    The absolute ODT numbers are pinned as well: with the identification field back, the two frames
+    must be distinguishable, which is the property whose absence justifies the skip in the first
+    test."""
+    handle = drifted_handle(mode=0x00)
+
+    handle.lib.Xcp_TriggerEventChannel(0)
+
+    frames = queued_frames(handle)
+    assert len(frames) == 2, 'two ODTs, each with one entry, sample to two frames'
+    first_pid = handle.lib.Xcp_Ptr.config.daqList[0].firstPid
+    assert [frame[0] for frame in frames] == [first_pid, first_pid + 1], \
+        'and each carries its own absolute ODT number'
+    assert not_identifiable(handle) == [], 'nothing was skipped, so nothing was reported'
+
+
+def test_a_single_odt_pid_off_list_still_transmits():
+    """The maxOdt term of the skip condition, isolated. The identical dynamic pool and the identical
+    PID_OFF grant, without the second ALLOC_ODT: a guard that keyed on PID_OFF alone would silence
+    this list too, and PID_OFF would become a bit that turns transmission off rather than the
+    identification field.
+
+    SduLength is asserted because the payload byte alone does not say the identification field is
+    absent -- one byte total is what says it."""
+    handle = XcpTest(dynamic_config(daq_count=1, odt_count=2, odt_entries_count=1,
+                                    identification_field_type='ABSOLUTE'))
+    connect(handle)
+    handle.xcp_read_slave_memory_u8.side_effect = lambda a, e, b: b.__setitem__(0, 0xA5)
+    assert response(handle, (0xD5, 0x00, 0x01, 0x00))[0] == 0xFF
+    assert response(handle, (0xD4, 0x00, 0x00, 0x00, 0x01))[0] == 0xFF
+    assert response(handle, (0xE0, 0x20, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00))[0] == 0xFF
+    assert response(handle, (0xD3, 0x00, 0x00, 0x00, 0x00, 0x01))[0] == 0xFF
+    assert response(handle, (0xE2, 0x00, 0x00, 0x00, 0x00, 0x00))[0] == 0xFF
+    assert response(handle, (0xE1, 0xFF, 0x01, 0x00) +
+                    tuple(u32_to_array(0x1000, 'LITTLE_ENDIAN')))[0] == 0xFF
+    assert response(handle, (0xDE, 0x01, 0x00, 0x00))[0] == 0xFF
+
+    handle.lib.Xcp_TriggerEventChannel(0)
+
+    assert queued_frames(handle) == [bytes((0xA5,))], \
+        'one ODT, one entry, and no identification field in front of it'
+    assert not_identifiable(handle) == []

--- a/test/transport_layer_cmd_test.py
+++ b/test/transport_layer_cmd_test.py
@@ -74,7 +74,11 @@ def test_transport_layer_cmd_sub_command_get_daq_list_can_identifier_returns_exp
     # check packet ID.
     assert raw_data[0] == 0xFF
 
-    # check CAN ID fixed.
+    # CAN_ID_FIXED, and 0x01 is the permanent answer rather than a placeholder: SET_DAQ_ID (0xFD)
+    # is deliberately not implemented (see the test below), so this slave genuinely cannot change a
+    # DAQ list's transmit identifier. The polarity -- 1 meaning fixed -- is the CAN Transport Layer
+    # specification's, which is not held in docs/external; what this assertion pins independently
+    # of that is that the byte does not drift while SET_DAQ_ID stays refused.
     assert raw_data[1] == 0x01
 
     # check reserved bytes.
@@ -122,6 +126,16 @@ def test_get_daq_id_answers_each_allocated_dynamic_list_by_its_own_number():
 
 
 def test_transport_layer_cmd_sub_cmd_set_daq_list_can_identifier_returns_err_cmd_unknown():
+    """SET_DAQ_ID is refused BY DESIGN, so this test pins a decision rather than marking a gap.
+
+    AUTOSAR SWS XCP R4.3.1 §4.1 Limitations: "The SET_DAQ_ID command according to the XCP CAN
+    Transport Layer Specification is not part of the AUTOSAR XCP module". ERR_CMD_UNKNOWN (0x20) is
+    what 1.1/1.4 prescribes for an optional command a slave does not implement, so the refusal is
+    conformant in both directions at once.
+
+    The request here is eight bytes, which matters: the handler length-checks before it refuses, so
+    a shorter frame is answered ERR_CMD_SYNTAX instead and would pass an assertion written only
+    against "some error". See test/asam_error_matrix_test.py for that half."""
     handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001))
     # CONNECT
     handle.lib.Xcp_CanIfRxIndication(0x0001, handle.get_pdu_info((0xFF, 0x00)))


### PR DESCRIPTION
The SP3 follow-ups: the transmit-side twin of the `PID_OFF` drop the
receive side already had, the removal of a handler dead since DD46, and
a pass over claims SP3 left stale.

## The defect

`SET_DAQ_LIST_MODE` grants `PID_OFF` only to a list with `ABSOLUTE`
identification, exactly one ODT, and a TX PDU no other list shares. A
grant describes the moment that command ran. Under `DAQ_DYNAMIC` the
master may allocate more ODTs afterwards — `ALLOC_ODT` is accepted from
`XCP_DAQ_ALLOC_ODT` as well as `XCP_DAQ_ALLOC_DAQ`, `SET_DAQ_LIST_MODE`
does not touch `daq_alloc_state`, and DD28 makes a repeat accumulate —
so this is a conformant sequence:

```
ALLOC_DAQ(1) → ALLOC_ODT(0, 1) → SET_DAQ_LIST_MODE(PID_OFF) → ALLOC_ODT(0, 1)
```

No `ERR_SEQUENCE` case in §1.6.4.2.1.3 covers it, and it leaves `maxOdt`
at 2 with `PID_OFF` still set. Both ODTs were then sampled and went out
on one PDU carrying no identification field and nothing else to tell
them apart. `Xcp_DaqReadIdentificationField` already re-checked `maxOdt`
and dropped such a frame on receive; the transmit side had no guard.

## What the specification says, and what it does not

Checked before implementing, and it changed the justification rather
than the fix. §1.1.2.1 and §1.6.4.1.1.3 are word-identical in 1.0 and
1.1, and between them:

- the only **normative** requirement on `PID_OFF` is that the
  identification field type be `ABSOLUTE`;
- disambiguation is assigned elsewhere — *"the unambiguous
  identification has to be done on the level of the Transport Layer"*;
- one CAN-Id and one ODT per list is introduced with **"e.g."** — an
  example of achieving that, not a mandate.

So the module's grant rule is *stricter* than the specification, which
is a defensible reading for a CAN transport where every ODT of a list
shares one TX PDU. The skip is therefore not a spec-mandated refusal: it
holds the module's own invariant true at the moment of use, because in
the drifted state the transport-level requirement cannot be met. The
comments say that rather than claiming the specification requires it.

`ALLOC_ODT` was also checked as a place to refuse the drift up front,
which would tell the master immediately. Its error set is
`ERR_OUT_OF_RANGE`, `ERR_MEMORY_OVERFLOW` and `ERR_SEQUENCE`; none
expresses this, so the refusal would have had to borrow a code that
means something else.

## Changes

- `Xcp_TriggerEventChannel` skips such a list whole and reports the new
  `XCP_E_DAQ_LIST_NOT_IDENTIFIABLE`. Transmitting anyway was rejected
  (the master expects no field, so every byte shifts) and so was
  clearing `PID_OFF` on growth (a silent mode change `ALLOC_ODT` has no
  error code to report).
- `Xcp_DTODaqStimPacket` is gone. Its 192 `Xcp_PIDTable` entries now
  point at `Xcp_CmdNotImplemented`; the table keeps all 256 entries and
  its direct indexing, because a 64-entry table indexed `pid - 0xC0`
  would turn a guarded dead range into an out-of-bounds read if the
  guard were ever removed. Behaviour-neutral: the generator emits
  exactly 64 `ctoInfo` entries with `IS_CTO` set against 192 without.
- Five stale claims corrected, and the roadmap marks SP3 complete with
  its concurrency question answered rather than open.

## Testing

Three tests, one per term of the guard. Each fails alone under the
mutation that deletes the term it covers:

| mutation | fails |
|---|---|
| guard disabled | the drift is not sampled |
| `maxOdt` term dropped | a single-ODT `PID_OFF` list still transmits |
| `PID_OFF` term dropped | the same list transmits both ODTs once `PID_OFF` is cleared |

Full suite: **12743 passed, 29 skipped, 0 failed.**

## Not in scope

`BIT_STIM`, `EV_STIM_TIMEOUT` and runtime STIM resource protection each
need their own design; they are recorded in the roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Added after review of the next roadmap item

`SET_DAQ_ID` (`TRANSPORT_LAYER_CMD` sub-command `0xFD`) was next on the
list. It turns out **AUTOSAR SWS XCP R4.3.1 §4.1** puts it out of scope
outright — *"The SET_DAQ_ID command according to the XCP CAN Transport
Layer Specification is not part of the AUTOSAR XCP module"* — and this
module tracks that SWS. Two further obstacles: its normative definition
lives in the XCP CAN Transport Layer specification, which is not in
`docs/external`, and implementing it would need `CanIf_SetDynamicTxId`
(SWS_CANIF_00189) plus an integrator guarantee that every DAQ transmit
PDU is a dynamic L-PDU.

Behaviour is unchanged — `ERR_CMD_UNKNOWN` is what §1.4 prescribes — but
every mention called it *absent*, a *TODO*, or roadmap residue. It is
now recorded as a deliberate exclusion in the README limitations, the
handler, the test, and the roadmap. `GET_DAQ_ID`'s `CAN_ID_FIXED` byte
is documented as truthful rather than provisional, and two commented-out
parse lines are removed — they read from the *response* buffer, so they
would never have parsed the request.

Also corrects two README limitations that SP2d and SP3 made false.
