### PR TITLE
Seed-and-key hardening: three shipped defects, and a configuration that could not be built

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,11 @@ Whenever the seed is requested by the master through the `GET_SEED` command, a n
 through the `Xcp_GetSeed` function. The reason is that otherwise the master could calculate a key for a single seed and 
 reuse it forever, which would weaken the resource protection.
 
-Whenever the master issues an `UNLOCK` command, the slave discards the seed as well, whether or not the command 
-succeeded. This implies a new `GET_SEED` request for each `UNLOCK` command.
+The slave discards the seed once an `UNLOCK` sequence has delivered the whole key, and on every outcome of that
+sequence alike: a key that matches, a key that does not, and an `Xcp_CalcKey` that fails to produce one at all. An
+intermediate frame of a key too long for one CTO keeps the seed, and an `UNLOCK` the slave refuses outright discards
+nothing, because it never gets as far as the key. This implies a new `GET_SEED` request for each completed `UNLOCK`
+sequence.
 
 The `Xcp_GetSeed` function implementation is left to the stack user. The target on which the stack is integrated could
 provide some random value generator, thus this is target-specific. The function's prototype is defined 
@@ -83,11 +86,33 @@ provide some random value generator, thus this is target-specific. The function'
 
 ## Key lifetime
 Whenever an `UNLOCK` command is issued by the master, the key is calculated by the slave using the last seed value
-requested by the master. Whether or not the keys match, the key is discarded after the command following the `UNLOCK`
-sequence has been executed.
+requested by the master. A key too long for one CTO is split over several `UNLOCK` frames; once the last of them has
+arrived the seed is discarded whatever the outcome, so the next `UNLOCK` sequence needs a `GET_SEED` of its own (see
+*Seed lifetime* above).
 
-If the master issues an `UNLOCK` command without calling `GET_SEED` first, the stack responds with an error packet
-identifier and the code `ERR_SEQUENCE`.
+The sequence itself has to be respected, and the slave answers an error packet identifier with the code `ERR_SEQUENCE`
+unless both of the following hold. First, the slave must currently hold a seed, which an `UNLOCK` with no `GET_SEED` in
+front of it at all does not satisfy. Second, the immediately preceding command must be that `GET_SEED` or a previous
+frame of the same key — any other command in between ends the sequence, including one that only reads status, and the
+master has to restart it with a fresh `GET_SEED`.
+
+A `GET_SEED` the integrator's `Xcp_GetSeed` refuses is answered `ERR_OUT_OF_RANGE` and transmits no seed bytes, but
+whether it also leaves the slave holding no seed is the integrator's own choice: the slave passes `pSeedLength` straight
+into its own bookkeeping, so an `Xcp_GetSeed` that returns `E_NOT_OK` without writing it leaves the slave seedless and
+the next `UNLOCK` refused, while one that writes a length and only then fails leaves a seed held, and a following
+`UNLOCK` can still be admitted. What a refused `GET_SEED` can never do is become the granted request: a grant releases
+the resource named by the last `GET_SEED` that actually succeeded, never the one that was refused. It is also no use to
+a master, since the refused request put no seed bytes on the wire to derive a key from. Returning `E_NOT_OK` without
+touching `pSeedLength` is nevertheless the cleaner contract, and the one to prefer.
+
+If the whole key arrives but does not match, the slave answers `ERR_ACCESS_LOCKED` and goes to the disconnected state.
+If `Xcp_CalcKey` fails outright, so that no key is ever compared, the slave answers `ERR_GENERIC` and stays connected.
+
+What a successful `UNLOCK` grants lasts for the whole XCP session, not for one command: the group stays accessible for
+as many commands as the master needs, and unrelated commands in between do not spend it. Grants accumulate — unlocking
+a second group leaves the first one granted — and `CONNECT` puts every group named in `resource_protection` back under
+protection, so a grant never outlives the session that earned it. `GET_STATUS` and `UNLOCK`'s own positive response
+both report the *Current Resource Protection Mask*, in which a bit that is **set** means the group is still protected.
 
 The implementation of the function responsible for key calculation, `Xcp_CalcKey` is left to the user. This is necessary,
 because the function must be shared between the master and the slave.
@@ -377,7 +402,11 @@ The remaining eight **PGM** commands (`PROGRAM_CLEAR`, `PROGRAM`, `PROGRAM_MAX`,
 of them define `CONNECT`'s "flash programming available" resource bit, so enabling
 `xcp_program_clear_api_enable`, `xcp_program_api_enable` or `xcp_program_max_api_enable` in a build with
 `programming.enabled` set is refused at code generation rather than shipped as an advertisement with nothing behind it.
-`resource_protection.programming` is refused in the same build for a different reason, given under *Limitations* below.
+`resource_protection.programming`, by contrast, is accepted in such a build. A granted resource lasts the whole XCP
+session (see *Key lifetime* above), so the `GET_SEED`/`UNLOCK` round that admits `PROGRAM_START` is still in effect when
+`PROGRAM_RESET` — itself a **PGM** command, and the only one that ends the session — is due. That is what makes a
+protected **PGM** group able to leave programming mode at all, given that `GET_SEED` and `UNLOCK` are themselves
+refused `ERR_PGM_ACTIVE` while the session is open.
 
 
 # Limitations
@@ -411,13 +440,6 @@ of them define `CONNECT`'s "flash programming available" resource bit, so enabli
   three `CONNECT`'s flash-programming resource bit is defined by, so enabling their API keys in a programming build
   is refused at generation and that bit is never set until they exist. Until they do, the group can open, prepare
   and end a programming sequence, but nothing in it transfers or erases code.
-- The `PGM` resource cannot be protected: `resource_protection.programming` is refused at generation in any build
-  with `programming.enabled` set. An `UNLOCK` is spent by the single command following it (see *Key lifetime*
-  above), so `PROGRAM_START` consumes it, and once the session is open the specification requires `GET_SEED` and
-  `UNLOCK` to be refused `ERR_PGM_ACTIVE` — leaving `PROGRAM_RESET`, the only command that ends the session, locked
-  with no way to unlock it. Every refusal in that chain is conformant on its own; the composition is a slave that
-  cannot leave programming mode, so the configuration is refused rather than shipped. Fixing it means changing the
-  key lifetime for every resource group, not the **PGM** group alone.
 - At most one DTO frame is in flight at a time (SP2c): `Xcp_StartNextTransmission` arbitrates a single transmit
   slot across command responses, event packets and DAQ frames alike, and starts the next one only once the
   current one is confirmed. This is mandatory rather than a simplification, not merely a design choice this

--- a/docs/superpowers/plans/2026-09-08-xcp-seed-key-hardening.md
+++ b/docs/superpowers/plans/2026-09-08-xcp-seed-key-hardening.md
@@ -1,0 +1,615 @@
+# Seed-and-Key Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make an unlock last the session, refuse an `UNLOCK` with no held seed, and report the resource protection mask with the polarity the specification defines — removing the generation refusal that makes `resource_protection.programming` unbuildable.
+
+**Architecture:** Three pre-existing defects share one field, `Xcp_Internal.protection_status`. The work lands in four tasks ordered so each is independently testable: the lifetime fix first (it is what makes the programming configuration viable), then the held-seed gate, then the removal of the generation refusal proved by an end-to-end programming run, and finally the representation change — the field becomes the still-locked mask and is renamed, which turns every reader into a compile error rather than silently correct-looking arithmetic.
+
+**Tech Stack:** C (AUTOSAR-style, MISRA-leaning), Python 3.7 + pytest + CFFI test harness, CMake, Jinja2 code generation, Docker.
+
+**Spec:** `docs/superpowers/specs/2026-09-08-xcp-seed-key-hardening-design.md` (DD78–DD83)
+
+## Global Constraints
+
+- **`./test.sh` is the only authoritative run, and it runs in Docker.** Host runs die at `cmake: not found`. Use exactly: `docker run --rm --user "$(id -u):$(id -g)" --env HOME=/tmp --ulimit nofile=65536:524288 --volume "$PWD:/usr/project" --workdir /usr/project xcp-test:sp4b ./test.sh`
+- **Never `rm -rf generated/*`** — it holds a tracked `generated/CMakeLists.txt`.
+- **`Xcp_Internal` and file-`static` tables are NOT reachable from the CFFI harness.** `test/conftest.py` builds its cdef from `interface/Xcp.h` alone. Every assertion must observe through transmitted bytes. Precedent: `test/clear_daq_list_test.py:80-92`.
+- **Mutation verification is required** on: DD80's gate expression, **each of DD81's two conjuncts separately**, and at least one DD82 reporting site. A compound condition needs a test per term, not per outcome.
+- **A test that cannot fail is a defect.** Before committing any test, revert the fix it pins and confirm it fails; record which test failed and how.
+- Commit messages for defect fixes begin `fix: pre-existing` and state the measured failure sequence.
+- The `resource_protection.data_stimulation` refusal (DD41/DD48) must still fire at the end of this work, with its own test unchanged.
+
+**Frames and helpers used throughout** (verified against the current tree):
+
+| Thing | Value |
+|---|---|
+| CONNECT | `(0xFF, 0x00)` |
+| GET_STATUS | `(0xFD,)` — group `MASK_NONE`, never protected |
+| SET_MTA | `(0xF6, 0x00, 0x00, 0x00) + tuple(u32_to_array(addr, 'LITTLE_ENDIAN'))` — group `MASK_NONE` |
+| DOWNLOAD (3 bytes) | `(0xF0, 0x03, 0x11, 0x22, 0x33)` — group `MASK_CAL_PAG`, **the protected observable** |
+| GET_SEED | `(0xF8, mode, resource)`; resource `0x01` = CAL_PAG, `0x10` = PGM |
+| UNLOCK | `(0xF7, remaining_len) + key_bytes` |
+| Locked refusal | `(0xFE, 0x25)` = `ERR_ACCESS_LOCKED` |
+| Sequence refusal | `(0xFE, 0x29)` = `ERR_SEQUENCE` |
+| Mocks | `handle.xcp_get_seed`, `handle.xcp_calc_key`, `handle.xcp_write_slave_memory_u8` |
+| Config flags | `resource_protection_calibration_paging=True`, `resource_protection_programming=True`, `programming_enabled=True` |
+| Helpers | `from .download_test import connect, set_mta`; `from .seed_key_test import get_seed_side_effect_copy_ok, calc_key_side_effect_copy_ok`; `from .seed_key_defects_test import exchange` |
+
+`exchange(handle, request, length=3)` resets the transmit mock, dispatches, pumps `Xcp_MainFunction`, asserts exactly one transmission, returns the first `length` response bytes, then confirms. Use it for every command; never read `call_args` without resetting first.
+
+---
+
+## File Structure
+
+| File | Responsibility | Tasks |
+|---|---|---|
+| `source/Xcp.c` | dispatch gate, protection accessors, `Xcp_Init` seeding | 1, 4 |
+| `source/Xcp_Std.c` | `CONNECT` teardown, `UNLOCK`, `GET_STATUS` | 1, 2, 4 |
+| `source/Xcp_Internal.h` | the field and accessor declarations | 4 |
+| `script/source_cfg.c.jinja2` | the generation refusal | 3 |
+| `test/seed_key_lifetime_test.py` | **new** — DD79 and DD81 behaviour | 1, 2 |
+| `test/pgm_protected_acceptance_test.py` | **new** — the DD83 end-to-end proof | 3 |
+| `test/seed_key_defects_test.py` | migrate five status-byte assertions | 4 |
+
+**Checked, and needing no change:** `test/get_status_test.py` and `test/asam_protocol_layer_test.py`
+both exercise `GET_STATUS` but assert only byte 0 and byte 1, never byte 2 — so the polarity change
+does not touch them. The five tests in `test/seed_key_defects_test.py` are the *only* existing
+assertions on the protection byte anywhere in the suite. If a run turns up a sixth, that is a
+finding worth reporting, not a test to quietly adjust.
+
+---
+
+### Task 1: DD79 — an unlock lasts the session
+
+**Files:**
+- Modify: `source/Xcp.c` (the clear-after-dispatch call; `Xcp_SetProtectionStatus`)
+- Modify: `source/Xcp_Std.c` (`Xcp_CTOCmdStdConnect`'s teardown block)
+- Test: `test/seed_key_lifetime_test.py` (create)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `Xcp_Internal.protection_status` now accumulates granted resources and is cleared only by `Xcp_Init` and `CONNECT`. Still means "unlocked set" — Task 4 inverts it. Task 3 depends on this task and nothing else.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `test/seed_key_lifetime_test.py`:
+
+```python
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""DD79 (docs/superpowers/specs/2026-09-08-xcp-seed-key-hardening-design.md) -- a pre-existing
+defect in shipped code: a successful UNLOCK grants a resource for exactly ONE following command.
+
+source/Xcp.c cleared the whole granted set after every dispatched command except UNLOCK itself, so
+an unrelated GET_STATUS spent the grant just as a CAL command did. XCP part 2 - Protocol Layer
+Specification 1.0/1.6.1.2.5 says the opposite: "a repetition of an UNLOCK sequence with a correct
+key will have a positive response and no other effect", which presumes the grant is still standing.
+
+DOWNLOAD (0xF0) is the protected observable throughout this file: Xcp_PIDToCmdGroupTable
+(source/Xcp.c) maps it to MASK_CAL_PAG, while SET_MTA (0xF6) and GET_STATUS (0xFD) map to
+MASK_NONE, so the setup and the interloper both stay reachable while CAL_PAG is locked."""
+
+from .parameter import *
+from .conftest import XcpTest
+from .download_test import connect, set_mta
+from .seed_key_test import get_seed_side_effect_copy_ok, calc_key_side_effect_copy_ok
+from .seed_key_defects_test import exchange
+
+GET_STATUS = (0xFD,)
+DOWNLOAD = (0xF0, 0x03, 0x11, 0x22, 0x33)
+SEED = [0x11, 0x22]
+KEY = [0x33, 0x44]
+
+
+def cal_protected_handle(**kwargs):
+    """A slave whose CALibration/Paging group is protected, connected and with a valid MTA.
+
+    The MTA is set BEFORE any unlock deliberately: SET_MTA is MASK_NONE, so it must succeed while
+    CAL_PAG is still locked, and doing it here keeps every DOWNLOAD below a test of the protection
+    gate rather than of address setup."""
+    handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001,
+                                   resource_protection_calibration_paging=True,
+                                   **kwargs))
+    connect(handle)
+    set_mta(handle, 0x1000)
+    return handle
+
+
+def unlock_cal_pag(handle):
+    """A complete GET_SEED/UNLOCK sequence for CAL_PAG, asserting each half so a failure here is
+    never mistaken for the behaviour under test."""
+    handle.xcp_get_seed.side_effect = get_seed_side_effect_copy_ok(handle, SEED)
+    handle.xcp_calc_key.side_effect = calc_key_side_effect_copy_ok(handle, KEY)
+
+    assert exchange(handle, (0xF8, 0x00, 0x01))[0] == 0xFF, 'GET_SEED(mode=0, CAL_PAG)'
+    assert exchange(handle, (0xF7, len(KEY)) + tuple(KEY))[0] == 0xFF, 'UNLOCK'
+
+
+def test_a_protected_command_is_refused_before_any_unlock():
+    """The precondition every other test in this file rests on. Without it, a DOWNLOAD that
+    succeeds proves nothing -- it would succeed identically if the resource were never protected,
+    which is exactly the configuration the rest of the suite runs in."""
+    handle = cal_protected_handle()
+
+    assert exchange(handle, DOWNLOAD)[0:2] == (0xFE, 0x25), 'ERR_ACCESS_LOCKED'
+
+
+def test_an_unlock_survives_an_unrelated_command():
+    """DD79, the defect itself. GET_STATUS is MASK_NONE and has no side effects, so the only thing
+    it can do to the DOWNLOAD that follows is spend its grant -- which is what it used to do."""
+    handle = cal_protected_handle()
+    unlock_cal_pag(handle)
+
+    assert exchange(handle, DOWNLOAD)[0] == 0xFF, 'the first protected command after UNLOCK'
+    assert exchange(handle, GET_STATUS)[0] == 0xFF
+    assert exchange(handle, DOWNLOAD)[0] == 0xFF, \
+        'the grant was spent by an unrelated GET_STATUS'
+
+
+def test_an_unlock_survives_repeated_use_of_the_protected_resource():
+    """The grant must not be consumed by the protected command either -- a variant the
+    single-command lifetime also broke, and one a master doing a real calibration session hits
+    immediately."""
+    handle = cal_protected_handle()
+    unlock_cal_pag(handle)
+
+    for attempt in range(5):
+        assert exchange(handle, DOWNLOAD)[0] == 0xFF, \
+            'DOWNLOAD number {} was refused'.format(attempt + 1)
+
+
+def test_an_unlock_does_not_survive_a_reconnect():
+    """The other half of DD79: the grant lasts the SESSION, not forever. This is the same session
+    boundary DD77 established, and the reset joins that block."""
+    handle = cal_protected_handle()
+    unlock_cal_pag(handle)
+    assert exchange(handle, DOWNLOAD)[0] == 0xFF
+
+    connect(handle)
+    set_mta(handle, 0x1000)
+
+    assert exchange(handle, DOWNLOAD)[0:2] == (0xFE, 0x25), \
+        'the grant outlived the session that earned it'
+```
+
+- [ ] **Step 2: Run the tests and confirm three of the four fail**
+
+```bash
+docker run --rm --user "$(id -u):$(id -g)" --env HOME=/tmp --volume "$PWD:/usr/project" --workdir /usr/project/build xcp-test:sp4b cmake .. -DXCP_ENABLE_TEST=ON -DXCP_PYTEST_ARGS="-k;seed_key_lifetime"
+docker run --rm --user "$(id -u):$(id -g)" --env HOME=/tmp --ulimit nofile=65536:524288 --volume "$PWD:/usr/project" --workdir /usr/project xcp-test:sp4b ./test.sh
+```
+
+Expected: `test_a_protected_command_is_refused_before_any_unlock` PASSES (the gate already refuses); the other three FAIL. `-x` stops at the first, so run, fix nothing, and note which one stopped it — then temporarily comment out the failing test to see the next, or trust the shared cause. Record the observed failure for each in the report.
+
+- [ ] **Step 3: Delete the clear-after-dispatch**
+
+In `source/Xcp.c`, inside the dispatch's allowed branch, delete:
+
+```c
+                                                    if (pid != XCP_PID_CMD_UNLOCK) {
+                                                        Xcp_ClearProtectionStatus();
+                                                    }
+```
+
+- [ ] **Step 4: Make grants accumulate**
+
+In `source/Xcp.c`, change `Xcp_SetProtectionStatus`:
+
+```c
+void Xcp_SetProtectionStatus(void) {
+    /* DD79: `|=`, not `=`. Once grants persist past the next command, an assignment would make
+     * unlocking a second resource silently drop the first -- invisible while a grant lasted one
+     * command, because there was never a second grant alive to lose. */
+    Xcp_Internal.protection_status |= Xcp_Internal.requested_protected_resource;
+}
+```
+
+- [ ] **Step 5: Re-lock at the session boundary**
+
+In `source/Xcp_Std.c`, in `Xcp_CTOCmdStdConnect`'s teardown block, immediately before
+`Xcp_Internal.connection_status = XCP_CONNECTION_STATE_CONNECTED;`:
+
+```c
+    /* DD79. With the clear-after-dispatch gone, this is the ONLY thing that re-locks a resource
+     * inside a running module, and XCP part 1 - Overview 1.0/2.3 -- quoted in full at
+     * Xcp_CanIfRxIndication (Xcp.c) -- names the protection status bits among what a DISCONNECTED
+     * slave has reset. A grant belongs to the session that earned it. */
+    Xcp_Internal.protection_status = 0x00u;
+```
+
+- [ ] **Step 6: Run the tests and confirm all four pass**
+
+Same commands as Step 2. Expected: 4 passed.
+
+- [ ] **Step 7: Mutation-verify the lifetime**
+
+Restore the deleted clear (Step 3) temporarily, re-run, and confirm `test_an_unlock_survives_an_unrelated_command` fails. Then restore the fix. Separately, change Step 4's `|=` back to `=` and confirm nothing fails — **this is expected**, because no test in this task unlocks two resources; record that honestly, and note that Task 4's accumulate test covers it.
+
+- [ ] **Step 8: Clear the pytest filter and run the full suite**
+
+```bash
+docker run --rm --user "$(id -u):$(id -g)" --env HOME=/tmp --volume "$PWD:/usr/project" --workdir /usr/project/build xcp-test:sp4b cmake .. -DXCP_ENABLE_TEST=ON -DXCP_PYTEST_ARGS=""
+docker run --rm --user "$(id -u):$(id -g)" --env HOME=/tmp --ulimit nofile=65536:524288 --volume "$PWD:/usr/project" --workdir /usr/project xcp-test:sp4b ./test.sh
+```
+
+Expected: both ctest targets pass. **If any existing test fails, do not adjust it without reporting** — a test that depended on a grant being spent is evidence about the old behaviour and its docstring must be read before it is changed.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add source/Xcp.c source/Xcp_Std.c test/seed_key_lifetime_test.py
+git commit -m "fix: pre-existing single-command unlock lifetime in shipped seed-and-key code"
+```
+
+---
+
+### Task 2: DD81 — `UNLOCK` requires a held seed
+
+**Files:**
+- Modify: `source/Xcp_Std.c` (`Xcp_DTOCmdStdUnlock`'s admission gate)
+- Test: `test/seed_key_lifetime_test.py` (append)
+
+**Interfaces:**
+- Consumes: `cal_protected_handle()`, `unlock_cal_pag()`, `SEED`, `KEY` from Task 1.
+- Produces: `UNLOCK` answers `ERR_SEQUENCE` unless `seed.total_length != 0`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `test/seed_key_lifetime_test.py`:
+
+```python
+def test_unlock_with_no_preceding_get_seed_is_refused():
+    """DD81, and the defect section 3b of the previous branch recorded and deliberately left
+    unfixed. XCP part 2 1.0/1.6.1.2.5: "The master only can send an UNLOCK sequence if previously
+    there was a GET_SEED sequence... If the master does not respect this sequence, the slave
+    returns an ERR_SEQUENCE."
+
+    ERR_SEQUENCE needs no deviation: it is in UNLOCK's own 1.7.3.2.1 row, and that row's prescribed
+    pre-action for it is literally GET_SEED, so the refusal tells the master exactly what to do."""
+    handle = cal_protected_handle()
+    handle.xcp_calc_key.side_effect = calc_key_side_effect_copy_ok(handle, KEY)
+
+    assert exchange(handle, (0xF7, len(KEY)) + tuple(KEY))[0:2] == (0xFE, 0x29), 'ERR_SEQUENCE'
+    assert exchange(handle, DOWNLOAD)[0:2] == (0xFE, 0x25), \
+        'the resource was granted by an UNLOCK against a seed that was never issued'
+
+
+def test_a_second_unlock_without_a_fresh_seed_is_refused():
+    """The seed is spent by the UNLOCK that consumes it -- Xcp_DTOCmdStdUnlock already zeroes
+    seed.total_length on a complete key, under a comment saying it "enforces a new seed to be
+    requested prior to unlock a next resource". Nothing ever checked it. This is that check."""
+    handle = cal_protected_handle()
+    unlock_cal_pag(handle)
+
+    assert exchange(handle, (0xF7, len(KEY)) + tuple(KEY))[0:2] == (0xFE, 0x29), 'ERR_SEQUENCE'
+
+
+def test_a_legitimate_multi_frame_key_is_still_admitted():
+    """The guard must not break a key too long for one frame. At MAX_CTO=8 a frame carries at most
+    MAX_CTO-2 = 6 key bytes, so a 10-byte key needs two UNLOCK frames; seed.total_length stays
+    non-zero across the whole sequence and is zeroed only on completion, so every frame is
+    admitted. Without this test the guard could be written to admit only the FIRST frame and both
+    tests above would still pass."""
+    handle = cal_protected_handle()
+    long_key = [0xA0 + i for i in range(10)]
+
+    handle.xcp_get_seed.side_effect = get_seed_side_effect_copy_ok(handle, SEED)
+    handle.xcp_calc_key.side_effect = calc_key_side_effect_copy_ok(handle, long_key)
+
+    assert exchange(handle, (0xF8, 0x00, 0x01))[0] == 0xFF
+    assert exchange(handle, (0xF7, 10) + tuple(long_key[0:6]))[0] == 0xFF, 'first UNLOCK frame'
+    assert exchange(handle, (0xF7, 4) + tuple(long_key[6:10]))[0] == 0xFF, 'second UNLOCK frame'
+
+    assert exchange(handle, DOWNLOAD)[0] == 0xFF, 'a legitimate multi-frame unlock was refused'
+```
+
+- [ ] **Step 2: Run and confirm the first two fail, the third passes**
+
+Filter with `-DXCP_PYTEST_ARGS="-k;seed_key_lifetime"` as in Task 1 Step 2. Expected: the two refusal tests FAIL (the UNLOCK is admitted and answers `0xFF`), the multi-frame test PASSES.
+
+- [ ] **Step 3: Add the held-seed conjunct**
+
+In `source/Xcp_Std.c`, in `Xcp_DTOCmdStdUnlock`, replace:
+
+```c
+    if ((Xcp_Internal.last_pid == XCP_PID_CMD_GET_SEED) || (Xcp_Internal.last_pid == XCP_PID_CMD_UNLOCK))
+```
+
+with:
+
+```c
+    /* DD81. Two terms answering two different questions, and both are load-bearing.
+     *
+     * last_pid asks whether the immediately preceding command was a successful GET_SEED or a prior
+     * frame of this same key. It cannot say WHICH -- it is a two-element set-membership test -- so
+     * it cannot answer "was a seed actually issued", and on its own it admitted an UNLOCK against a
+     * seed that never existed (XCP part 2 1.0/1.6.1.2.5: "The master only can send an UNLOCK
+     * sequence if previously there was a GET_SEED sequence").
+     *
+     * seed.total_length asks exactly that second question. The mechanism already existed and
+     * nothing read it: the sequence below zeroes this field once a full key arrives, to "enforce a
+     * new seed to be requested prior to unlock a next resource". It stays non-zero for every frame
+     * of a multi-frame key, so this admits the whole legitimate sequence and refuses a replay.
+     *
+     * ERR_SEQUENCE is not a deviation: UNLOCK's own 1.7.3.2.1 row lists it, with GET_SEED as its
+     * prescribed pre-action. */
+    if (((Xcp_Internal.last_pid == XCP_PID_CMD_GET_SEED) || (Xcp_Internal.last_pid == XCP_PID_CMD_UNLOCK)) &&
+        (Xcp_Internal.seed.total_length != 0x00u))
+```
+
+- [ ] **Step 4: Run and confirm all seven tests in the file pass**
+
+Expected: 7 passed.
+
+- [ ] **Step 5: Mutation-verify each conjunct separately**
+
+Two independent runs, restoring the gate between them. Record which test failed in each:
+
+1. Drop the `seed.total_length` term → `test_unlock_with_no_preceding_get_seed_is_refused` and `test_a_second_unlock_without_a_fresh_seed_is_refused` must fail.
+2. Drop the `last_pid` terms (keep only `seed.total_length != 0`) → at least one test must fail. **If none does, say so plainly in the report rather than inventing one** — it would mean the `last_pid` half is unpinned by this suite, which is a finding, not a failure to hide.
+
+- [ ] **Step 6: Full suite, then commit**
+
+Clear the filter and run the full suite as in Task 1 Step 8.
+
+```bash
+git add source/Xcp_Std.c test/seed_key_lifetime_test.py
+git commit -m "fix: pre-existing missing held-seed check in shipped UNLOCK code"
+```
+
+---
+
+### Task 3: DD83 — remove the programming refusal, and prove it obsolete
+
+**Files:**
+- Modify: `script/source_cfg.c.jinja2` (delete the `resource_protection.programming` raise)
+- Test: `test/pgm_protected_acceptance_test.py` (create)
+
+**Interfaces:**
+- Consumes: Task 1's session-lifetime grant. Depends on Task 1 and on nothing else.
+- Produces: `resource_protection_programming=True` becomes a buildable configuration, which **Task 4 requires** for its migrated tests.
+
+- [ ] **Step 1: Write the end-to-end test**
+
+Create `test/pgm_protected_acceptance_test.py`. Read `test/pgm_acceptance_test.py` first and follow its established shape for pumping `Xcp_MainFunction` and confirming deferred responses; the integrator callbacks (`Xcp_ProgramStart`, `Xcp_ProgramClear`, `Xcp_ProgramWrite`, `Xcp_ProgramReset`) are polled, so each returns `E_NOT_OK` until it is finished and the response arrives on a later `Xcp_MainFunction`.
+
+```python
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""DD83 -- the configuration this proves buildable could not be generated at all before this task.
+
+script/source_cfg.c.jinja2 raised on `resource_protection.programming: true` with
+`programming.enabled: true`, because an unlock was spent by the single command that followed it:
+PROGRAM_START consumed the grant, the session became XCP_PGM_ACTIVE, PROGRAM_RESET -- the only
+command that ends it -- was locked again, and GET_SEED and UNLOCK were themselves refused
+ERR_PGM_ACTIVE. The slave could never leave the programming session.
+
+Every link in that chain depended on the grant being spent, so DD79 dissolves it. This test walks
+the whole sequence rather than arguing it: an argument that a dead end no longer exists is worth
+much less than a run that goes through where the dead end was."""
+```
+
+The test must perform, in one session, with `programming_enabled=True`, `resource_protection_programming=True` and the PGM API flags the sequence needs enabled:
+
+`CONNECT` → `GET_SEED(mode=0, resource=0x10)` → `UNLOCK` → `PROGRAM_START` → `PROGRAM_CLEAR` → `PROGRAM` → `PROGRAM_RESET`, asserting a positive response at every step, and asserting **before** the unlock that `PROGRAM_START` answers `(0xFE, 0x25)` so the protection is proven live rather than absent.
+
+- [ ] **Step 2: Confirm the configuration cannot be generated yet**
+
+Run the new test. Expected: the generator raises, and the failure names `resource_protection.programming`. This is the precondition — it proves the refusal is real and that this test exercises it.
+
+- [ ] **Step 3: Delete the refusal**
+
+In `script/source_cfg.c.jinja2`, delete the `{%- if %}` / `{{ raise(...) }}` / `{%- endif %}` block guarding `configuration.programming.enabled` together with `configuration.apis.resource_protection.programming`. **Leave the `stim.capable` / `resource_protection.data_stimulation` raise immediately above it untouched** — that one is DD41/DD48 and is still true.
+
+- [ ] **Step 4: Run and confirm the sequence completes**
+
+Expected: the new test passes end to end.
+
+- [ ] **Step 5: Confirm the STIM refusal still fires**
+
+```bash
+docker run --rm --user "$(id -u):$(id -g)" --env HOME=/tmp --volume "$PWD:/usr/project" --workdir /usr/project/build xcp-test:sp4b cmake .. -DXCP_ENABLE_TEST=ON -DXCP_PYTEST_ARGS="-k;stim or generation or configuration"
+```
+
+Then the full run. Expected: the existing `data_stimulation` refusal test still passes, unmodified.
+
+- [ ] **Step 6: Full suite, then commit**
+
+```bash
+git add script/source_cfg.c.jinja2 test/pgm_protected_acceptance_test.py
+git commit -m "feat: a protected PGM resource can now conduct a programming sequence"
+```
+
+---
+
+### Task 4: DD78, DD80, DD82 — store what the wire means
+
+**Files:**
+- Modify: `source/Xcp_Internal.h` (field at `:359`, accessor declarations at `:652-654`)
+- Modify: `source/Xcp.c` (`Xcp_Init` seeding, the dispatch gate, the accessors, the `§1.7.3.2.2` citation)
+- Modify: `source/Xcp_Std.c` (`CONNECT` re-seed, `UNLOCK`'s two response sites, `GET_STATUS` byte 2)
+- Modify: `test/seed_key_defects_test.py` (five migrated assertions)
+- Test: `test/seed_key_lifetime_test.py` (append polarity and accumulate tests)
+
+**Interfaces:**
+- Consumes: Tasks 1–3. Task 3 is a hard prerequisite: the migrated tests configure `resource_protection_programming=True`, which only becomes buildable there.
+- Produces: `Xcp_Internal.locked_resource` (the still-protected mask), `Xcp_GetLockedResources(void)`, `Xcp_UnlockResources(uint8 mask)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `test/seed_key_lifetime_test.py`:
+
+```python
+def test_get_status_reports_which_resources_are_still_protected():
+    """DD82. XCP part 2 1.0/1.6.1.1.3 defines the Current Resource Protection Status as a mask
+    where 1 = the group IS protected, and 1.6.1.2.5 makes UNLOCK's positive response carry that
+    same mask. The module reported the UNLOCKED set instead -- so after unlocking CAL_PAG it said
+    CAL_PAG was protected, at the moment it stopped being."""
+    handle = cal_protected_handle()
+
+    assert exchange(handle, GET_STATUS, length=3)[2] == 0x01, \
+        'CAL_PAG is configured protected and nothing has been unlocked'
+
+    unlock_cal_pag(handle)
+
+    assert exchange(handle, GET_STATUS, length=3)[2] == 0x00, \
+        'CAL_PAG was reported protected after being unlocked'
+
+
+def test_get_status_reports_nothing_protected_when_nothing_is_configured_protected():
+    """The domain half of the defect, not just the direction. In a build where no resource is
+    protected -- test/parameter.py's DefaultConfig, which is what almost the whole suite runs --
+    unlocking PGM used to make this byte report 0x10, claiming a protection the build does not
+    have."""
+    handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001))
+    connect(handle)
+
+    assert exchange(handle, GET_STATUS, length=3)[2] == 0x00
+
+
+def test_unlock_answers_the_remaining_protection_mask():
+    """1.6.1.2.5: "The answer upon UNLOCK contains the Current Resource Protection Mask as
+    described at GET_STATUS." Byte 1 of UNLOCK's positive response, same polarity as above."""
+    handle = cal_protected_handle()
+    handle.xcp_get_seed.side_effect = get_seed_side_effect_copy_ok(handle, SEED)
+    handle.xcp_calc_key.side_effect = calc_key_side_effect_copy_ok(handle, KEY)
+
+    assert exchange(handle, (0xF8, 0x00, 0x01))[0] == 0xFF
+    assert exchange(handle, (0xF7, len(KEY)) + tuple(KEY))[0:2] == (0xFF, 0x00), \
+        'UNLOCK reported the granted resource instead of what remains protected'
+```
+
+- [ ] **Step 2: Run and confirm they fail**
+
+Expected: all three FAIL, reporting the inverted values (`0x00` where `0x01` is expected, `0x01` where `0x00` is expected).
+
+- [ ] **Step 3: Rename the field**
+
+In `source/Xcp_Internal.h`, change `uint8 protection_status;` to:
+
+```c
+    /* The Current Resource Protection Mask of XCP part 2 1.0/1.6.1.1.3: a set bit means the group
+     * IS still protected. This is the value transmitted verbatim by GET_STATUS byte 2 and UNLOCK
+     * response byte 1, so no reader inverts it and no reader can get the polarity wrong.
+     *
+     * DD78: this field used to hold the opposite -- the UNLOCKED set -- and was reported as if it
+     * were this mask, at three sites. It was renamed rather than redefined in place so that every
+     * existing reader became a compile error instead of silently correct-looking arithmetic. */
+    uint8 locked_resource;
+```
+
+- [ ] **Step 4: Follow the compile errors**
+
+Build and fix each site the rename breaks. The complete set, with the replacement for each:
+
+| Site | Becomes |
+|---|---|
+| `source/Xcp.c` accessors | `uint8 Xcp_GetLockedResources(void) { return Xcp_Internal.locked_resource; }` and `void Xcp_UnlockResources(uint8 mask) { Xcp_Internal.locked_resource &= (uint8)(~mask); }`; delete `Xcp_ClearProtectionStatus` entirely |
+| `source/Xcp_Internal.h:652-654` | declare the two above; delete the third |
+| `source/Xcp.c` `Xcp_Init` | `Xcp_Internal.locked_resource = Xcp_Ptr->general->protectedResource;` |
+| `source/Xcp_Std.c` `CONNECT` | `Xcp_Internal.locked_resource = Xcp_Ptr->general->protectedResource;` (replacing Task 1 Step 5's line) |
+| `source/Xcp_Std.c` UNLOCK success | `Xcp_UnlockResources(Xcp_Internal.requested_protected_resource);` then `... SduDataPtr[0x01u] = Xcp_GetLockedResources();` |
+| `source/Xcp_Std.c` UNLOCK partial | `... SduDataPtr[0x01u] = Xcp_GetLockedResources();` |
+| `source/Xcp_Std.c` GET_STATUS | `... SduDataPtr[0x02u] = Xcp_GetLockedResources();` |
+
+- [ ] **Step 5: Collapse the dispatch gate**
+
+In `source/Xcp.c`, replace the two-term condition with:
+
+```c
+                                                /* DD80. One term, because a resource that was never
+                                                 * configured protected is never in the mask, which
+                                                 * subsumes the old `(group & protectedResource) == 0`
+                                                 * disjunct.
+                                                 *
+                                                 * The equivalence was checked, not assumed: every
+                                                 * Xcp_PIDToCmdGroupTable entry carries exactly one
+                                                 * group bit or MASK_NONE, so this agrees with the old
+                                                 * form for every PID. They would diverge only on a
+                                                 * multi-bit entry -- the old form meant "any one of
+                                                 * its groups is unlocked", this means "all of them
+                                                 * are". Keep entries single-bit; if that ever has to
+                                                 * change, this is the safe reading and the old one
+                                                 * was not. */
+                                                if ((Xcp_PIDToCmdGroupTable[pid] & Xcp_Internal.locked_resource) == 0x00u)
+```
+
+- [ ] **Step 6: Correct the citation on the refusal branch**
+
+In the same `else` branch, replace the reference to `1.0/1.7.3.2.2` with `1.0/1.6.1.1.3`, and the sentence with:
+
+```c
+                                                    /* XCP part 2 - Protocol Layer Specification 1.0/1.6.1.1.3
+                                                     * states this rule once per resource group -- "all commands
+                                                     * of the CALibration/PAGing group are protected and will
+                                                     * return an ERR_ACCESS_LOCKED upon an attempt to execute the
+                                                     * command without a previous successful GET_SEED/UNLOCK
+                                                     * sequence", and likewise for DAQ/STIM and PGM. It was cited
+                                                     * here as 1.7.3.2.2, which is the CAL error TABLE: a narrow
+                                                     * citation for a rule that governs every group. 1.6.1.1.3 is
+                                                     * also where the mask this branch tests is defined, which is
+                                                     * the coherence DD78 relies on.
+                                                     *
+                                                     * Without this branch the response buffer keeps whatever the
+                                                     * previous command left in it and is transmitted anyway, so
+                                                     * the master reads a stale positive response to a command the
+                                                     * slave refused to run. */
+```
+
+- [ ] **Step 7: Add the accumulate test**
+
+Append to `test/seed_key_lifetime_test.py` a test that unlocks CAL_PAG and then DAQ in one session
+(configure `resource_protection_calibration_paging=True, resource_protection_data_acquisition=True`;
+GET_SEED resource `0x01` then `0x04`, each followed by its own UNLOCK, since DD81 requires a fresh
+seed per unlock) and asserts that a `MASK_CAL_PAG` command **and** GET_STATUS byte 2 both show
+CAL_PAG still granted after the DAQ unlock — i.e. byte 2 reads `0x00`, not `0x01`.
+
+- [ ] **Step 8: Migrate the five status-byte assertions**
+
+In `test/seed_key_defects_test.py`, these five tests assert the protection byte and all encode the
+old polarity in a build where nothing is configured protected:
+
+- `test_a_failed_get_seed_leaves_the_resource_locked`
+- `test_a_failed_get_seed_does_not_let_a_stale_admission_grant_the_resource_it_requested`
+- `test_a_legitimate_multi_frame_get_seed_and_unlock_sequence_still_unlocks_the_resource`
+- `test_an_unlock_whose_calc_key_fails_answers_an_error_instead_of_a_stale_positive_response`
+- `test_a_failed_unlock_does_not_leave_a_stale_answer_for_whatever_reads_it_next`
+
+Each must gain `resource_protection_programming=True` on its handle (buildable since Task 3) so the
+resource it exercises is genuinely protected, and each assertion inverts: "granted" becomes byte 2
+== `0x00`, "still locked" becomes byte 2 == `0x10`. **Update each docstring to match** — several
+state the expected value in prose, and a docstring that contradicts its assertion is worse than none.
+
+- [ ] **Step 9: Run the full suite**
+
+Expected: green. Any remaining failure is a reader of the old polarity that Steps 4 and 8 missed;
+report it rather than adjusting the test to match whatever the code now does.
+
+- [ ] **Step 10: Mutation-verify a reporting site**
+
+Change `GET_STATUS`'s byte 2 back to reporting the granted set (`(uint8)(~Xcp_GetLockedResources())`
+is not equivalent — use `Xcp_Ptr->general->protectedResource & (uint8)(~Xcp_GetLockedResources())`)
+and confirm `test_get_status_reports_which_resources_are_still_protected` fails. Restore.
+
+Also mutate the gate: change `== 0x00u` to `!= 0x00u` and confirm
+`test_a_protected_command_is_refused_before_any_unlock` fails. Restore.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add source/Xcp.c source/Xcp_Std.c source/Xcp_Internal.h test/seed_key_lifetime_test.py test/seed_key_defects_test.py
+git commit -m "fix: pre-existing inverted resource protection mask in shipped GET_STATUS and UNLOCK"
+```
+
+---
+
+## Final verification
+
+- [ ] Full `./test.sh` in the container on a clean build tree, both ctest targets green.
+- [ ] All four required mutation verifications recorded, each naming the test that failed — plus the two honest negatives Task 1 Step 7 and Task 2 Step 5 may produce.
+- [ ] `git log --grep="^fix: pre-existing"` lists the three defect commits from this branch.
+- [ ] The `resource_protection.data_stimulation` refusal still fires with its test unmodified.
+- [ ] Update `docs/superpowers/specs/2026-08-29-xcp-part2-roadmap.md`, which is stale: it still names SP2d as next, though SP2d (#12), SP3, SP4a (#16) have landed and SP4b is in review. Fold this into the final commit, matching the pattern of PRs #5 and #8.

--- a/docs/superpowers/specs/2026-08-29-xcp-part2-roadmap.md
+++ b/docs/superpowers/specs/2026-08-29-xcp-part2-roadmap.md
@@ -319,7 +319,9 @@ SP1 removes `Xcp_DTODaqPacket` from the table entirely.
 Ordered. Each sub-project is independently shippable and leaves the suite green.
 
 **Progress:** SP1 is complete (#1). SP2a is complete (#2), with follow-ups in #3 and #4. SP2b is
-complete (#6), with a hygiene pass in #7. **SP2c is next.**
+complete (#6), with a hygiene pass in #7. SP2d is complete (#12). SP3 is complete. SP4a is complete
+(#16), and SP4b is in review. **SP2c remains deferred — see its own entry below for why, which is
+unchanged — so SP4c is next.**
 
 ### SP1 — Calibration and page switching (CAL + PAG) — **complete**
 
@@ -383,8 +385,8 @@ not:
   also differ in risk: prioritisation reorders what the ring already holds, while multiple
   outstanding frames changes the ring's own invariants. Consider splitting them.
 
-- **SP2d** — **next.** Dynamic DAQ list configuration (§1.6.4.2 in 1.0, renumbered in 1.1), the
-  `DAQ_CONFIG_TYPE` = dynamic branch, and the four remaining commands: `FREE_DAQ` (0xD6),
+- **SP2d** — **complete** (#12). Dynamic DAQ list configuration (§1.6.4.2 in 1.0, renumbered in
+  1.1), the `DAQ_CONFIG_TYPE` = dynamic branch, and the four remaining commands: `FREE_DAQ` (0xD6),
   `ALLOC_DAQ` (0xD5), `ALLOC_ODT` (0xD4) and `ALLOC_ODT_ENTRY` (0xD3). Chosen ahead of SP2c
   because it is additive to the dispatch surface, and because a master that cannot allocate its
   own lists is confined to whatever the generated static configuration happens to contain.
@@ -454,7 +456,7 @@ one design can carry, so SP4 is **three sub-projects**:
   continues past `PROGRAM_START` through a genuine `PROGRAM_CLEAR` and a multi-frame
   `PROGRAM`/`PROGRAM_NEXT` block before `PROGRAM_RESET`, composing SP4b's own contribution into
   the same end-to-end sequence SP4a's Task 6 began.
-- **SP4c — sectors, formats and verification.** `GET_SECTOR_INFO` (0xCD) and the flash sector
+- **SP4c — sectors, formats and verification. Next.** `GET_SECTOR_INFO` (0xCD) and the flash sector
   configuration model, `PROGRAM_FORMAT` (0xCB) with functional access mode and the block sequence
   counter, `PROGRAM_VERIFY` (0xC8).
 

--- a/docs/superpowers/specs/2026-09-08-xcp-seed-key-hardening-design.md
+++ b/docs/superpowers/specs/2026-09-08-xcp-seed-key-hardening-design.md
@@ -1,0 +1,255 @@
+# Seed-and-key hardening — design
+
+**Date:** 2026-09-08
+**Status:** design, approved in outline; not yet planned or implemented
+**Predecessors:** `2026-09-07-xcp-shared-state-defects-design.md` (DD70–DD77), whose §3b left one
+defect deliberately unfixed and whose DD73 is what makes the fix below possible.
+
+Three defects in one subsystem, all pre-existing, all shipped, and all answering the same
+question badly: **what does `Xcp_Internal.protection_status` mean, and how long does it last?**
+Because they share one field they share one design, and fixing any one alone would leave the
+field's meaning half-changed.
+
+---
+
+## 0. Specification numbering
+
+Every citation below was read in the 1.0 PDF via `pdftotext -layout` before being written down.
+This section exists because four citation errors have been found on the immediately preceding
+branch, one of which reached three shipped source comments.
+
+| Cited as | Actual title |
+|---|---|
+| §1.6.1.1.3 | Get current session status from slave (GET_STATUS) |
+| §1.6.1.2.4 | Get seed for unlocking a protected resource (GET_SEED) |
+| §1.6.1.2.5 | Send key for unlocking a protected resource (UNLOCK) |
+| §1.7.3.2.1 | Standard commands (STD) — the error/pre-action table |
+| §1.7.3.2.2 | Calibration commands (CAL) — the error/pre-action table |
+
+**A correction this design makes to existing code.** `source/Xcp.c` cites §1.7.3.2.2 for the
+generic rule that a command addressing a locked resource answers `ERR_ACCESS_LOCKED`. §1.7.3.2.2 is
+the *CAL* error table; the generic rule is in **§1.6.1.1.3**, which states it once per resource
+group — "*all commands of the CALibration/PAGing group are protected and will return an
+ERR_ACCESS_LOCKED upon an attempt to execute the command without a previous successful
+GET_SEED/UNLOCK sequence*", and likewise for DAQ/STIM and PGM. Narrow citation, general claim.
+
+That §1.6.1.1.3 defines **both** the protection mask's meaning and the refusal it causes is the
+observation the whole design turns on.
+
+---
+
+## 1. What is wrong today
+
+### D-A — an unlock is spent by the next command
+
+`source/Xcp.c`, immediately after every successful dispatch:
+
+```c
+if (pid != XCP_PID_CMD_UNLOCK) {
+    Xcp_ClearProtectionStatus();
+}
+```
+
+So a granted resource survives exactly one following command — and not only a command that *used*
+the grant: an unrelated `GET_STATUS` spends it identically. §1.6.1.2.5 says the opposite, that "*a
+repetition of an UNLOCK sequence with a correct key will have a positive response and no other
+effect*", which presumes the grant is still standing to be re-granted.
+
+**Its worst consequence is already recorded as a generation refusal.** With PGM protected,
+`PROGRAM_START` spends the unlock; the session becomes `XCP_PGM_ACTIVE`; `PROGRAM_RESET` — the only
+command that ends it — is locked again; and `GET_SEED`/`UNLOCK` are themselves refused
+`ERR_PGM_ACTIVE`. The slave cannot leave the programming session. `script/source_cfg.c.jinja2`
+therefore *refuses to generate* `resource_protection.programming: true` at all. A configuration the
+schema accepts and `CONNECT` advertises cannot be built.
+
+### D-B — `UNLOCK` never asks whether a seed is held
+
+Its only gate is `last_pid ∈ {GET_SEED, UNLOCK}`, which is about *sequence*. §1.6.1.2.5 is explicit:
+"*The master only can send an UNLOCK sequence if previously there was a GET_SEED sequence… If the
+master does not respect this sequence, the slave returns an ERR_SEQUENCE.*" Three routes were
+measured on the fixed tree of the previous branch, all reaching `Xcp_CalcKey` with a zero-length
+seed and all granting the resource.
+
+The enforcement mechanism already exists and nothing consults it: `source/Xcp_Std.c` zeroes
+`seed.total_length` once a full key arrives, under the comment "*enforces a new seed to be requested
+prior to unlock a next resource*". DD73 — which stopped `GET_SEED` zeroing the same field — is what
+makes it trustworthy enough to read.
+
+### D-C — the protection mask is reported inverted, at three sites
+
+§1.6.1.1.3 defines the Current Resource Protection Status as a mask where **1 = the group is
+protected**, and §1.6.1.2.5 makes `UNLOCK`'s positive response carry that same mask. The module
+writes `Xcp_GetProtectionStatus()` — the *unlocked* set — into `UNLOCK`'s complete-key response
+byte 1, its partial-key response byte 1, and `GET_STATUS` byte 2.
+
+Wrong in direction and in domain. In the default build, where nothing is configured protected,
+unlocking PGM makes `GET_STATUS` report `0x10`: **PGM is protected**, claimed in a build where it is
+not, at the moment it was granted. The configured mask `Xcp_Ptr->general->protectedResource` is read
+in exactly one place — the dispatch gate — and by no reporting site at all, which is *why* the
+polarity is wrong rather than merely reversed.
+
+---
+
+## 2. Design decisions
+
+### DD78 — the field stores the still-locked mask, and is renamed to force that
+
+`Xcp_Internal.protection_status` (the unlocked set) becomes `Xcp_Internal.locked_resource`, holding
+the Current Resource Protection Mask exactly as §1.6.1.1.3 defines it. The accessors follow:
+`Xcp_GetProtectionStatus`/`Xcp_SetProtectionStatus` become
+`Xcp_GetLockedResources`/`Xcp_UnlockResources(mask)`, and `Xcp_ClearProtectionStatus` is deleted
+along with its single call site.
+
+**The rename is a safety mechanism, not tidying.** The field's meaning inverts, so every existing
+reader must be revisited; renaming turns all of them into compile errors rather than silently
+correct-looking arithmetic. An alternative was considered and rejected — keep the field meaning
+"unlocked" and compute `protectedResource & ~protection_status` at each reporting site — because it
+preserves exactly the property that caused D-C: a field whose readers must remember to invert it.
+Three chances to get polarity wrong become zero when the stored value *is* the wire value.
+
+### DD79 — an unlock lasts the session
+
+Four writes, and no others:
+
+| Where | What |
+|---|---|
+| `Xcp_Init` | `locked_resource = Xcp_Ptr->general->protectedResource` |
+| `CONNECT` | the same re-seed, joining DD77's teardown block |
+| `UNLOCK`, on success | `locked_resource &= ~requested_protected_resource` |
+| nowhere else | — |
+
+`Xcp_Ptr` is assigned before the initialisation block that will hold the first write, and that block
+already dereferences it, so seeding from configuration there is safe and matches the existing
+pattern.
+
+D-A is then fixed by construction rather than by a rule: with no clear-after-dispatch there is
+nothing to spend, and the session boundary is the only thing that re-locks. `&=` also makes grants
+accumulate, so unlocking DAQ after PGM keeps both — which the current assignment would not have
+done once grants began to persist.
+
+`requested_protected_resource` keeps its present job: `GET_SEED` records which resource the seed was
+issued for, `UNLOCK` grants exactly that.
+
+### DD80 — the dispatch gate collapses to one term
+
+```c
+/* allowed iff no group this command belongs to is still locked */
+if ((Xcp_PIDToCmdGroupTable[pid] & Xcp_Internal.locked_resource) == 0x00u)
+```
+
+replacing `((group & protectedResource) == 0) || ((group & unlocked) != 0)`. A resource never
+configured protected is never in the mask, so the first term is subsumed.
+
+**The equivalence was checked, not assumed.** Every one of `Xcp_PIDToCmdGroupTable`'s entries
+carries exactly one group bit or `NONE` — the only values appearing are `MASK_CAL_PAG`, `MASK_DAQ`,
+`MASK_PGM` and `MASK_NONE` — so old and new agree for every PID. They diverge only on a
+hypothetical multi-bit entry, where the old form means "any one of its groups is unlocked" and the
+new means "all of them are". The new reading is the safe one, and the single-bit property is
+recorded as an invariant the table must keep.
+
+### DD81 — `UNLOCK` requires a held seed
+
+One added conjunct on the existing admission gate:
+
+```c
+if (((Xcp_Internal.last_pid == XCP_PID_CMD_GET_SEED) || (Xcp_Internal.last_pid == XCP_PID_CMD_UNLOCK)) &&
+    (Xcp_Internal.seed.total_length != 0x00u))
+```
+
+The terms answer different questions and both are load-bearing. `last_pid` asks whether the
+immediately preceding command was a successful `GET_SEED` or a prior frame of this same key — it
+cannot distinguish which, being a two-element set-membership test, which is why a prediction that it
+could was wrong on the previous branch. `seed.total_length` asks whether a seed exists and is
+unspent. It stays non-zero across a multi-frame key and is zeroed only on completion, so it admits
+every legitimate frame and refuses every D-B route.
+
+`ERR_SEQUENCE` is the answer and needs **no deviation**: it is in `UNLOCK`'s own §1.7.3.2.1 row, and
+that row's prescribed pre-action for it is `GET_SEED` — the refusal tells the master exactly what to
+do next.
+
+**A sentence that must not be misread.** §1.6.1.2.5's "*a repetition of an UNLOCK sequence with a
+correct key will have a positive response and no other effect*" does not require a bare repeated
+`UNLOCK` to succeed. The preceding sentence defines an UNLOCK sequence as one preceded by a
+GET_SEED sequence, so a repetition is `GET_SEED`→`UNLOCK` again; "no other effect" means it must not
+re-lock or otherwise disturb an already-granted resource, which `&= ~granted` gives for free.
+
+### DD82 — the three reporting sites emit the mask directly
+
+`UNLOCK`'s complete-key response byte 1, `UNLOCK`'s partial-key response byte 1, and `GET_STATUS`
+byte 2 all become `Xcp_GetLockedResources()` with no arithmetic. Under DD78 the stored value is
+already the wire value.
+
+### DD83 — the programming generation refusal is removed; STIM's is not
+
+Every link in the refused dead end depended on the unlock being spent. Under DD79 `PROGRAM_RESET`
+stays unlocked, the chain never forms, and `GET_SEED`/`UNLOCK` remaining refused during
+`XCP_PGM_ACTIVE` becomes harmless because no re-unlock is needed. The `raise` in
+`script/source_cfg.c.jinja2` is deleted, and its obsolescence is *proved by an end-to-end test*
+rather than argued (§5).
+
+The second refusal in the same generator — `resource_protection.data_stimulation`, DD41/DD48 — is
+**untouched and stays**. It exists because `Xcp_PIDToCmdGroupTable` maps every DAQ command to
+`MASK_DAQ`, so no command is gated on `MASK_STIM` and a STIM protection would be advertised but not
+enforced. That is command-group mapping work, unrelated to lifetime or polarity.
+
+---
+
+## 3. What this does not change
+
+- The wrong-key path still answers `ERR_ACCESS_LOCKED` and disconnects, per §1.6.1.2.5. With
+  DD74/DD77's teardown re-seeding the mask, a bad key now genuinely re-locks everything.
+- DD76's `ERR_GENERIC` branch for a failing `Xcp_CalcKey` is unchanged.
+- `GET_SEED`'s own behaviour, including DD72's rollback and DD73's length handling.
+- The `Xcp_CTOErrorMatrix`, except where a newly reachable error code requires a row bit.
+- `CONNECT`'s RESOURCE byte, which reports available resources and is a different byte from the
+  protection mask.
+
+---
+
+## 4. Test strategy
+
+**The existing security tests get stronger, not merely updated, and this is a correction rather than
+churn.** `test/seed_key_defects_test.py` proves the DD72 bypass by watching `protection_status` go
+non-zero — a status byte, in a build where `DefaultConfig` leaves every `resource_protection_*`
+false, so the feature under test is switched off. Under DD78 that observable correctly disappears,
+which forces the better one: configure `resource_protection.calibration_paging: true`, and a bypass
+becomes visible as *a CAL command running when it should have answered `ERR_ACCESS_LOCKED`*.
+Behaviour, not bookkeeping. This is the same failure that hid two of the six defects on the previous
+branch — a test double that cannot observe the value under test.
+
+New tests, each pinning one claim:
+
+| Claim | Shape |
+|---|---|
+| An unlock persists | unlock CAL_PAG, run several unrelated commands, a CAL command is still accepted |
+| …but not across sessions | unlock, `CONNECT`, the CAL command answers `ERR_ACCESS_LOCKED` |
+| Unlocks accumulate | unlock CAL_PAG then DAQ; commands of both groups remain accepted |
+| No seed, no unlock | `UNLOCK` with no preceding `GET_SEED` → `ERR_SEQUENCE` |
+| A spent seed is spent | a completed `UNLOCK`, then `UNLOCK` again → `ERR_SEQUENCE` |
+| The mask is the wire format | with protection configured, `GET_STATUS` byte 2 and `UNLOCK` byte 1 report the *still-locked* set |
+| The refusal is obsolete | the end-to-end sequence of §5 |
+
+**Mutation verification is required on four points**, the change being security-relevant throughout:
+the gate expression of DD80; **each of DD81's two conjuncts separately** — a compound condition needs
+a test per term, not per outcome; and at least one DD82 reporting site.
+
+**One honest limit.** `Xcp_PIDToCmdGroupTable` is `static` in `source/Xcp.c` and is therefore no more
+reachable from the CFFI harness than `Xcp_Internal` is, so DD80's single-bit invariant cannot be
+asserted directly. It gets a stated invariant in the comment and indirect behavioural coverage —
+unlocking one resource must not make another group's commands reachable. That is weaker than a
+direct check, and the plan should say so rather than imply the invariant is tested.
+
+---
+
+## 5. Acceptance
+
+1. Each of D-A, D-B and D-C has a test that fails on the current code and passes after the fix.
+2. **The end-to-end proof that DD83's refusal is obsolete:** with `resource_protection.programming:
+   true` and `programming.enabled: true`, the sequence `CONNECT` → `GET_SEED(PGM)` → `UNLOCK` →
+   `PROGRAM_START` → `PROGRAM_CLEAR` → `PROGRAM` → `PROGRAM_RESET` completes, every step answering
+   positively. This configuration cannot be built at all today.
+3. The four mutation verifications of §4 are carried out and recorded, each naming which test failed.
+4. `./test.sh` green in the CI container, both ctest targets, on a clean build tree.
+5. No new instance of the recurring test-authoring traps, and no test whose name claims a property
+   its assertions cannot fail on.
+6. The `resource_protection.data_stimulation` refusal still fires, with its own test unchanged.

--- a/script/source_cfg.c.jinja2
+++ b/script/source_cfg.c.jinja2
@@ -1068,41 +1068,6 @@ static Xcp_GeneralType Xcp_GeneralConfig{{'%02X' % loop.index0}} = {
 {%- if stim.capable and configuration.apis.resource_protection.data_stimulation %}
 {{ raise('resource_protection.data_stimulation is set and this configuration can stimulate, but no command is gated on the STIM resource: Xcp_PIDToCmdGroupTable (source/Xcp.c) maps every DAQ command to MASK_DAQ, so CONNECT and GET_STATUS would advertise a protection the slave does not enforce and SET_DAQ_LIST_MODE(DIRECTION = STIM), WRITE_DAQ and START_STOP_DAQ_LIST would stay reachable with nothing unlocked (XCP part 2 1.1/1.5; DD41 and DD48 in docs/superpowers/specs/2026-09-04-xcp-stim-sp3-design.md)') }}
 {%- endif %}
-{#- Final-review finding 2, and the exact analogue of DD48 immediately above: bit 4 below is the
-    PGM resource of XCP part 2 1.1/1.5, and this time the module DOES enforce it -- which is what
-    makes the combination unusable rather than merely decorative.
-
-    An unlock is spent by ONE command. Xcp_SetProtectionStatus (source/Xcp.c) copies the requested
-    resource into protection_status on a successful UNLOCK, and the dispatch loop in
-    Xcp_CanIfRxIndication clears it again after EVERY dispatched command whose PID is not UNLOCK --
-    including commands that are not protected at all, so an interposed GET_STATUS spends it too.
-    That is pre-existing, documented in README.md under *Key lifetime*, and identical for CAL_PAG
-    and DAQ. For those two it is merely unpleasant: §1.7.3.2.x's action for ERR_ACCESS_LOCKED is
-    "unlock slave, repeat 2 times", so a conformant master re-unlocks and carries on.
-
-    For PGM it is fatal, and the composition is what is fatal, not any one refusal. Once
-    PROGRAM_START has been dispatched -- spending the unlock that admitted it -- the session is
-    XCP_PGM_ACTIVE, and the only door out of it is PROGRAM_RESET, which is a PGM-group command and
-    therefore locked again. Re-unlocking is impossible, and conformantly so: GET_SEED and UNLOCK
-    both carry XCP_INTERNAL_ERR_PGM_ACTIVE in Xcp_CTOErrorMatrix (source/Xcp.c) and are refused
-    ERR_PGM_ACTIVE by DD51's gate, exactly as §1.7.3.2.1/§1.7.3.2.5 provide. DISCONNECT is refused
-    the same way. Every answer is correct; the master retries into silence and the slave cannot
-    leave the state short of Xcp_Init. Measured on a build of this branch, not reasoned:
-    PROGRAM_RESET after the sequence answers ERR_ACCESS_LOCKED (0xFE 0x25), GET_SEED and UNLOCK
-    answer ERR_PGM_ACTIVE (0xFE 0x12).
-
-    So the configuration is refused here rather than shipped. Removing this guard needs the unlock
-    LIFETIME fixed (a cross-group change to the protection model, out of this sub-project's scope)
-    or the GET_SEED/UNLOCK-vs-ERR_PGM_ACTIVE interaction resolved -- not merely SP4b landing the
-    remaining PGM commands, which inherits the group unchanged and makes the trap larger.
-
-    Conditioned on `programming.enabled` as well as on the flag, for DD48's own reason: a build
-    with the feature compiled out has no PGM command to lock, so the flag advertises a resource
-    nothing in the build can reach and is inert. The refused combination is the one that can be
-    driven into the dead end. #}
-{%- if configuration.programming.enabled | default(false) and configuration.apis.resource_protection.programming %}
-{{ raise('resource_protection.programming is set and programming.enabled is true, but a protected PGM resource cannot conduct a programming sequence: an UNLOCK is spent by the single command that follows it (source/Xcp.c, README.md "Key lifetime"), so PROGRAM_START consumes it, and once the session is XCP_PGM_ACTIVE the only command that ends it -- PROGRAM_RESET -- is locked again while GET_SEED and UNLOCK are themselves refused ERR_PGM_ACTIVE (XCP part 2 1.1/1.7.3.2.1 and 1.7.3.2.5), leaving the slave unable to leave the programming session at all; leave resource_protection.programming false until the unlock lifetime is fixed (final-review finding 2 in .superpowers/sdd/2026-09-06-xcp-pgm-sp4a/final-review.md)') }}
-{%- endif %}
     ({% if configuration.apis.resource_protection.calibration_paging %}0x01u{% else %}0x00u{% endif %} << 0x00u) |
     ({% if configuration.apis.resource_protection.data_acquisition %}0x01u{% else %}0x00u{% endif %} << 0x02u) |
     ({% if configuration.apis.resource_protection.data_stimulation %}0x01u{% else %}0x00u{% endif %} << 0x03u) |

--- a/source/Xcp.c
+++ b/source/Xcp.c
@@ -1272,7 +1272,20 @@ void Xcp_Init(const Xcp_Type *pConfig)
             Xcp_Internal.pgm_block.requested_elements = 0x00u;
             Xcp_Internal.pgm_block.frame_elements = 0x00u;
 #endif /* #if (XCP_FLASH_PROGRAMMING_ENABLED == STD_ON) */
-            Xcp_Internal.protection_status = 0x00u;
+            /* DD78. Every configured-protected group starts protected, which is what
+             * `= protectedResource` says and what `= 0x00u` could not: on the old, inverted field
+             * 0 happened to mean "nothing granted", and that coincidence is exactly what let a
+             * granted bit be reported as a protected one. Xcp_CTOCmdStdConnect (Xcp_Std.c) re-seeds
+             * this same way at the session boundary; the two must agree, since a freshly
+             * initialised module and a freshly connected one owe the master the same answer.
+             *
+             * Xcp_Ptr is assigned at the top of this function, so the configuration is readable
+             * here. This used to be written TWICE -- this assignment, and a Xcp_ClearProtectionStatus()
+             * call further down past the buffer loops; redundant while both wrote zero, and a real
+             * hazard once they would not. The second is gone: this line, among the other
+             * Xcp_Internal field resets and beside requested_protected_resource, is the one place
+             * that seeds it. */
+            Xcp_Internal.locked_resource = Xcp_Ptr->general->protectedResource;
             Xcp_Internal.requested_protected_resource = 0x00u;
             Xcp_Internal.last_pid = 0x00u;
             Xcp_Internal.ongoing_transmit_type = ONGOING_TRANSMIT_TYPE_NONE;
@@ -1354,8 +1367,6 @@ void Xcp_Init(const Xcp_Type *pConfig)
             for (idx = 0x00000000u; idx < (sizeof(Xcp_Internal.internal_buffer) / sizeof(Xcp_Internal.internal_buffer[0x00u])); idx ++) {
                 Xcp_Internal.internal_buffer[idx] = 0x00u;
             }
-
-            Xcp_ClearProtectionStatus();
 
             Xcp_State = XCP_INITIALIZED;
         }
@@ -1702,15 +1713,17 @@ void Xcp_CanIfRxIndication(PduIdType rxPduId, const PduInfoType *pPduInfo)
                                  * runs. Named here, not only at DD72's own guard, because a reader
                                  * who greps XCP_PID_CMD_UNLOCK lands on this block.
                                  *
-                                 * A third bullet stood here before DD79: `Xcp_ClearProtectionStatus()`
-                                 * ran too, because the guard on it was `pid != XCP_PID_CMD_UNLOCK` and
-                                 * no DTO-range PID is UNLOCK. That silently revoked an unlock the
-                                 * master had already completed, mid-session, and was the worst of the
-                                 * three: the master's next protected command was answered
+                                 * A third bullet stood here before DD79: a clear of the whole granted
+                                 * set (`Xcp_ClearProtectionStatus()`, a function DD78 has since
+                                 * deleted along with the inverted field it wrote) ran too, because
+                                 * the guard on it was `pid != XCP_PID_CMD_UNLOCK` and no DTO-range
+                                 * PID is UNLOCK. That silently revoked an unlock the master had
+                                 * already completed, mid-session, and was the worst of the three:
+                                 * the master's next protected command was answered
                                  * ERR_ACCESS_LOCKED with nothing to say why. DD79 deleted that call
                                  * and its guard from the dispatch outright, not just from this
                                  * hypothetical, so a frame reaching here no longer touches
-                                 * protection_status at all.
+                                 * locked_resource at all.
                                  *
                                  * Those 192 entries HAVE since been re-pointed at
                                  * Xcp_CmdNotImplemented, and unlike DD79's deletion above, that
@@ -1856,8 +1869,21 @@ void Xcp_CanIfRxIndication(PduIdType rxPduId, const PduInfoType *pPduInfo)
 #endif /* #if (XCP_FLASH_PROGRAMMING_ENABLED == STD_ON) */
                                                 ))
                                             {
-                                                if (((Xcp_PIDToCmdGroupTable[pid] & Xcp_Ptr->general->protectedResource) == 0x00u) ||
-                                                    ((Xcp_PIDToCmdGroupTable[pid] & Xcp_GetProtectionStatus()) != 0x00u))
+                                                /* DD80. One term, because a resource that was never
+                                                 * configured protected is never in the mask, which
+                                                 * subsumes the old `(group & protectedResource) == 0`
+                                                 * disjunct.
+                                                 *
+                                                 * The equivalence was checked, not assumed: every
+                                                 * Xcp_PIDToCmdGroupTable entry carries exactly one
+                                                 * group bit or MASK_NONE, so this agrees with the old
+                                                 * form for every PID. They would diverge only on a
+                                                 * multi-bit entry -- the old form meant "any one of
+                                                 * its groups is unlocked", this means "all of them
+                                                 * are". Keep entries single-bit; if that ever has to
+                                                 * change, this is the safe reading and the old one
+                                                 * was not. */
+                                                if ((Xcp_PIDToCmdGroupTable[pid] & Xcp_GetLockedResources()) == 0x00u)
                                                 {
                                                     result = Xcp_PIDTable[pid](&response_expected, pPduInfo);
 
@@ -1886,12 +1912,21 @@ void Xcp_CanIfRxIndication(PduIdType rxPduId, const PduInfoType *pPduInfo)
                                                 }
                                                 else
                                                 {
-                                                    /* XCP part 2 - Protocol Layer Specification 1.0/1.7.3.2.2
-                                                     * A command addressing a protected resource that has not been
-                                                     * unlocked answers ERR_ACCESS_LOCKED. Without this branch the
-                                                     * response buffer keeps whatever the previous command left in
-                                                     * it and is transmitted anyway, so the master reads a stale
-                                                     * positive response to a command the slave refused to run. */
+                                                    /* XCP part 2 - Protocol Layer Specification 1.0/1.6.1.1.3
+                                                     * states this rule once per resource group -- "all commands
+                                                     * of the CALibration/PAGing group are protected and will
+                                                     * return an ERR_ACCESS_LOCKED upon an attempt to execute the
+                                                     * command without a previous successful GET_SEED/UNLOCK
+                                                     * sequence", and likewise for DAQ/STIM and PGM. It was cited
+                                                     * here as 1.7.3.2.2, which is the CAL error TABLE: a narrow
+                                                     * citation for a rule that governs every group. 1.6.1.1.3 is
+                                                     * also where the mask this branch tests is defined, which is
+                                                     * the coherence DD78 relies on.
+                                                     *
+                                                     * Without this branch the response buffer keeps whatever the
+                                                     * previous command left in it and is transmitted anyway, so
+                                                     * the master reads a stale positive response to a command the
+                                                     * slave refused to run. */
                                                     Xcp_FillErrorPacket(XCP_E_ASAM_ACCESS_LOCKED,
                                                                         &Xcp_Internal.cto_response.pdu_info);
                                                 }
@@ -2654,19 +2689,22 @@ Std_ReturnType Xcp_BlockTransferWriteSlaveMemory(uint8 *pBuffer, uint8 elementSi
     return result;
 }
 
-uint8 Xcp_GetProtectionStatus(void) {
-    return Xcp_Internal.protection_status;
+uint8 Xcp_GetLockedResources(void) {
+    return Xcp_Internal.locked_resource;
 }
 
-void Xcp_SetProtectionStatus(void) {
-    /* DD79: `|=`, not `=`. Once grants persist past the next command, an assignment would make
-     * unlocking a second resource silently drop the first -- invisible while a grant lasted one
-     * command, because there was never a second grant alive to lose. */
-    Xcp_Internal.protection_status |= Xcp_Internal.requested_protected_resource;
-}
-
-void Xcp_ClearProtectionStatus(void) {
-    Xcp_Internal.protection_status = 0x00u;
+void Xcp_UnlockResources(uint8 mask) {
+    /* DD79: a masked CLEAR of the named bits, not an assignment. Once grants persist past the next
+     * command, assigning would make unlocking a second resource silently re-lock the first --
+     * invisible while a grant lasted one command, because there was never a second grant alive to
+     * lose. DD78 inverted what this field holds; clearing the requested bits out of the still-
+     * protected mask is the same accumulation the old `|=` expressed on the granted set.
+     *
+     * A group that was never configured protected is not in the mask to begin with, so unlocking
+     * it is a no-op here rather than a bit set claiming a protection the build does not have --
+     * which is the domain half of DD78, and the reason GET_STATUS could report 0x10 on a build
+     * where PGM is not protected at all. */
+    Xcp_Internal.locked_resource &= (uint8)(~mask);
 }
 
 uint8 Xcp_CmdNotImplemented(boolean *responseExpected, const PduInfoType *pPduInfo)

--- a/source/Xcp.c
+++ b/source/Xcp.c
@@ -1679,35 +1679,55 @@ void Xcp_CanIfRxIndication(PduIdType rxPduId, const PduInfoType *pPduInfo)
                                  * conditionally, since an optional command a build leaves out
                                  * generates a disabled entry. Remove
                                  * this condition and a frame on the CTO PDU whose first byte falls
-                                 * in the DTO range runs the whole dispatch body -- and THREE things
-                                 * happen there, not one:
+                                 * in the DTO range runs the whole dispatch body. Only ONE thing
+                                 * happens there today, and it is harmless -- two more used to, and
+                                 * are recorded below along with what stopped each:
                                  *
                                  * - Xcp_PIDTable[pid] resolves to Xcp_CmdNotImplemented, which
-                                 *   answers ERR_CMD_UNKNOWN. Harmless in itself, and the least of
-                                 *   the three; it used to be Xcp_DTODaqStimPacket, a no-op
-                                 *   returning E_OK without filling the response buffer, which
-                                 *   transmitted whatever stale bytes that buffer still held.
-                                 * - `Xcp_Internal.last_pid = pid` runs on the way out, overwriting
-                                 *   the record of the previous command. Xcp_DTOCmdStdUnlock
-                                 *   (source/Xcp_Std.c) admits a key only when last_pid is GET_SEED
-                                 *   or UNLOCK, so one such frame between the two breaks the
-                                 *   seed-and-key sequence gate.
-                                 * - `Xcp_ClearProtectionStatus()` runs too, because the guard on it
-                                 *   is `pid != XCP_PID_CMD_UNLOCK` and no DTO-range PID is UNLOCK.
-                                 *   **That silently revokes an unlock the master already completed,
-                                 *   mid-session**, and it is the worst of the three: the master's
-                                 *   next protected command is answered ERR_ACCESS_LOCKED with
-                                 *   nothing to say why.
+                                 *   answers ERR_CMD_UNKNOWN. Harmless in itself; it used to be
+                                 *   Xcp_DTODaqStimPacket, a no-op returning E_OK without filling the
+                                 *   response buffer, which transmitted whatever stale bytes that
+                                 *   buffer still held.
+                                 *
+                                 * A second bullet stood here before DD72: `Xcp_Internal.last_pid =
+                                 * pid` ran on the way out, unconditionally, overwriting the record of
+                                 * the previous command. Xcp_DTOCmdStdUnlock (source/Xcp_Std.c) admits
+                                 * a key only when last_pid is GET_SEED or UNLOCK, so this really did
+                                 * break the seed-and-key sequence gate. DD72 guarded that write on
+                                 * the handler's own response instead (later in this same function,
+                                 * `if (SduDataPtr[0x00u] != XCP_PID_ERROR)`), and
+                                 * Xcp_CmdNotImplemented's own ERR_CMD_UNKNOWN above already satisfies
+                                 * it -- Xcp_FillErrorPacket fills that same byte with XCP_PID_ERROR
+                                 * before DD72's check is ever reached -- so this write no longer
+                                 * runs. Named here, not only at DD72's own guard, because a reader
+                                 * who greps XCP_PID_CMD_UNLOCK lands on this block.
+                                 *
+                                 * A third bullet stood here before DD79: `Xcp_ClearProtectionStatus()`
+                                 * ran too, because the guard on it was `pid != XCP_PID_CMD_UNLOCK` and
+                                 * no DTO-range PID is UNLOCK. That silently revoked an unlock the
+                                 * master had already completed, mid-session, and was the worst of the
+                                 * three: the master's next protected command was answered
+                                 * ERR_ACCESS_LOCKED with nothing to say why. DD79 deleted that call
+                                 * and its guard from the dispatch outright, not just from this
+                                 * hypothetical, so a frame reaching here no longer touches
+                                 * protection_status at all.
                                  *
                                  * Those 192 entries HAVE since been re-pointed at
-                                 * Xcp_CmdNotImplemented, and that did NOT make this safe -- it is
-                                 * the trap worth naming, because the change looks like a fix and
-                                 * is not one. The last two bullets happen after the handler
-                                 * returns, whatever the handler was, so they run either way. The
-                                 * routing decision is the guard; the table's contents are not.
-                                 * They were changed only to delete a dead function and to stop the
-                                 * table claiming a stimulation handler this dispatch path has not
-                                 * had since DD46 moved STIM to the DTO PduId. */
+                                 * Xcp_CmdNotImplemented, and unlike DD79's deletion above, that
+                                 * repointing is genuinely part of why the second bullet no longer
+                                 * fires: DD72's guard tests the RESPONSE, so whether last_pid
+                                 * survives depends on what Xcp_PIDTable[pid] answers, and
+                                 * Xcp_CmdNotImplemented's answer happens to qualify. That is a
+                                 * property of what these entries currently point to, not of the
+                                 * routing decision -- a handler placed here that answered anything
+                                 * else would put last_pid back at risk, and nothing enforces that
+                                 * none ever will. Whether Xcp_PIDTable[pid] is reached AT ALL is
+                                 * still decided above, by the routing condition this whole comment
+                                 * is about, regardless of the table's contents -- that remains the
+                                 * actual fix, not any handler's good behaviour. These entries were
+                                 * changed only to delete a dead function and to stop the table
+                                 * claiming a stimulation handler this dispatch path has not had
+                                 * since DD46 moved STIM to the DTO PduId. */
                                 if ((Xcp_Ptr->general->ctoInfo[pid] & XCP_CTO_INFO_IS_CTO_MASK) != 0x00u) {
                                     /* XCP part 2 - Protocol Layer Specification 1.0/1.7.3.1
                                      * Check if the received CTO reacts to ERR_CMD_BUSY error. If so, check if the CTO response ongoing flag is set, and
@@ -1862,10 +1882,6 @@ void Xcp_CanIfRxIndication(PduIdType rxPduId, const PduInfoType *pPduInfo)
                                                     if (Xcp_Internal.cto_response.pdu_info.SduDataPtr[0x00u] != XCP_PID_ERROR)
                                                     {
                                                         Xcp_Internal.last_pid = pid;
-                                                    }
-
-                                                    if (pid != XCP_PID_CMD_UNLOCK) {
-                                                        Xcp_ClearProtectionStatus();
                                                     }
                                                 }
                                                 else
@@ -2643,7 +2659,10 @@ uint8 Xcp_GetProtectionStatus(void) {
 }
 
 void Xcp_SetProtectionStatus(void) {
-    Xcp_Internal.protection_status = Xcp_Internal.requested_protected_resource;
+    /* DD79: `|=`, not `=`. Once grants persist past the next command, an assignment would make
+     * unlocking a second resource silently drop the first -- invisible while a grant lasted one
+     * command, because there was never a second grant alive to lose. */
+    Xcp_Internal.protection_status |= Xcp_Internal.requested_protected_resource;
 }
 
 void Xcp_ClearProtectionStatus(void) {

--- a/source/Xcp_Internal.h
+++ b/source/Xcp_Internal.h
@@ -356,7 +356,14 @@ typedef struct {
     uint8 connect_mode;
     Xcp_ConnectionState connection_status;
     uint8 session_status;
-    uint8 protection_status;
+    /* The Current Resource Protection Mask of XCP part 2 1.0/1.6.1.1.3: a set bit means the group
+     * IS still protected. This is the value transmitted verbatim by GET_STATUS byte 2 and UNLOCK
+     * response byte 1, so no reader inverts it and no reader can get the polarity wrong.
+     *
+     * DD78: this field used to hold the opposite -- the UNLOCKED set -- and was reported as if it
+     * were this mask, at three sites. It was renamed rather than redefined in place so that every
+     * existing reader became a compile error instead of silently correct-looking arithmetic. */
+    uint8 locked_resource;
     uint8 requested_protected_resource;
     uint8 last_pid;
 
@@ -649,9 +656,8 @@ Std_ReturnType Xcp_BlockTransferWriteSlaveMemory(uint8 *pBuffer, uint8 elementSi
  */
 uint8 Xcp_BlockTransferFrameElements(uint8 numberOfDataElements, uint8 elementSize);
 void Xcp_BlockTransferAbort(void);
-uint8 Xcp_GetProtectionStatus(void);
-void Xcp_SetProtectionStatus(void);
-void Xcp_ClearProtectionStatus(void);
+uint8 Xcp_GetLockedResources(void);
+void Xcp_UnlockResources(uint8 mask);
 
 /**
  * @brief Hands CanIf the next packet awaiting transmission, if the module is idle.

--- a/source/Xcp_Std.c
+++ b/source/Xcp_Std.c
@@ -770,7 +770,23 @@ uint8 Xcp_DTOCmdStdUnlock(boolean *responseExpected, const PduInfoType *pPduInfo
 
     *responseExpected = TRUE;
 
-    if ((Xcp_Internal.last_pid == XCP_PID_CMD_GET_SEED) || (Xcp_Internal.last_pid == XCP_PID_CMD_UNLOCK))
+    /* DD81. Two terms answering two different questions, and both are load-bearing.
+     *
+     * last_pid asks whether the immediately preceding command was a successful GET_SEED or a prior
+     * frame of this same key. It cannot say WHICH -- it is a two-element set-membership test -- so
+     * it cannot answer "was a seed actually issued", and on its own it admitted an UNLOCK against a
+     * seed that never existed (XCP part 2 1.0/1.6.1.2.5: "The master only can send an UNLOCK
+     * sequence if previously there was a GET_SEED sequence").
+     *
+     * seed.total_length asks exactly that second question. The mechanism already existed and
+     * nothing read it: the sequence below zeroes this field once a full key arrives, to "enforce a
+     * new seed to be requested prior to unlock a next resource". It stays non-zero for every frame
+     * of a multi-frame key, so this admits the whole legitimate sequence and refuses a replay.
+     *
+     * ERR_SEQUENCE is not a deviation: UNLOCK's own 1.7.3.2.1 row lists it, with GET_SEED as its
+     * prescribed pre-action. */
+    if (((Xcp_Internal.last_pid == XCP_PID_CMD_GET_SEED) || (Xcp_Internal.last_pid == XCP_PID_CMD_UNLOCK)) &&
+        (Xcp_Internal.seed.total_length != 0x00u))
     {
         if (pPduInfo->SduDataPtr[0x01u] >= 0x01u)
         {

--- a/source/Xcp_Std.c
+++ b/source/Xcp_Std.c
@@ -831,8 +831,15 @@ uint8 Xcp_DTOCmdStdUnlock(boolean *responseExpected, const PduInfoType *pPduInfo
                                                          &Xcp_Internal.key_master.buffer[0x00u]) == E_OK)
                         {
                             Xcp_Internal.cto_response.pdu_info.SduDataPtr[0x00u] = XCP_PID_RESPONSE;
-                            Xcp_SetProtectionStatus();
-                            Xcp_Internal.cto_response.pdu_info.SduDataPtr[0x01u] = Xcp_GetProtectionStatus();
+                            Xcp_UnlockResources(Xcp_Internal.requested_protected_resource);
+                            /* XCP part 2 - Protocol Layer Specification 1.0/1.6.1.2.5: "The answer
+                             * upon UNLOCK contains the Current Resource Protection Mask as described
+                             * at GET_STATUS" -- so this byte reports what is STILL protected after
+                             * the grant above, not the resource just granted. DD78: it used to
+                             * report the granted set, which made a successful UNLOCK of CAL_PAG
+                             * answer 0x01, i.e. "CAL_PAG is protected", at the moment it stopped
+                             * being. */
+                            Xcp_Internal.cto_response.pdu_info.SduDataPtr[0x01u] = Xcp_GetLockedResources();
 
                             Xcp_FinalizeResPacket(0x02u, &Xcp_Internal.cto_response.pdu_info);
                         }
@@ -917,7 +924,11 @@ uint8 Xcp_DTOCmdStdUnlock(boolean *responseExpected, const PduInfoType *pPduInfo
                 else
                 {
                     Xcp_Internal.cto_response.pdu_info.SduDataPtr[0x00u] = XCP_PID_RESPONSE;
-                    Xcp_Internal.cto_response.pdu_info.SduDataPtr[0x01u] = Xcp_GetProtectionStatus();
+                    /* An intermediate frame of a multi-frame key: nothing has been granted yet, so
+                     * this reports the mask unchanged -- the same Current Resource Protection Mask
+                     * (1.0/1.6.1.1.3) the completed sequence above reports, read at a moment when it
+                     * still holds everything it held before the sequence began. */
+                    Xcp_Internal.cto_response.pdu_info.SduDataPtr[0x01u] = Xcp_GetLockedResources();
                 }
             }
             else
@@ -981,8 +992,8 @@ uint8 Xcp_DTOCmdStdGetSeed(boolean *responseExpected, const PduInfoType *pPduInf
             /* DD72 (authentication bypass, pre-existing). This used to assign
              * requested_protected_resource unconditionally, before either check above could
              * refuse the request, and never rolled it back on failure -- so a GET_SEED that never
-             * produced a seed still left this resource requestable. Xcp_SetProtectionStatus
-             * (source/Xcp.c) copies this field into protection_status verbatim once UNLOCK's key
+             * produced a seed still left this resource requestable. Xcp_UnlockResources
+             * (source/Xcp.c) clears this field's bits out of locked_resource once UNLOCK's key
              * matches, with no way to tell "GET_SEED succeeded for this resource" from "GET_SEED
              * was merely asked for this resource and refused". Committing the write only once
              * both checks above have passed is a true rollback rather than a reset to a fixed
@@ -1261,7 +1272,10 @@ uint8 Xcp_CTOCmdStdGetStatus(boolean *responseExpected, const PduInfoType *pPduI
 
     Xcp_Internal.cto_response.pdu_info.SduDataPtr[0x00u] = XCP_PID_RESPONSE;
     Xcp_Internal.cto_response.pdu_info.SduDataPtr[0x01u] = Xcp_Internal.session_status;
-    Xcp_Internal.cto_response.pdu_info.SduDataPtr[0x02u] = Xcp_GetProtectionStatus();
+    /* XCP part 2 - Protocol Layer Specification 1.0/1.6.1.1.3, byte 2: the Current Resource
+     * Protection Status -- a set bit means that group IS protected. Transmitted verbatim, because
+     * Xcp_Internal.locked_resource holds exactly that (DD78). */
+    Xcp_Internal.cto_response.pdu_info.SduDataPtr[0x02u] = Xcp_GetLockedResources();
     Xcp_Internal.cto_response.pdu_info.SduDataPtr[0x03u] = 0x00u;
     /* XCP part 2 - Protocol Layer Specification 1.0/1.6.1.1.3, bytes 4,5: session configuration id.
      * 1.6.1.2.3 has it set by a prior SET_REQUEST carrying STORE_DAQ_REQ, held in non-volatile
@@ -1634,8 +1648,13 @@ uint8 Xcp_CTOCmdStdConnect(boolean *responseExpected, const PduInfoType *pPduInf
     /* DD79. With the clear-after-dispatch gone, this is the ONLY thing that re-locks a resource
      * inside a running module, and XCP part 1 - Overview 1.0/2.3 -- quoted in full at
      * Xcp_CanIfRxIndication (Xcp.c) -- names the protection status bits among what a DISCONNECTED
-     * slave has reset. A grant belongs to the session that earned it. */
-    Xcp_Internal.protection_status = 0x00u;
+     * slave has reset. A grant belongs to the session that earned it.
+     *
+     * DD78: re-seeded from the configuration rather than zeroed. Zero is now "nothing is
+     * protected", which would hand every new session an unconditional grant of every group; the
+     * configured mask is what a freshly initialised module holds (Xcp_Init, Xcp.c) and is what
+     * re-locking means on a field that stores what the wire means. */
+    Xcp_Internal.locked_resource = Xcp_Ptr->general->protectedResource;
 
     Xcp_Internal.connection_status = XCP_CONNECTION_STATE_CONNECTED;
 

--- a/source/Xcp_Std.c
+++ b/source/Xcp_Std.c
@@ -1615,6 +1615,12 @@ uint8 Xcp_CTOCmdStdConnect(boolean *responseExpected, const PduInfoType *pPduInf
      * different and larger question -- the DD25/SP2d one this does not settle. */
     Xcp_Internal.daq_pointer.valid = FALSE;
 
+    /* DD79. With the clear-after-dispatch gone, this is the ONLY thing that re-locks a resource
+     * inside a running module, and XCP part 1 - Overview 1.0/2.3 -- quoted in full at
+     * Xcp_CanIfRxIndication (Xcp.c) -- names the protection status bits among what a DISCONNECTED
+     * slave has reset. A grant belongs to the session that earned it. */
+    Xcp_Internal.protection_status = 0x00u;
+
     Xcp_Internal.connection_status = XCP_CONNECTION_STATE_CONNECTED;
 
     return E_OK;

--- a/test/pgm_acceptance_test.py
+++ b/test/pgm_acceptance_test.py
@@ -134,13 +134,26 @@ PGM_RESOURCE = 0x10  # XCP_RESOURCE_PROTECTION_STATUS_MASK_PGM, source/Xcp_Inter
 
 
 def unlock_pgm(handle, seed=(0x42,)):
-    """One full, confirmed GET_SEED/UNLOCK round for the PGM resource. Mechanically correct on any
-    handle -- the response reflects the resource the request named regardless of whether that
-    resource is actually configured as protected (seed_key_test.py's own
-    test_unlock_unlocks_the_requested_resource_if_the_key_is_valid runs with every
-    resource_protection_* flag at its False default and still gets back (0xFF, resource)) -- which
-    is what lets the sequence below carry a real exchange on a build where, by the module
-    docstring's finding, no build may configure the PGM resource as protected at all."""
+    """One full, confirmed GET_SEED/UNLOCK round for the PGM resource, carried on a build that
+    deliberately does not configure PGM as protected -- see the module docstring for why this file
+    keeps the rich sequence and the protection concern apart.
+
+    What that costs, stated rather than glossed. DD78 made UNLOCK's byte 1 the Current Resource
+    Protection Mask of XCP part 2 1.0/1.6.1.1.3 (1 = the group IS still protected), which is what
+    1.6.1.2.5 says it carries. On a build protecting nothing that mask is 0x00 before this round
+    and 0x00 after it, so the assertion below pins that the round is HONOURED -- a positive PID and
+    an empty mask, no error and no stale byte from GET_SEED -- and cannot pin that a grant was
+    made, because on this build there is no protection to grant relief from. That is the whole of
+    what this helper claims.
+
+    An earlier version of this docstring claimed the opposite: that the response "reflects the
+    resource the request named regardless of whether that resource is actually configured as
+    protected", citing seed_key_test.py's test_unlock_unlocks_the_requested_resource_if_the_key_is_
+    valid as running with every resource_protection_* flag False and still getting (0xFF, resource)
+    back. Both halves are now false -- the byte reports what remains protected, and that test
+    configures the resource under test as protected precisely so its own assertions mean something.
+    test/pgm_protected_acceptance_test.py is where a genuinely protected PGM resource is walked
+    end to end (DD83 having made that configuration buildable)."""
     seed = list(seed)
     handle.xcp_get_seed.side_effect = get_seed_side_effect_copy_ok(handle, seed)
     handle.xcp_calc_key.side_effect = calc_key_side_effect_copy_ok(handle, seed)
@@ -159,7 +172,9 @@ def unlock_pgm(handle, seed=(0x42,)):
     handle.lib.Xcp_CanIfRxIndication(0x0001, handle.get_pdu_info((0xF7, len(seed)) + tuple(seed)))
     handle.lib.Xcp_MainFunction()
     frame = transmitted(handle)
-    assert frame[0:2] == (0xFF, PGM_RESOURCE), 'UNLOCK must succeed and report PGM unlocked'
+    assert frame[0:2] == (0xFF, 0x00), (
+        'UNLOCK must succeed and report an empty protection mask -- this build protects no '
+        'resource, so nothing is left protected either side of the round; got {}'.format(frame))
     handle.lib.Xcp_CanIfTxConfirmation(0x0002, handle.define('E_OK'))
 
 

--- a/test/pgm_acceptance_test.py
+++ b/test/pgm_acceptance_test.py
@@ -20,44 +20,50 @@ separate questions. That is what test_a_real_masters_full_programming_sequence_c
 below is for, and it is why it is one long test rather than several short ones: the whole point is
 that nothing resets the module in between.
 
-**A resource-protection finding, read this before wondering why the test below does not set
-resource_protection_programming.** The task brief asks for the PGM resource to be configured
-protected so GET_SEED/UNLOCK is 'real rather than decorative'. That configuration no longer exists:
-script/source_cfg.c.jinja2 refuses `resource_protection.programming` outright in any build with
-`programming.enabled` set (final-review finding 2, guarded by
-pgm_configuration_test.py's test_generation_refuses_the_pgm_resource_on_a_build_that_can_program),
-and the reason is the wall this docstring already described.
+**A resource-protection finding, now historical -- read this before wondering why the test below
+still does not set resource_protection_programming.** The original SP4a task brief asked for the
+PGM resource to be configured protected so GET_SEED/UNLOCK would be 'real rather than decorative'.
+At the time this docstring was first written, that configuration could not be generated at all:
+script/source_cfg.c.jinja2 refused `resource_protection.programming` outright in any build with
+`programming.enabled` set (final-review finding 2), for the reason described next.
 
-The wall, unchanged: this module's README ('Key lifetime') documents that an UNLOCK's effect 'is
-discarded after the command FOLLOWING the UNLOCK sequence has been executed', which source/Xcp.c
-implements as Xcp_ClearProtectionStatus() running after every dispatched command except UNLOCK
-itself -- so one GET_SEED/UNLOCK round unlocks exactly the ONE command sent right after it, never
-more. PROGRAM_START is that one command, and dispatching it (immediately, in the handler, before it
-ever defers) is what spends it. By the time the session reaches XCP_PGM_ACTIVE and PROGRAM_RESET is
-due, PGM is locked again, and there is no way to re-unlock it: GET_SEED and UNLOCK both carry
-XCP_INTERNAL_ERR_PGM_ACTIVE in their own Xcp_CTOErrorMatrix rows (source/Xcp.c) -- pre-existing,
-not touched by SP4a -- so DD51's own new ACTIVE-session trigger refuses both of them right back.
-Measured directly (see task-6-report.md): a PROGRAM_RESET sent in this state answers (0xFE, 0x25),
-ERR_ACCESS_LOCKED, not the positive response DD57 promises. Nothing between PROGRAM_START's
-dispatch and PROGRAM_RESET can change that -- SYNCH does not reset pgm_state for an established
-ACTIVE session (Task 3's own fix, DD55 corrected), and no command this module implements re-opens
-GET_SEED/UNLOCK while ACTIVE.
+The wall, now dissolved (DD83): this module's README ('Key lifetime') used to document that an
+UNLOCK's effect 'is discarded after the command FOLLOWING the UNLOCK sequence has been executed',
+which source/Xcp.c implemented as Xcp_ClearProtectionStatus() running after every dispatched
+command except UNLOCK itself -- so one GET_SEED/UNLOCK round unlocked exactly the ONE command sent
+right after it, never more. PROGRAM_START was that one command, and dispatching it (immediately, in
+the handler, before it ever defers) is what spent it. By the time the session reached
+XCP_PGM_ACTIVE and PROGRAM_RESET was due, PGM was locked again, and there was no way to re-unlock
+it: GET_SEED and UNLOCK both carried XCP_INTERNAL_ERR_PGM_ACTIVE in their own Xcp_CTOErrorMatrix
+rows (source/Xcp.c) -- pre-existing, not touched by SP4a -- so DD51's own ACTIVE-session trigger
+refused both of them right back. Measured directly at the time (see task-6-report.md): a
+PROGRAM_RESET sent in this state answered (0xFE, 0x25), ERR_ACCESS_LOCKED, not the positive
+response DD57 promises.
 
-That is a genuine interaction between two mechanisms that both predate this task and are each
-correct on their own -- resource protection's one-shot lifetime, and the pre-existing (not SP4a's)
-ERR_PGM_ACTIVE bit on GET_SEED/UNLOCK -- and fixing it means changing the unlock lifetime for every
-resource group, not something a test may repair by itself. The final review's verdict was that a
-configuration that cannot conduct the sequence it advertises must not ship, so it is refused at
-generation the way DD48 refuses its STIM equivalent.
+That was a genuine interaction between two mechanisms that each predated SP4a and were each correct
+on their own -- resource protection's one-shot lifetime, and the pre-existing ERR_PGM_ACTIVE bit on
+GET_SEED/UNLOCK -- so fixing it meant changing the unlock lifetime for every resource group, not
+something a test could repair by itself. DD79 is that fix: a granted resource now lasts the whole
+session instead of the single command following the unlock, so the GET_SEED/UNLOCK round that
+admits PROGRAM_START is still in effect when PROGRAM_RESET needs it, and the dead end above no
+longer forms.
+test/pgm_protected_acceptance_test.py::test_a_protected_pgm_resource_conducts_a_full_programming_sequence_end_to_end
+now proves exactly that: CONNECT, PROGRAM_START refused before any unlock (protection proven live),
+GET_SEED/UNLOCK, PROGRAM_START, PROGRAM_CLEAR, PROGRAM and PROGRAM_RESET, every step answering
+positively.
 
-What this file therefore does: the test below sends a real, wire-correct GET_SEED/UNLOCK exchange
-for the PGM resource where the brief places it (CONNECT, then this, then SET_MTA), proving the
-handshake itself is correct on a build that does not enforce it. A companion test that pinned
-GET_SEED/UNLOCK actually GATING a PGM command used to live here; it required exactly the refused
-configuration and went with it. The mechanism it exercised is not left unproven -- seed_key_test.py
-pins GET_SEED/UNLOCK itself, and asam_error_matrix_test.py pins ERR_ACCESS_LOCKED on protected
-commands of the other resource groups -- but nothing in this suite now proves it on a PGM command,
-and nothing can until the unlock lifetime is fixed.
+What this file still does, and why it still does not set resource_protection_programming: the test
+below is about the RICH sequence composing -- GET_PGM_PROCESSOR_INFO, a genuinely interrupted and
+polled PROGRAM_START, a slow PROGRAM_CLEAR, a real multi-frame PROGRAM/PROGRAM_NEXT block, a
+zero-element PROGRAM, PROGRAM_RESET and the disconnect it triggers -- not whether protection
+survives across it. Layering resource_protection_programming onto this test would conflate two
+concerns this suite now keeps apart on purpose: this file proves the rich command sequence
+composes; pgm_protected_acceptance_test.py proves protection survives a deliberately minimal one,
+including the exact fact this paragraph used to say nothing could prove -- GET_SEED/UNLOCK actually
+GATING a PGM command (PROGRAM_START answers ERR_ACCESS_LOCKED there before the unlock). The test
+below still sends a real, wire-correct GET_SEED/UNLOCK exchange for the PGM resource where the
+original brief places it (CONNECT, then this, then SET_MTA), proving the handshake itself is
+correct -- but, as before, on a build where nothing gates on it.
 
 Every exchange below follows the standing rule this sub-project's five prior tasks paid for the
 hard way (task reports in .superpowers/sdd/2026-09-06-xcp-pgm-sp4a/): reset can_if_transmit

--- a/test/pgm_acceptance_test.py
+++ b/test/pgm_acceptance_test.py
@@ -28,10 +28,12 @@ script/source_cfg.c.jinja2 refused `resource_protection.programming` outright in
 `programming.enabled` set (final-review finding 2), for the reason described next.
 
 The wall, now dissolved (DD83): this module's README ('Key lifetime') used to document that an
-UNLOCK's effect 'is discarded after the command FOLLOWING the UNLOCK sequence has been executed',
-which source/Xcp.c implemented as Xcp_ClearProtectionStatus() running after every dispatched
-command except UNLOCK itself -- so one GET_SEED/UNLOCK round unlocked exactly the ONE command sent
-right after it, never more. PROGRAM_START was that one command, and dispatching it (immediately, in
+UNLOCK's effect 'is discarded after the command FOLLOWING the UNLOCK sequence has been executed'.
+It no longer does -- that section was rewritten alongside DD79 and now describes the session-long
+grant -- but source/Xcp.c did implement exactly that lifetime, as Xcp_ClearProtectionStatus() (a
+function DD78 has since deleted, along with the inverted field it wrote) running after every
+dispatched command except UNLOCK itself -- so one GET_SEED/UNLOCK round unlocked exactly the ONE
+command sent right after it, never more. PROGRAM_START was that one command, and dispatching it (immediately, in
 the handler, before it ever defers) is what spent it. By the time the session reached
 XCP_PGM_ACTIVE and PROGRAM_RESET was due, PGM was locked again, and there was no way to re-unlock
 it: GET_SEED and UNLOCK both carried XCP_INTERNAL_ERR_PGM_ACTIVE in their own Xcp_CTOErrorMatrix

--- a/test/pgm_configuration_test.py
+++ b/test/pgm_configuration_test.py
@@ -3,10 +3,7 @@
 
 import os
 
-import pytest
-
 from bsw_code_gen import BSWCodeGen
-from jinja2.exceptions import UndefinedError
 
 from .parameter import *
 from .conftest import XcpTest
@@ -359,41 +356,45 @@ def test_the_gate_touches_only_pgm_ctoinfo_rows():
             % (i, off_lines[i])
 
 
-def test_generation_refuses_the_pgm_resource_on_a_build_that_can_program():
-    """Final-review finding 2, and the exact analogue of DD48's STIM refusal
-    (daq_configuration_test.py's test_generation_refuses_the_stim_resource_on_a_configuration_that_
-    can_stimulate). The difference between the two is instructive: DD48 refuses a protection the
-    module does NOT enforce, this refuses one it enforces too well.
+def test_generation_accepts_the_pgm_resource_on_a_build_that_can_program():
+    """DD83. This test used to be the guard itself -- named for the refusal rather than the
+    acceptance this rename now reflects -- and it made generation fail outright whenever
+    `resource_protection.programming: true` was combined with `programming.enabled: true`,
+    because an UNLOCK was spent by the single command that followed it (source/Xcp.c, README.md's
+    old *Key lifetime* section) -- PROGRAM_START consumed the grant that admitted it, the session
+    became XCP_PGM_ACTIVE, PROGRAM_RESET (the only command that ends it, and itself
+    PGM-group-protected) was locked again, and GET_SEED/UNLOCK could not re-open it because DD51's
+    ERR_PGM_ACTIVE gate refuses both while ACTIVE. A programming session, once opened, could never
+    legitimately be left, so the configuration was refused at generation rather than shipped.
 
-    Measured on this branch before the guard existed, not reasoned. An UNLOCK is spent by the one
-    command that follows it -- Xcp_ClearProtectionStatus runs after every dispatched PID but UNLOCK
-    (source/Xcp.c), README.md's *Key lifetime* documents it, and even an unprotected interposed
-    GET_STATUS spends it -- so PROGRAM_START consumes the unlock that admitted it. The session is
-    then XCP_PGM_ACTIVE, and:
+    DD79 makes a granted resource last the whole session instead of the single command following
+    the unlock that grants it, so the GET_SEED/UNLOCK round that admits PROGRAM_START is still in
+    effect when PROGRAM_RESET needs it, and the dead end above no longer forms. This test only
+    proves the CONFIGURATION generates and advertises the resource correctly -- the same content
+    check test_generation_accepts_the_pgm_resource_on_a_build_that_cannot_program below makes, on
+    the build that test's own name says cannot exist. The sequence itself -- GET_SEED, UNLOCK,
+    PROGRAM_START, PROGRAM_CLEAR, PROGRAM, PROGRAM_RESET, every step confirmed positive, and
+    PROGRAM_START proven refused before the unlock so the protection is live rather than absent --
+    is walked end to end by
+    test/pgm_protected_acceptance_test.py::test_a_protected_pgm_resource_conducts_a_full_programming_sequence_end_to_end,
+    which is what actually discharges the claim this generation-level check only advertises.
 
-        PROGRAM_RESET   -> (0xFE, 0x25) ERR_ACCESS_LOCKED, the unlock having been spent
-        GET_SEED        -> (0xFE, 0x12) ERR_PGM_ACTIVE
-        UNLOCK          -> (0xFE, 0x12)
-        DISCONNECT      -> (0xFE, 0x12)
+    Kept, renamed and inverted rather than deleted: this stays the only GENERATION-level guard on
+    this configuration. If a refusal is ever reintroduced here -- for this reason or another -- it
+    fails this one test in a single line; a regression in the session-lifetime mechanism itself
+    would instead surface as a much noisier failure partway through the acceptance test's own
+    nine-step sequence."""
+    handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001,
+                                   resource_protection_programming=True,
+                                   **GATE_ON))
 
-    Every one of those refusals is individually conformant -- 1.1/1.7.3.2.1 and 1.7.3.2.5 list
-    ERR_PGM_ACTIVE for GET_SEED, UNLOCK and DISCONNECT with the action "wait t7, repeat infinitely
-    times" -- and the composition is a slave that cannot leave a programming session at all: the
-    only door out is PROGRAM_RESET, PROGRAM_RESET is in the locked group, and the only way to
-    unlock the group is refused because the session is open.
-
-    Refused at generation rather than repaired here because repairing it means changing the unlock
-    LIFETIME, which is one mechanism shared by CAL_PAG, DAQ and PGM alike and needs its own design.
-    Asserts only that generation fails, never on the message: raise(...) is not a registered Jinja
-    global, so every guard in source_cfg.c.jinja2 aborts with the same "'raise' is undefined"
-    UndefinedError (daq_configuration_test.py carries the full explanation above its own four).
-    What makes this test discriminating is not the message but its companion below, which shows
-    the same GATE_ON configuration generates cleanly once resource_protection.programming is left
-    False."""
-    with pytest.raises(UndefinedError):
-        XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001,
-                              resource_protection_programming=True,
-                              **GATE_ON))
+    # Bit 4, PGM, in the resource layout of XCP part 2 1.1/1.5 -- written as the shift
+    # script/source_cfg.c.jinja2 emits rather than as a name, because
+    # XCP_RESOURCE_PROTECTION_STATUS_MASK_PGM lives in source/Xcp_Internal.h, which the harness does
+    # not parse for defines. The same assertion
+    # test_generation_accepts_the_pgm_resource_on_a_build_that_cannot_program makes below, now also
+    # true of a build that CAN program.
+    assert handle.config.lib.Xcp[0].general.protectedResource == (0x01 << 0x04)
 
 
 def test_generation_accepts_the_pgm_resource_on_a_build_that_cannot_program():

--- a/test/pgm_configuration_test.py
+++ b/test/pgm_configuration_test.py
@@ -360,8 +360,9 @@ def test_generation_accepts_the_pgm_resource_on_a_build_that_can_program():
     """DD83. This test used to be the guard itself -- named for the refusal rather than the
     acceptance this rename now reflects -- and it made generation fail outright whenever
     `resource_protection.programming: true` was combined with `programming.enabled: true`,
-    because an UNLOCK was spent by the single command that followed it (source/Xcp.c, README.md's
-    old *Key lifetime* section) -- PROGRAM_START consumed the grant that admitted it, the session
+    because an UNLOCK was spent by the single command that followed it (source/Xcp.c, and
+    README.md's *Key lifetime* section as it read before DD79 rewrote it) -- PROGRAM_START consumed
+    the grant that admitted it, the session
     became XCP_PGM_ACTIVE, PROGRAM_RESET (the only command that ends it, and itself
     PGM-group-protected) was locked again, and GET_SEED/UNLOCK could not re-open it because DD51's
     ERR_PGM_ACTIVE gate refuses both while ACTIVE. A programming session, once opened, could never

--- a/test/pgm_protected_acceptance_test.py
+++ b/test/pgm_protected_acceptance_test.py
@@ -21,6 +21,7 @@ from .seed_key_defects_test import exchange
 
 
 PGM_RESOURCE = 0x10  # XCP_RESOURCE_PROTECTION_STATUS_MASK_PGM, source/Xcp_Internal.h: 0x01u << 4.
+GET_STATUS = (0xFD,)
 
 
 def test_a_protected_pgm_resource_conducts_a_full_programming_sequence_end_to_end():
@@ -57,6 +58,15 @@ def test_a_protected_pgm_resource_conducts_a_full_programming_sequence_end_to_en
     assert exchange(handle, (0xD2,))[0:2] == (0xFE, 0x25), \
         'PROGRAM_START must be refused ERR_ACCESS_LOCKED before the PGM resource is unlocked'
 
+    # DD78. The same fact the refusal above demonstrates, read off the wire where a master would
+    # read it: GET_STATUS byte 2 is the Current Resource Protection Mask of 1.0/1.6.1.1.3, 1 = the
+    # group IS protected. Checked here and again through UNLOCK's own byte 1 below, so that the
+    # behaviour (refused, then admitted) and the report the master gets about it are pinned
+    # together -- a module whose gate and whose status byte disagreed would pass one and fail the
+    # other.
+    assert exchange(handle, GET_STATUS, length=3)[2] == PGM_RESOURCE, \
+        'GET_STATUS must report PGM protected on a build that configures it so, before any unlock'
+
     # One GET_SEED/UNLOCK round for the PGM resource -- the only one this test ever sends. Task 2's
     # held-seed admission gate makes this a genuine sequence: UNLOCK reads the seed GET_SEED just
     # produced, not merely last_pid's own set-membership.
@@ -68,7 +78,11 @@ def test_a_protected_pgm_resource_conducts_a_full_programming_sequence_end_to_en
     assert frame[0:3] == (0xFF, len(seed), seed[0]), 'GET_SEED must return the PGM seed'
 
     frame = exchange(handle, (0xF7, len(seed)) + tuple(seed), length=2)
-    assert frame[0:2] == (0xFF, PGM_RESOURCE), 'UNLOCK must succeed and report PGM unlocked'
+    assert frame[0:2] == (0xFF, 0x00), (
+        'UNLOCK must succeed and report an empty protection mask -- 1.0/1.6.1.2.5 makes byte 1 the '
+        'same Current Resource Protection Mask GET_STATUS reports, and PGM was this build\'s only '
+        'protected group; 0x10 here would mean the slave still calls PGM protected at the moment '
+        'it granted it (DD78). Got {}'.format(frame))
 
     # PROGRAM_START: polled, not immediate. Xcp_ProgramStart returns E_NOT_OK once (the status code
     # must not be read on that call -- DD54's poison value would surface as ERR_GENERIC-with-0xEE if

--- a/test/pgm_protected_acceptance_test.py
+++ b/test/pgm_protected_acceptance_test.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""DD83 -- the configuration this proves buildable could not be generated at all before this task.
+
+script/source_cfg.c.jinja2 raised on `resource_protection.programming: true` with
+`programming.enabled: true`, because an unlock was spent by the single command that followed it:
+PROGRAM_START consumed the grant, the session became XCP_PGM_ACTIVE, PROGRAM_RESET -- the only
+command that ends it -- was locked again, and GET_SEED and UNLOCK were themselves refused
+ERR_PGM_ACTIVE. The slave could never leave the programming session.
+
+Every link in that chain depended on the grant being spent, so DD79 dissolves it. This test walks
+the whole sequence rather than arguing it: an argument that a dead end no longer exists is worth
+much less than a run that goes through where the dead end was."""
+
+from .pgm_deferred_test import program_start, program_reset, transmitted, busy_then
+from .pgm_program_test import pgm_program_handle, program
+from .pgm_clear_test import program_clear
+from .seed_key_test import get_seed_side_effect_copy_ok, calc_key_side_effect_copy_ok
+from .seed_key_defects_test import exchange
+
+
+PGM_RESOURCE = 0x10  # XCP_RESOURCE_PROTECTION_STATUS_MASK_PGM, source/Xcp_Internal.h: 0x01u << 4.
+
+
+def test_a_protected_pgm_resource_conducts_a_full_programming_sequence_end_to_end():
+    """CONNECT -> PROGRAM_START refused (protection is live) -> GET_SEED/UNLOCK for the PGM
+    resource -> PROGRAM_START (deferred, genuinely polled) -> PROGRAM_CLEAR -> PROGRAM ->
+    PROGRAM_RESET, every step confirmed before the next request (SWS_Xcp_00859: the transmit
+    pipeline carries one frame at a time).
+
+    The refusal this replaces argued the sequence below is impossible: PROGRAM_START spends the
+    single-command grant GET_SEED/UNLOCK produced, the session becomes XCP_PGM_ACTIVE,
+    PROGRAM_RESET -- the only command that ends it, and itself PGM-group-protected
+    (Xcp_PIDToCmdGroupTable, source/Xcp.c) -- is locked again, and GET_SEED/UNLOCK cannot be
+    replayed to re-open it because DD51's ERR_PGM_ACTIVE gate refuses both while ACTIVE. This test
+    performs exactly ONE GET_SEED/UNLOCK round, before PROGRAM_START, and never touches GET_SEED or
+    UNLOCK again -- so if the grant does not survive PROGRAM_START, PROGRAM_CLEAR, PROGRAM and
+    PROGRAM_RESET all the way to the end, one of those four answers ERR_ACCESS_LOCKED (0xFE, 0x25)
+    instead of the positive response asserted here. DD79 (Task 1) is what makes the grant last the
+    whole session instead of the one command following the unlock; DD81 (Task 2) is what makes the
+    one GET_SEED/UNLOCK round itself genuine (UNLOCK answers ERR_SEQUENCE without a held seed).
+
+    PROGRAM_START alone is pumped through a genuine busy cycle (Xcp_ProgramStart returns E_NOT_OK
+    once before reporting E_OK, and DD54's own poison-value convention -- 0xEE, only ever read on a
+    premature answer -- makes a module that read the status code early answer ERR_GENERIC-with-0xEE
+    on the wire): the point being proven here is resource protection surviving PROGRAM_START's own
+    deferral, not deferral itself, which pgm_deferred_test.py and pgm_acceptance_test.py already
+    prove exhaustively. PROGRAM_CLEAR, PROGRAM and PROGRAM_RESET are each left at the suite's
+    default synchronous integrator (conftest.py: E_OK, status code 0) -- the same default
+    pgm_clear_test.py's and pgm_program_test.py's own basic success tests, and this module's own
+    PROGRAM_RESET step, rely on -- since re-deriving their own deferred-polling correctness a
+    second time is not this test's job."""
+    handle = pgm_program_handle(resource_protection_programming=True)
+
+    # Proven live, not merely advertised: PROGRAM_START is refused before any resource is unlocked.
+    assert exchange(handle, (0xD2,))[0:2] == (0xFE, 0x25), \
+        'PROGRAM_START must be refused ERR_ACCESS_LOCKED before the PGM resource is unlocked'
+
+    # One GET_SEED/UNLOCK round for the PGM resource -- the only one this test ever sends. Task 2's
+    # held-seed admission gate makes this a genuine sequence: UNLOCK reads the seed GET_SEED just
+    # produced, not merely last_pid's own set-membership.
+    seed = [0x42]
+    handle.xcp_get_seed.side_effect = get_seed_side_effect_copy_ok(handle, seed)
+    handle.xcp_calc_key.side_effect = calc_key_side_effect_copy_ok(handle, seed)
+
+    frame = exchange(handle, (0xF8, 0x00, PGM_RESOURCE), length=3)
+    assert frame[0:3] == (0xFF, len(seed), seed[0]), 'GET_SEED must return the PGM seed'
+
+    frame = exchange(handle, (0xF7, len(seed)) + tuple(seed), length=2)
+    assert frame[0:2] == (0xFF, PGM_RESOURCE), 'UNLOCK must succeed and report PGM unlocked'
+
+    # PROGRAM_START: polled, not immediate. Xcp_ProgramStart returns E_NOT_OK once (the status code
+    # must not be read on that call -- DD54's poison value would surface as ERR_GENERIC-with-0xEE if
+    # it were), so the answer does not arrive on the first Xcp_MainFunction; pump and confirm rather
+    # than assume it does.
+    busy_then(handle, 0x00, busy_calls=2)
+    handle.can_if_transmit.reset_mock()
+    program_start(handle)  # call 1, inside the handler itself (DD53): still busy, so it defers.
+
+    handle.lib.Xcp_MainFunction()  # call 2: still busy.
+    assert transmitted(handle)[0:2] == (0xFD, 0x05), \
+        'EV_CMD_PENDING must keep the master informed while PROGRAM_START is still pending'
+    handle.lib.Xcp_CanIfTxConfirmation(0x0002, handle.define('E_OK'))
+
+    handle.can_if_transmit.reset_mock()
+    handle.lib.Xcp_MainFunction()  # call 3: the integrator finally reports E_OK.
+    assert transmitted(handle)[0] == 0xFF, \
+        'PROGRAM_START must succeed once the PGM resource is unlocked'
+    handle.lib.Xcp_CanIfTxConfirmation(0x0002, handle.define('E_OK'))
+
+    # The session is now XCP_PGM_ACTIVE. Before DD79, the grant that admitted PROGRAM_START would
+    # already be gone (spent by PROGRAM_START itself) and every command below, PGM-group-protected
+    # like PROGRAM_START, would answer ERR_ACCESS_LOCKED instead of what is asserted here.
+
+    # PROGRAM_CLEAR: default synchronous integrator (conftest.py), same single-poll pattern
+    # pgm_clear_test.py's own basic success tests use.
+    handle.can_if_transmit.reset_mock()
+    program_clear(handle, mode=0x00, clear_range=0x00001000)
+    handle.lib.Xcp_MainFunction()
+    assert transmitted(handle)[0] == 0xFF, 'PROGRAM_CLEAR must succeed with the grant still held'
+    handle.lib.Xcp_CanIfTxConfirmation(0x0002, handle.define('E_OK'))
+
+    # PROGRAM: two recognisable bytes, well under any block-mode threshold at this suite's default
+    # MAX_CTO -- a single frame, synchronously written.
+    handle.can_if_transmit.reset_mock()
+    program(handle, 0x02, data=(0xAA, 0xBB))
+    handle.lib.Xcp_MainFunction()
+    assert transmitted(handle)[0] == 0xFF, 'PROGRAM must succeed with the grant still held'
+    handle.lib.Xcp_CanIfTxConfirmation(0x0002, handle.define('E_OK'))
+
+    # PROGRAM_RESET: the only command that ends the session, and itself PGM-group-protected -- the
+    # exact command the refused configuration could never legitimately reach.
+    handle.can_if_transmit.reset_mock()
+    program_reset(handle)
+    handle.lib.Xcp_MainFunction()
+    assert transmitted(handle)[0] == 0xFF, 'PROGRAM_RESET must succeed and end the session'
+    handle.lib.Xcp_CanIfTxConfirmation(0x0002, handle.define('E_OK'))

--- a/test/seed_key_defects_test.py
+++ b/test/seed_key_defects_test.py
@@ -26,9 +26,23 @@ Two independent legs, both fixed here:
   successful GET_SEED from a refused one.
 
 test_a_failed_get_seed_leaves_the_resource_locked below is the direct reproduction of the measured
-scenario and is sensitive to the last_pid leg; test_a_failed_get_seed_does_not_let_a_stale_
-admission_grant_the_resource_it_requested isolates the requested_protected_resource leg, which the
-first test cannot -- see its own docstring. Both are mutation-verified in task-2-report.md.
+scenario, and is kept for that. It no longer isolates either leg, and neither did the test that
+used to sit beside it: DD81 (docs/superpowers/specs/2026-09-08-xcp-seed-key-hardening-design.md)
+added a `seed.total_length != 0x00u` conjunct to Xcp_DTOCmdStdUnlock's own admission test
+(source/Xcp_Std.c), and a GET_SEED that produced no seed fails that conjunct first -- so the UNLOCK
+is refused whatever last_pid and requested_protected_resource hold, and reverting either DD72 leg
+leaves every byte those two tests assert unchanged. The module is not weaker for it, DD81 subsumes
+DD72 for that shape of scenario; but a test named for a property it cannot fail on is not coverage.
+
+Both legs are therefore pinned by scenarios in which a seed IS genuinely held, so that DD81's
+conjunct is satisfied and DD72's two legs are the only things left that can decide the outcome:
+test_a_refused_get_seed_does_not_re_arm_the_unlock_sequence isolates the last_pid leg, and
+test_a_failed_get_seed_does_not_let_a_stale_admission_grant_the_resource_it_requested isolates the
+requested_protected_resource leg. Each is insensitive to the other leg by construction -- see their
+own docstrings -- and both use get_seed_side_effect_fail_with_length below, an Xcp_GetSeed that
+writes the seed length and only then refuses. Both are mutation-verified in
+.superpowers/sdd/2026-09-08-xcp-seed-key-hardening/final-fix-report.md; the original DD72
+measurements are in task-2-report.md.
 
 DD73 -- a second, independent pre-existing defect in the same shipped seed-and-key code: the key
 calculation must receive the seed's actual length, not the "bytes left to send" bookkeeping
@@ -89,6 +103,29 @@ def get_seed_side_effect_fail(handle):
     makes Xcp_DTOCmdStdGetSeed's own two checks refuse the request with ERR_OUT_OF_RANGE; both are
     true here for one realistic cause, not to double up on the trigger."""
     def wrapper(_p_seed_buffer, _max_seed_length, _p_seed_length):
+        return handle.define('E_NOT_OK')
+    return wrapper
+
+
+def get_seed_side_effect_fail_with_length(handle, seed):
+    """The other realistic way an integrator's Xcp_GetSeed can refuse: it fills pSeedBuffer and
+    pSeedLength -- so Xcp_Internal.seed.total_length, which Xcp_DTOCmdStdGetSeed passes by pointer
+    (source/Xcp_Std.c), is left non-zero -- and only THEN decides it cannot serve the request and
+    returns E_NOT_OK. Xcp_DTOCmdStdGetSeed still refuses with ERR_OUT_OF_RANGE, because it checks
+    the return value as well as the length, and the seed bytes never leave the slave: the handler
+    fills an error packet instead of transmitting them.
+
+    That is exactly what makes this double, and not get_seed_side_effect_fail above, the one that
+    can isolate either leg of DD72. get_seed_side_effect_fail leaves total_length at the 0
+    Xcp_DTOCmdStdGetSeed itself reset it to, which trips DD81's own seed conjunct
+    (Xcp_DTOCmdStdUnlock, source/Xcp_Std.c) and refuses every following UNLOCK before either DD72
+    leg can decide anything -- the masking this file's own module docstring records. With a seed
+    genuinely held, DD81's conjunct is satisfied and the two DD72 legs are the only things left
+    that can change the outcome."""
+    def wrapper(p_seed_buffer, _max_seed_length, p_seed_length):
+        for i, b in enumerate(seed):
+            p_seed_buffer[i] = b
+        p_seed_length[0] = len(seed)
         return handle.define('E_NOT_OK')
     return wrapper
 
@@ -165,7 +202,15 @@ def test_a_failed_get_seed_leaves_the_resource_locked():
     configured protected -- buildable since DD83 -- because on a build that protects nothing, "the
     resource is still locked" is not a property this byte can express: it reads 0x00 whether the
     bypass happened or not. GET_STATUS byte 2 is the Current Resource Protection Mask of
-    1.0/1.6.1.1.3, 1 = still protected, so "PGM is still locked" is 0x10 here."""
+    1.0/1.6.1.1.3, 1 = still protected, so "PGM is still locked" is 0x10 here.
+
+    This test is the measured reproduction and nothing more: it can no longer fail on DD72's
+    last_pid leg. get_seed_side_effect_fail never writes pSeedLength, so seed.total_length is left
+    at the 0 Xcp_DTOCmdStdGetSeed itself reset it to, and DD81's own conjunct (source/Xcp_Std.c)
+    refuses the UNLOCK below before last_pid can matter -- every byte asserted here is identical
+    with that leg reverted. That leg is pinned instead by
+    test_a_refused_get_seed_does_not_re_arm_the_unlock_sequence below, which holds a seed while the
+    refusal happens. See this file's own module docstring."""
     handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001, resource_protection_programming=True))
     connect(handle)
 
@@ -190,30 +235,113 @@ def test_a_failed_get_seed_leaves_the_resource_locked():
                 status_response[2], PGM, get_seed_response, unlock_response))
 
 
+def test_a_refused_get_seed_does_not_re_arm_the_unlock_sequence():
+    """Isolates the last_pid leg -- the one DD72's own measured scenario above can no longer fail
+    on, since DD81 refuses that scenario's UNLOCK on the seed conjunct first.
+
+    The shape that still discriminates needs a seed genuinely HELD while a GET_SEED is refused, and
+    needs last_pid to have been moved OUT of {GET_SEED, UNLOCK} before the refusal, so that writing
+    it back in is a change the wire can see:
+
+      GET_SEED(mode=0, CAL_PAG) succeeds  -> seed held, last_pid = GET_SEED's pid (0xF8)
+      GET_STATUS                          -> answers positively, so DD72's gate advances last_pid
+                                             to 0xFD; Xcp_CTOCmdStdGetStatus (source/Xcp_Std.c)
+                                             never touches Xcp_Internal.seed, so the seed survives
+      GET_SEED(mode=0, CAL_PAG) refused   -> get_seed_side_effect_fail_with_length above writes the
+                                             length and then returns E_NOT_OK, so this answers
+                                             ERR_OUT_OF_RANGE with a seed still held
+      UNLOCK                              -> must be refused ERR_SEQUENCE
+
+    With the leg intact, the refused GET_SEED's own error response stops DD72's gate advancing
+    last_pid, it stays at GET_STATUS's 0xFD, and the UNLOCK is refused. With the leg reverted --
+    last_pid written for every dispatched command, refused or not (source/Xcp.c) -- the refusal
+    itself puts 0xF8 back, both conjuncts pass, Xcp_CalcKey runs over the held seed and CAL_PAG is
+    granted: a key admitted against a GET_SEED the slave refused, which is DD72 exactly. This is
+    the one shape in which a REFUSED command re-arms the sequence gate.
+
+    Insensitive to the other leg by construction: both GET_SEEDs name CAL_PAG, so
+    requested_protected_resource is CAL_PAG whether it is committed before or after
+    Xcp_DTOCmdStdGetSeed's own checks, and reverting that leg cannot change any byte below.
+
+    CAL_PAG is the build's only protected group, so GET_STATUS byte 2 -- the Current Resource
+    Protection Mask of 1.0/1.6.1.1.3, 1 = still protected -- reads 0x01 while the refusal holds and
+    0x00 the moment a grant leaks through. xcp_calc_key is armed with a matching key rather than
+    left unconfigured, so a broken gate answers an unambiguous positive instead of an artifact of
+    an unconfigured mock. Mutation-verified in
+    .superpowers/sdd/2026-09-08-xcp-seed-key-hardening/final-fix-report.md."""
+    handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001,
+                                   resource_protection_calibration_paging=True))
+    connect(handle)
+
+    seed = [0x11, 0x22]
+    key = [0xAA, 0xBB]
+    handle.xcp_get_seed.side_effect = get_seed_side_effect_copy_ok(handle, seed)
+    handle.xcp_calc_key.side_effect = calc_key_side_effect_copy_ok(handle, key)
+
+    get_seed_response = exchange(handle, (0xF8, 0x00, CAL_PAG))
+    assert get_seed_response[0:2] == (0xFF, len(seed)), (
+        'GET_SEED(mode=0, CAL_PAG) answered {}, expected a genuine seed -- the whole scenario needs '
+        'one to be held'.format(get_seed_response))
+
+    status_response = exchange(handle, GET_STATUS)
+    assert status_response[0] == 0xFF, 'GET_STATUS'
+    assert status_response[2] == CAL_PAG, (
+        'protection mask=0x{:02X} before any UNLOCK, expected CAL_PAG (0x{:02X}) protected'.format(
+                status_response[2], CAL_PAG))
+
+    handle.xcp_get_seed.side_effect = get_seed_side_effect_fail_with_length(handle, [0x33, 0x44])
+
+    refused_get_seed_response = exchange(handle, (0xF8, 0x00, CAL_PAG))
+    assert refused_get_seed_response[0:2] == (0xFE, 0x22), (
+        'GET_SEED(mode=0, CAL_PAG) answered {}, expected (0xFE, 0x22) [ERR_OUT_OF_RANGE] -- an '
+        'Xcp_GetSeed returning E_NOT_OK is refused however much it wrote first'.format(
+                refused_get_seed_response))
+
+    unlock_response = exchange(handle, (0xF7, len(key), *key))
+    assert unlock_response[0:2] == (0xFE, 0x29), (
+        'UNLOCK answered {}, expected (0xFE, 0x29) [ERR_SEQUENCE] -- the command before it was a '
+        'REFUSED GET_SEED, and before that a GET_STATUS, so no successful GET_SEED precedes it; a '
+        'positive answer here means the refused GET_SEED re-armed the sequence gate'.format(
+                unlock_response))
+
+    status_response = exchange(handle, GET_STATUS)
+    assert status_response[2] == CAL_PAG, (
+        'protection mask=0x{:02X} after an UNLOCK admitted only by a REFUSED GET_SEED -- expected '
+        'CAL_PAG (0x{:02X}) still protected (GET_SEED: {}, UNLOCK: {})'.format(
+                status_response[2], CAL_PAG, refused_get_seed_response, unlock_response))
+
+
 def test_a_failed_get_seed_does_not_let_a_stale_admission_grant_the_resource_it_requested():
-    """Isolates the requested_protected_resource leg. A GET_SEED/UNLOCK exchange for CAL_PAG
-    completes legitimately first, which -- 1.1/1.6.1.2.5's own multi-frame KEY continuation
-    support, admitting a further UNLOCK whenever last_pid is already UNLOCK's own pid -- leaves
-    last_pid sitting on a value Xcp_DTOCmdStdUnlock accepts. A second GET_SEED, for PGM this time,
-    is then made to fail: with only the last_pid leg fixed, that failure does not touch last_pid,
-    so it is still left at UNLOCK's pid from the CAL_PAG exchange above rather than CONNECT's --
-    and an immediately following UNLOCK is admitted through that carryover regardless of the
-    last_pid leg's own state. What must not happen is that admission granting PGM: whether it
-    grants CAL_PAG again (a harmless re-grant of what was already legitimately obtained) or PGM
-    (the bypass) turns entirely on requested_protected_resource, which is this test's own target.
+    """Isolates the requested_protected_resource leg. GET_SEED(mode=0, CAL_PAG) succeeds, so a seed
+    is held, requested_protected_resource is CAL_PAG and last_pid is GET_SEED's own pid.
+    GET_SEED(mode=0, PGM) is then refused by an Xcp_GetSeed that has already written the seed
+    length (get_seed_side_effect_fail_with_length above) -- so the refusal leaves a seed held
+    rather than destroying the one CAL_PAG earned, which is what keeps DD81's own seed conjunct out
+    of the way, and its error response leaves last_pid on GET_SEED's pid. The UNLOCK that follows
+    is therefore admitted on both conjuncts and reaches Xcp_CalcKey, so a grant genuinely happens.
+    The only question left is WHICH group it releases, and that is requested_protected_resource
+    alone: CAL_PAG, whose GET_SEED succeeded, or PGM, whose GET_SEED was refused -- the bypass.
 
-    test_a_failed_get_seed_leaves_the_resource_locked above cannot show this: immediately after
-    CONNECT, last_pid is CONNECT's own pid, already outside {GET_SEED, UNLOCK}, so the last_pid leg
-    alone already refuses that test's UNLOCK regardless of what requested_protected_resource holds.
-    Mutation-verified in task-2-report.md.
+    This is also §1.2(k)'s own route in the final review: it is not exploitable in the field,
+    because the refused GET_SEED transmits no seed bytes and the master therefore cannot compute
+    the matching key. That is an argument about the attacker's information, not about the module's
+    bookkeeping; what this test pins is the bookkeeping, which is what DD72's rollback fixed.
 
-    DD78 configures PGM as protected (buildable since DD83) and inverts what the protection byte
-    means: 1 = the group IS protected, 1.0/1.6.1.1.3. So the harmless outcome and the bypass are
-    now told apart by whether PGM's own bit SURVIVES -- 0x10 throughout if requested_protected_
-    resource was never allowed to become PGM, 0x00 if it was and the stale admission cleared it.
-    CAL_PAG is not configured protected here, so unlocking it is legitimately a no-op on the mask;
-    it is the vehicle for leaving last_pid where the scenario needs it, not the thing measured."""
-    handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001, resource_protection_programming=True))
+    Both CAL_PAG and PGM are configured protected here, so the two outcomes are distinct values of
+    the same byte rather than one value and its absence. GET_STATUS byte 2 is the Current Resource
+    Protection Mask of 1.0/1.6.1.1.3, 1 = still protected: 0x10 means the grant went to CAL_PAG and
+    PGM survives, 0x01 means it went to PGM. UNLOCK's own byte 1 carries the same mask
+    (1.0/1.6.1.2.5) and is asserted for the same reason.
+
+    Insensitive to the other leg: the UNLOCK below is admitted on last_pid == GET_SEED's pid
+    whether or not a refused dispatch is allowed to write last_pid, since the refused command IS a
+    GET_SEED and the value it would write is the one already there.
+    test_a_refused_get_seed_does_not_re_arm_the_unlock_sequence above is where that leg is pinned.
+    Mutation-verified in
+    .superpowers/sdd/2026-09-08-xcp-seed-key-hardening/final-fix-report.md."""
+    handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001,
+                                   resource_protection_calibration_paging=True,
+                                   resource_protection_programming=True))
     connect(handle)
 
     legitimate_seed = [0x11, 0x22]
@@ -225,29 +353,37 @@ def test_a_failed_get_seed_does_not_let_a_stale_admission_grant_the_resource_it_
     handle.xcp_get_seed.side_effect = get_seed_side_effect_copy_ok(handle, legitimate_seed)
     handle.xcp_calc_key.side_effect = calc_key_side_effect_copy_ok(handle, legitimate_key)
 
+    assert exchange(handle, GET_STATUS)[2] == CAL_PAG | PGM, (
+        'CAL_PAG (0x{:02X}) and PGM (0x{:02X}) are both configured protected and nothing has been '
+        'unlocked yet'.format(CAL_PAG, PGM))
+
     get_seed_response = exchange(handle, (0xF8, 0x00, CAL_PAG))
     assert get_seed_response[0:2] == (0xFF, len(legitimate_seed))
 
-    unlock_response = exchange(handle, (0xF7, len(legitimate_key), *legitimate_key))
-    assert unlock_response[0:2] == (0xFF, PGM), (
-        'UNLOCK(CAL_PAG) answered {}, expected a positive response reporting PGM (0x{:02X}) still '
-        'protected -- CAL_PAG is not configured protected on this build, so unlocking it clears '
-        'nothing from the mask'.format(unlock_response, PGM))
-
-    handle.xcp_get_seed.side_effect = get_seed_side_effect_fail(handle)
+    handle.xcp_get_seed.side_effect = get_seed_side_effect_fail_with_length(handle, [0x33, 0x44])
 
     failed_get_seed_response = exchange(handle, (0xF8, 0x00, PGM))
-    assert failed_get_seed_response[0:2] == (0xFE, 0x22)
+    assert failed_get_seed_response[0:2] == (0xFE, 0x22), (
+        'GET_SEED(mode=0, PGM) answered {}, expected (0xFE, 0x22) [ERR_OUT_OF_RANGE]'.format(
+                failed_get_seed_response))
 
-    second_unlock_response = exchange(handle, (0xF7, len(legitimate_key), *legitimate_key))
+    unlock_response = exchange(handle, (0xF7, len(legitimate_key), *legitimate_key))
+    assert unlock_response[0] == 0xFF, (
+        'UNLOCK answered {}, expected a positive response -- a seed is held and last_pid is still '
+        'GET_SEED\'s own pid, so this must reach Xcp_CalcKey and grant something; with nothing '
+        'granted there is no leg to isolate'.format(unlock_response))
+    assert unlock_response[1] == PGM, (
+        'UNLOCK reported 0x{:02X} still protected, expected PGM (0x{:02X}) -- the grant belongs to '
+        'CAL_PAG, whose GET_SEED succeeded, not to PGM, whose GET_SEED was refused'.format(
+                unlock_response[1], PGM))
 
     status_response = exchange(handle, GET_STATUS)
     assert status_response[2] == PGM, (
         'protection mask=0x{:02X} after PGM\'s own GET_SEED answered ERR_OUT_OF_RANGE -- expected '
-        'PGM (0x{:02X}) still protected; 0x00 means the stale admission granted the resource that '
-        'failed GET_SEED (first UNLOCK: {}, failed GET_SEED: {}, second UNLOCK: {})'.format(
-                status_response[2], PGM, unlock_response, failed_get_seed_response,
-                second_unlock_response))
+        'PGM (0x{:02X}) still protected; 0x{:02X} means the stale admission granted the resource '
+        'that failed GET_SEED instead of the one that succeeded (GET_SEED: {}, failed GET_SEED: '
+        '{}, UNLOCK: {})'.format(status_response[2], PGM, CAL_PAG, get_seed_response,
+                                 failed_get_seed_response, unlock_response))
 
 
 def test_unlock_computes_the_key_from_the_seeds_actual_length():

--- a/test/seed_key_defects_test.py
+++ b/test/seed_key_defects_test.py
@@ -4,14 +4,22 @@
 """DD72 (docs/superpowers/specs/2026-09-07-xcp-shared-state-defects-design.md) -- a pre-existing
 authentication bypass in shipped seed-and-key code, independent of any feature branch this
 repository carries. Measured on the unfixed code: GET_SEED for the PGM resource, made to fail,
-answered (0xFE, 0x22); UNLOCK then answered (0xFF, 0x10); GET_STATUS then reported
-protection_status = 0x10. The PGM resource was unlocked with no seed ever produced.
+answered (0xFE, 0x22); UNLOCK then answered (0xFF, 0x10); GET_STATUS's own protection byte then
+reported 0x10 as well. The PGM resource was unlocked with no seed ever produced.
+
+Read those two 0x10s with DD78 in mind: at the time of that measurement the module reported the
+UNLOCKED set in a byte the specification defines as the still-PROTECTED one (1.0/1.6.1.1.3), so
+0x10 meant "PGM granted". DD78 inverted the stored representation -- Xcp_Internal.locked_resource
+now IS the wire value -- and every assertion in this file reads the new polarity: 1 = the group is
+still protected. Each test below that asserts the byte configures PGM as protected
+(resource_protection_programming, buildable since DD83), because on a build protecting nothing the
+byte reads 0x00 whether the bypass happened or not.
 
 Two independent legs, both fixed here:
 - Xcp_DTOCmdStdGetSeed (source/Xcp_Std.c) used to commit requested_protected_resource before
-  Xcp_GetSeed ran and never rolled it back on failure, so Xcp_SetProtectionStatus (source/Xcp.c)
-  could later copy a resource whose own seed request had been refused straight into
-  protection_status.
+  Xcp_GetSeed ran and never rolled it back on failure, so a later successful UNLOCK
+  (Xcp_UnlockResources, source/Xcp.c) could grant a resource whose own seed request had been
+  refused.
 - The CTO dispatch in Xcp_CanIfRxIndication (source/Xcp.c) used to write last_pid for every
   dispatched command unconditionally, including one whose own handler refused it, so
   Xcp_DTOCmdStdUnlock's "last_pid == GET_SEED" admission check (source/Xcp_Std.c) could not tell a
@@ -65,7 +73,8 @@ precedent (test_clear_daq_list_invalidates_a_pointer_aimed_at_it)."""
 from .parameter import *
 from .conftest import XcpTest
 from .download_test import connect
-from .seed_key_test import get_seed_key_slices, get_seed_side_effect_copy_ok, calc_key_side_effect_copy_ok
+from .seed_key_test import (get_seed_key_slices, get_seed_side_effect_copy_ok,
+                            calc_key_side_effect_copy_ok, RESOURCE_PROTECTION_FLAG)
 
 CAL_PAG = 0x01
 PGM = 0x10
@@ -119,8 +128,8 @@ def calc_key_side_effect_fail(handle):
 def exchange(handle, request, length=3):
     """Sends one CTO request and returns the first `length` response bytes -- 3 is enough for
     every status-code assertion in this file: byte 0 is always the PID (0xFF/0xFE), byte 1 is the
-    error code (GET_SEED/UNLOCK error responses) or session_status (GET_STATUS), byte 2 is
-    protection_status (GET_STATUS only; unused trailing_value padding elsewhere). A caller that
+    error code (GET_SEED/UNLOCK error responses) or session_status (GET_STATUS), byte 2 is the
+    resource protection mask (GET_STATUS only; unused trailing_value padding elsewhere). A caller that
     needs to check the transmitted DATA too -- GET_SEED's own seed bytes, task-3-brief.md step 4 --
     passes a larger length; SduDataPtr always holds a full MAX_CTO-sized frame, so any length up to
     MAX_CTO is safe to read regardless of how many of those bytes this particular response filled.
@@ -150,8 +159,14 @@ def test_a_failed_get_seed_leaves_the_resource_locked():
     UNLOCK must still be refused, and GET_STATUS must still report the resource locked.
 
     Before the fix: GET_SEED -> (0xFE, 0x22) [XCP_E_ASAM_OUT_OF_RANGE], UNLOCK -> (0xFF, 0x10)
-    [granted], GET_STATUS -> protection_status 0x10. Recorded in task-2-report.md."""
-    handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001))
+    [granted], GET_STATUS -> 0x10 in the protection byte. Recorded in task-2-report.md.
+
+    DD78 changed both the configuration and the expected value. The PGM resource is now genuinely
+    configured protected -- buildable since DD83 -- because on a build that protects nothing, "the
+    resource is still locked" is not a property this byte can express: it reads 0x00 whether the
+    bypass happened or not. GET_STATUS byte 2 is the Current Resource Protection Mask of
+    1.0/1.6.1.1.3, 1 = still protected, so "PGM is still locked" is 0x10 here."""
+    handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001, resource_protection_programming=True))
     connect(handle)
 
     handle.xcp_get_seed.side_effect = get_seed_side_effect_fail(handle)
@@ -169,9 +184,10 @@ def test_a_failed_get_seed_leaves_the_resource_locked():
     assert unlock_response[0:2] == (0xFE, 0x29)  # XCP_E_ASAM_SEQUENCE
 
     status_response = exchange(handle, GET_STATUS)
-    assert status_response[2] == 0x00, (
-        'protection_status=0x{:02X} after a failed GET_SEED and a should-be-refused UNLOCK '
-        '(GET_SEED: {}, UNLOCK: {})'.format(status_response[2], get_seed_response, unlock_response))
+    assert status_response[2] == PGM, (
+        'protection mask=0x{:02X} after a failed GET_SEED and a should-be-refused UNLOCK, expected '
+        'PGM (0x{:02X}) to still be protected (GET_SEED: {}, UNLOCK: {})'.format(
+                status_response[2], PGM, get_seed_response, unlock_response))
 
 
 def test_a_failed_get_seed_does_not_let_a_stale_admission_grant_the_resource_it_requested():
@@ -189,8 +205,15 @@ def test_a_failed_get_seed_does_not_let_a_stale_admission_grant_the_resource_it_
     test_a_failed_get_seed_leaves_the_resource_locked above cannot show this: immediately after
     CONNECT, last_pid is CONNECT's own pid, already outside {GET_SEED, UNLOCK}, so the last_pid leg
     alone already refuses that test's UNLOCK regardless of what requested_protected_resource holds.
-    Mutation-verified in task-2-report.md."""
-    handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001))
+    Mutation-verified in task-2-report.md.
+
+    DD78 configures PGM as protected (buildable since DD83) and inverts what the protection byte
+    means: 1 = the group IS protected, 1.0/1.6.1.1.3. So the harmless outcome and the bypass are
+    now told apart by whether PGM's own bit SURVIVES -- 0x10 throughout if requested_protected_
+    resource was never allowed to become PGM, 0x00 if it was and the stale admission cleared it.
+    CAL_PAG is not configured protected here, so unlocking it is legitimately a no-op on the mask;
+    it is the vehicle for leaving last_pid where the scenario needs it, not the thing measured."""
+    handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001, resource_protection_programming=True))
     connect(handle)
 
     legitimate_seed = [0x11, 0x22]
@@ -206,7 +229,10 @@ def test_a_failed_get_seed_does_not_let_a_stale_admission_grant_the_resource_it_
     assert get_seed_response[0:2] == (0xFF, len(legitimate_seed))
 
     unlock_response = exchange(handle, (0xF7, len(legitimate_key), *legitimate_key))
-    assert unlock_response[0:2] == (0xFF, CAL_PAG)
+    assert unlock_response[0:2] == (0xFF, PGM), (
+        'UNLOCK(CAL_PAG) answered {}, expected a positive response reporting PGM (0x{:02X}) still '
+        'protected -- CAL_PAG is not configured protected on this build, so unlocking it clears '
+        'nothing from the mask'.format(unlock_response, PGM))
 
     handle.xcp_get_seed.side_effect = get_seed_side_effect_fail(handle)
 
@@ -216,11 +242,11 @@ def test_a_failed_get_seed_does_not_let_a_stale_admission_grant_the_resource_it_
     second_unlock_response = exchange(handle, (0xF7, len(legitimate_key), *legitimate_key))
 
     status_response = exchange(handle, GET_STATUS)
-    assert status_response[2] == CAL_PAG, (
-        'protection_status=0x{:02X} after PGM\'s own GET_SEED answered ERR_OUT_OF_RANGE -- '
-        'expected CAL_PAG (0x{:02X}, already legitimately granted) or, if PGM leaked through, '
-        '0x{:02X} (first UNLOCK: {}, failed GET_SEED: {}, second UNLOCK: {})'.format(
-                status_response[2], CAL_PAG, PGM, unlock_response, failed_get_seed_response,
+    assert status_response[2] == PGM, (
+        'protection mask=0x{:02X} after PGM\'s own GET_SEED answered ERR_OUT_OF_RANGE -- expected '
+        'PGM (0x{:02X}) still protected; 0x00 means the stale admission granted the resource that '
+        'failed GET_SEED (first UNLOCK: {}, failed GET_SEED: {}, second UNLOCK: {})'.format(
+                status_response[2], PGM, unlock_response, failed_get_seed_response,
                 second_unlock_response))
 
 
@@ -238,11 +264,21 @@ def test_unlock_computes_the_key_from_the_seeds_actual_length():
     received_seed_lengths == [0], for every seed -- matching the design doc's own measurement
     exactly. test_a_legitimate_multi_frame_get_seed_and_unlock_sequence_still_unlocks_the_resource
     below makes the same assertion for a seed spanning more than one frame -- task-3-brief.md's
-    own neighbour (step 4), since total_length's pacing role is exactly what the fix changes."""
+    own neighbour (step 4), since total_length's pacing role is exactly what the fix changes.
+
+    DD78 configures CAL_PAG as protected and inverts UNLOCK's own byte 1: it is the Current
+    Resource Protection Mask of 1.0/1.6.1.1.3, 1 = still protected, so a successful unlock of the
+    build's only protected group answers 0x00. That assertion is a precondition here rather than
+    the measurement -- this test is about what Xcp_CalcKey RECEIVED -- but it has to be a real one:
+    an UNLOCK that never completed would leave received_seed_lengths empty and the seedLength
+    assertion below would fail for the wrong reason. Protecting CAL_PAG is what keeps that
+    precondition able to fail; without it the byte reads 0x00 whether the sequence was honoured or
+    not."""
     seed = [0x11, 0x22, 0x33, 0x44]
     key = [0x99]
 
-    handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001))
+    handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001,
+                                   resource_protection_calibration_paging=True))
     connect(handle)
 
     received_seed_lengths = []
@@ -257,9 +293,10 @@ def test_unlock_computes_the_key_from_the_seeds_actual_length():
                 list(get_seed_response[2:2 + len(seed)]), seed))
 
     unlock_response = exchange(handle, (0xF7, len(key), *key))
-    assert unlock_response[0:2] == (0xFF, CAL_PAG), (
-        'UNLOCK was not admitted ({}) for a legitimate single-frame seed/key exchange'.format(
-                unlock_response))
+    assert unlock_response[0:2] == (0xFF, 0x00), (
+        'UNLOCK answered {} for a legitimate single-frame seed/key exchange, expected '
+        '(0xFF, 0x00) -- CAL_PAG is this build\'s only protected group and has just been '
+        'granted'.format(unlock_response))
 
     assert received_seed_lengths == [len(seed)], (
         'Xcp_CalcKey received seedLength={} for a {}-byte seed {} -- the key was not computed '
@@ -285,12 +322,21 @@ def test_a_legitimate_multi_frame_get_seed_and_unlock_sequence_still_unlocks_the
     frame's reported length or the frame count (either of which the fix could satisfy by
     accident), and confirms Xcp_CalcKey's own double received seedLength == len(seed) -- the value
     the pre-fix code zeroed out -- here in the multi-frame case, complementing
-    test_unlock_computes_the_key_from_the_seeds_actual_length's single-frame one above."""
+    test_unlock_computes_the_key_from_the_seeds_actual_length's single-frame one above.
+
+    DD78 configures the resource under test as protected (RESOURCE_PROTECTION_FLAG,
+    test/seed_key_test.py -- all four are buildable on DefaultConfig, PGM since DD83) and inverts
+    the protection byte: it is the Current Resource Protection Mask of 1.0/1.6.1.1.3, 1 = the group
+    IS protected. So "the grant took effect" is now byte 2 reading 0x00 with that resource the only
+    bit that was ever in the mask, which also proves the RIGHT group was released. On a build
+    protecting nothing the byte reads 0x00 from CONNECT onwards and could not have told a grant
+    from a refusal at all."""
     max_cto = 8
     seed = [0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA]
     key = seed
 
-    handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001, max_cto=max_cto))
+    handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001, max_cto=max_cto,
+                                   **{RESOURCE_PROTECTION_FLAG[resource]: True}))
     connect(handle)
 
     received_seed_lengths = []
@@ -329,9 +375,10 @@ def test_a_legitimate_multi_frame_get_seed_and_unlock_sequence_still_unlocks_the
                 received_seed_lengths, len(seed), seed, len(seed_slices)))
 
     status_response = exchange(handle, GET_STATUS)
-    assert status_response[2] == resource, (
-        'GET_STATUS reported protection_status=0x{:02X}, expected the requested resource 0x{:02X} '
-        'to be granted'.format(status_response[2], resource))
+    assert status_response[2] == 0x00, (
+        'GET_STATUS reported a protection mask of 0x{:02X} after a legitimate multi-frame '
+        'GET_SEED/UNLOCK for resource 0x{:02X}, which is the only group this build protects -- '
+        'expected 0x00, nothing left protected'.format(status_response[2], resource))
 
 
 def test_an_unlock_whose_calc_key_fails_answers_an_error_instead_of_a_stale_positive_response():
@@ -368,17 +415,24 @@ def test_an_unlock_whose_calc_key_fails_answers_an_error_instead_of_a_stale_posi
     1.0/1.7.3.2.1's seven listed UNLOCK error codes (verified against the 1.0 PDF, which
     pdftotext -layout extracts cleanly) fits an integrator callback failing outright, and why
     ERR_GENERIC is the same recorded deviation DD57 already uses for PROGRAM_RESET's identical
-    shape of problem (source/Xcp_Pgm.c)."""
+    shape of problem (source/Xcp_Pgm.c).
+
+    DD78 configures PGM as protected (buildable since DD83) and runs the sequence against PGM
+    rather than CAL_PAG, so that "nothing was granted" is a claim this build can actually falsify:
+    GET_STATUS byte 2 is the Current Resource Protection Mask of 1.0/1.6.1.1.3, 1 = still
+    protected, and it must still read PGM (0x10) at the end. A grant slipping through would clear
+    that bit to 0x00. On the old, unprotected build the byte read 0x00 whether the failed UNLOCK
+    granted anything or not."""
     seed = [0x11, 0x22, 0x33, 0x44]
     key = [0x99]
 
-    handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001))
+    handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001, resource_protection_programming=True))
     connect(handle)
 
     handle.xcp_get_seed.side_effect = get_seed_side_effect_copy_ok(handle, seed)
     handle.xcp_calc_key.side_effect = calc_key_side_effect_fail(handle)
 
-    get_seed_response = exchange(handle, (0xF8, 0x00, CAL_PAG), length=2 + len(seed))
+    get_seed_response = exchange(handle, (0xF8, 0x00, PGM), length=2 + len(seed))
     assert get_seed_response[0:2] == (0xFF, len(seed))
 
     unlock_response = exchange(handle, (0xF7, len(key), *key), length=8)
@@ -391,9 +445,10 @@ def test_an_unlock_whose_calc_key_fails_answers_an_error_instead_of_a_stale_posi
                 unlock_response))
 
     status_response = exchange(handle, GET_STATUS)
-    assert status_response[2] == 0x00, (
-        'protection_status=0x{:02X} after a GET_SEED/UNLOCK exchange whose Xcp_CalcKey failed -- '
-        'nothing should have been granted'.format(status_response[2]))
+    assert status_response[2] == PGM, (
+        'protection mask=0x{:02X} after a GET_SEED/UNLOCK exchange whose Xcp_CalcKey failed -- '
+        'nothing should have been granted, so PGM (0x{:02X}) must still be protected'.format(
+                status_response[2], PGM))
 
 
 def test_a_failed_unlock_does_not_leave_a_stale_answer_for_whatever_reads_it_next():
@@ -433,17 +488,23 @@ def test_a_failed_unlock_does_not_leave_a_stale_answer_for_whatever_reads_it_nex
     issued -- the same unconditional discard the reissuing above relies on -- so this is refused
     with ERR_SEQUENCE before ever reaching Xcp_CalcKey again. It documents DD81's own interaction
     with the defect this test is named for, in the place a reader of that defect would look for
-    it."""
+    it.
+
+    DD78 configures PGM as protected (buildable since DD83) and runs the whole chain against PGM
+    rather than CAL_PAG, so the closing "nothing was ever granted" assertion is one this build can
+    falsify: GET_STATUS byte 2 is the Current Resource Protection Mask of 1.0/1.6.1.1.3, 1 = still
+    protected, and PGM's own bit (0x10) must survive all four probes. Any grant leaking out of the
+    chain clears it to 0x00; on the old, unprotected build the byte read 0x00 either way."""
     seed = [0x11, 0x22, 0x33, 0x44]
 
-    handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001))
+    handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001, resource_protection_programming=True))
     connect(handle)
 
     handle.xcp_get_seed.side_effect = get_seed_side_effect_copy_ok(handle, seed)
     handle.xcp_calc_key.side_effect = calc_key_side_effect_fail(handle)
 
     for attempt, key in enumerate(([0x99], [0x55], [0x11, 0x22])):
-        get_seed_response = exchange(handle, (0xF8, 0x00, CAL_PAG), length=2 + len(seed))
+        get_seed_response = exchange(handle, (0xF8, 0x00, PGM), length=2 + len(seed))
         assert get_seed_response[0:2] == (0xFF, len(seed)), (
             'GET_SEED before attempt #{} answered {}, expected a genuine fresh seed (0xFF, {}) -- '
             'DD81 now requires one before every attempt below, so this is asserted rather than '
@@ -462,9 +523,10 @@ def test_a_failed_unlock_does_not_leave_a_stale_answer_for_whatever_reads_it_nex
         'UNLOCK (DD81, source/Xcp_Std.c)'.format(no_fresh_seed_response))
 
     status_response = exchange(handle, GET_STATUS)
-    assert status_response[2] == 0x00, (
-        'protection_status=0x{:02X} after a chain of UNLOCK attempts whose Xcp_CalcKey always '
-        'failed -- nothing should ever have been granted'.format(status_response[2]))
+    assert status_response[2] == PGM, (
+        'protection mask=0x{:02X} after a chain of UNLOCK attempts whose Xcp_CalcKey always '
+        'failed -- nothing should ever have been granted, so PGM (0x{:02X}) must still be '
+        'protected'.format(status_response[2], PGM))
 
 
 def test_a_key_mismatch_still_answers_access_locked_not_the_calc_key_failure_code():

--- a/test/seed_key_defects_test.py
+++ b/test/seed_key_defects_test.py
@@ -405,29 +405,35 @@ def test_a_failed_unlock_does_not_leave_a_stale_answer_for_whatever_reads_it_nex
     Xcp_Internal.h -- see this file's own module docstring), so last_pid's value cannot be read
     directly; this observes the fix's effect through consequences instead.
 
-    What last_pid actually gates in Xcp_DTOCmdStdUnlock is membership in
-    {GET_SEED, UNLOCK} (source/Xcp_Std.c's own `if ((last_pid == GET_SEED) || (last_pid ==
-    UNLOCK))`), by design admitting a FURTHER unlock attempt whenever last_pid is already UNLOCK's
-    own pid -- 1.0/1.6.1.2.5's own multi-frame key continuation, and the same mechanism
-    test_a_failed_get_seed_does_not_let_a_stale_admission_grant_the_resource_it_requested above
-    already exercises. Reaching Xcp_DTOCmdStdUnlock's own Xcp_CalcKey call at all -- pre-fix or
-    post-fix -- already requires last_pid to be GET_SEED or UNLOCK, and whichever of those two
-    member values it ends up as afterwards, a following UNLOCK is equally admitted through that
-    same membership test either way: last_pid landing on the WRONG one of its two admitted values
-    is not something Xcp_DTOCmdStdUnlock's own gate can ever tell apart (confirmed by direct trace
-    and empirically, both ways, while investigating this task -- see task-7-report.md). So a bare
-    "does a following UNLOCK get admitted" probe cannot isolate this leg the way
-    DD72's own two tests isolate its two legs -- unlike GET_SEED failing, which (immediately after
-    CONNECT) can flip last_pid from OUTSIDE that set to inside it, UNLOCK failing never can, since
-    reaching its own failure path already means last_pid was inside the set to begin with.
+    DD81 (source/Xcp_Std.c, task-2-report.md) changed what "a following UNLOCK gets admitted"
+    means: admission now also requires Xcp_Internal.seed.total_length != 0, and
+    Xcp_DTOCmdStdUnlock discards that field once a full key has been received, success or failure
+    alike. Before DD81 this test relied on exactly the gap DD81 closes: last_pid staying at
+    UNLOCK's own pid after a failed attempt was, on its own, enough to admit the next attempt with
+    no seed behind it at all, which is how one GET_SEED used to be stretched across all three
+    probes below. That route is gone -- a chain of failed UNLOCKs sharing one seed now stops
+    reaching Xcp_CalcKey after its first member, which would silently cut this test's coverage of
+    DD76 (task 7, the defect this test exists to keep fixed) from three probes of the stale-answer
+    property to one. So each attempt below reissues its own GET_SEED first, asserting it is
+    genuinely honoured rather than assuming it: Xcp_DTOCmdStdGetSeed(mode=0) (source/Xcp_Std.c)
+    has no dependency on last_pid or on anything an UNLOCK leaves behind, and a failed
+    Xcp_CalcKey does not disconnect the session (unlike a KEY MISMATCH,
+    Xcp_CheckMasterSlaveKeyMatch's own failure -- see
+    test_a_key_mismatch_still_answers_access_locked_not_the_calc_key_failure_code below), so this
+    is expected to succeed every time.
 
-    What the fix actually guarantees, and what this test pins instead: every dispatch that reads
-    byte 0 next -- including DD72's own gate, and including the following UNLOCK's own answer --
-    now sees the truth. A chain of failing UNLOCK attempts (fresh key bytes each time, no new
-    GET_SEED reissued in between -- Xcp_DTOCmdStdUnlock discards the seed once a full key has been
-    received, success or failure, so none would even be honoured) never again shows the stale
-    positive response the defect used to produce, on the first attempt or any later one, and
-    GET_STATUS confirms nothing is ever granted across the whole chain."""
+    What this still pins, unchanged from before DD81: every dispatch that reads byte 0 next --
+    including DD72's own gate, and including the following UNLOCK's own answer -- sees the truth.
+    A chain of failing UNLOCK attempts, each now with its own genuinely fresh seed, never again
+    shows the stale positive response DD76 used to produce, on the first attempt or any later one,
+    and GET_STATUS confirms nothing is ever granted across the whole chain.
+
+    The fourth probe is new, added alongside DD81: one more UNLOCK, after the chain, with no fresh
+    GET_SEED behind it. The last chain member's own completion already discarded the seed it was
+    issued -- the same unconditional discard the reissuing above relies on -- so this is refused
+    with ERR_SEQUENCE before ever reaching Xcp_CalcKey again. It documents DD81's own interaction
+    with the defect this test is named for, in the place a reader of that defect would look for
+    it."""
     seed = [0x11, 0x22, 0x33, 0x44]
 
     handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001))
@@ -436,15 +442,24 @@ def test_a_failed_unlock_does_not_leave_a_stale_answer_for_whatever_reads_it_nex
     handle.xcp_get_seed.side_effect = get_seed_side_effect_copy_ok(handle, seed)
     handle.xcp_calc_key.side_effect = calc_key_side_effect_fail(handle)
 
-    get_seed_response = exchange(handle, (0xF8, 0x00, CAL_PAG), length=2 + len(seed))
-    assert get_seed_response[0:2] == (0xFF, len(seed))
-
     for attempt, key in enumerate(([0x99], [0x55], [0x11, 0x22])):
+        get_seed_response = exchange(handle, (0xF8, 0x00, CAL_PAG), length=2 + len(seed))
+        assert get_seed_response[0:2] == (0xFF, len(seed)), (
+            'GET_SEED before attempt #{} answered {}, expected a genuine fresh seed (0xFF, {}) -- '
+            'DD81 now requires one before every attempt below, so this is asserted rather than '
+            'assumed'.format(attempt, get_seed_response, len(seed)))
+
         unlock_response = exchange(handle, (0xF7, len(key), *key), length=8)
         assert unlock_response[0:2] == (0xFE, 0x31), (
             'UNLOCK attempt #{} (key={}) answered {}, expected (0xFE, 0x31) [ERR_GENERIC] again -- '
             'a stale answer from an earlier exchange would show up here as something else, most '
             'likely a positive (0xFF, ...) reply nobody computed'.format(attempt, key, unlock_response))
+
+    no_fresh_seed_response = exchange(handle, (0xF7, 0x01, 0x01), length=8)
+    assert no_fresh_seed_response[0:2] == (0xFE, 0x29), (
+        'UNLOCK with no fresh GET_SEED behind it answered {}, expected (0xFE, 0x29) [ERR_SEQUENCE] '
+        '-- the last chain attempt already discarded its own seed on completion, same as any other '
+        'UNLOCK (DD81, source/Xcp_Std.c)'.format(no_fresh_seed_response))
 
     status_response = exchange(handle, GET_STATUS)
     assert status_response[2] == 0x00, (

--- a/test/seed_key_lifetime_test.py
+++ b/test/seed_key_lifetime_test.py
@@ -94,3 +94,80 @@ def test_an_unlock_does_not_survive_a_reconnect():
 
     assert exchange(handle, DOWNLOAD)[0:2] == (0xFE, 0x25), \
         'the grant outlived the session that earned it'
+
+
+def test_unlock_with_no_preceding_get_seed_is_refused():
+    """DD81, and the defect section 3b of the previous branch recorded and deliberately left
+    unfixed. XCP part 2 1.0/1.6.1.2.5: "The master only can send an UNLOCK sequence if previously
+    there was a GET_SEED sequence... If the master does not respect this sequence, the slave
+    returns an ERR_SEQUENCE."
+
+    ERR_SEQUENCE needs no deviation: it is in UNLOCK's own 1.7.3.2.1 row, and that row's prescribed
+    pre-action for it is literally GET_SEED, so the refusal tells the master exactly what to do."""
+    handle = cal_protected_handle()
+    handle.xcp_calc_key.side_effect = calc_key_side_effect_copy_ok(handle, KEY)
+
+    assert exchange(handle, (0xF7, len(KEY)) + tuple(KEY))[0:2] == (0xFE, 0x29), 'ERR_SEQUENCE'
+    assert exchange(handle, DOWNLOAD)[0:2] == (0xFE, 0x25), \
+        'the resource was granted by an UNLOCK against a seed that was never issued'
+
+
+def test_a_second_unlock_without_a_fresh_seed_is_refused():
+    """The seed is spent by the UNLOCK that consumes it -- Xcp_DTOCmdStdUnlock already zeroes
+    seed.total_length on a complete key, under a comment saying it "enforces a new seed to be
+    requested prior to unlock a next resource". Nothing ever checked it. This is that check."""
+    handle = cal_protected_handle()
+    unlock_cal_pag(handle)
+
+    assert exchange(handle, (0xF7, len(KEY)) + tuple(KEY))[0:2] == (0xFE, 0x29), 'ERR_SEQUENCE'
+
+
+def test_a_legitimate_multi_frame_key_is_still_admitted():
+    """The guard must not break a key too long for one frame. At MAX_CTO=8 a frame carries at most
+    MAX_CTO-2 = 6 key bytes, so a 10-byte key needs two UNLOCK frames; seed.total_length stays
+    non-zero across the whole sequence and is zeroed only on completion, so every frame is
+    admitted. Without this test the guard could be written to admit only the FIRST frame and both
+    tests above would still pass."""
+    handle = cal_protected_handle()
+    long_key = [0xA0 + i for i in range(10)]
+
+    handle.xcp_get_seed.side_effect = get_seed_side_effect_copy_ok(handle, SEED)
+    handle.xcp_calc_key.side_effect = calc_key_side_effect_copy_ok(handle, long_key)
+
+    assert exchange(handle, (0xF8, 0x00, 0x01))[0] == 0xFF
+    assert exchange(handle, (0xF7, 10) + tuple(long_key[0:6]))[0] == 0xFF, 'first UNLOCK frame'
+    assert exchange(handle, (0xF7, 4) + tuple(long_key[6:10]))[0] == 0xFF, 'second UNLOCK frame'
+
+    assert exchange(handle, DOWNLOAD)[0] == 0xFF, 'a legitimate multi-frame unlock was refused'
+
+
+def test_an_unlock_after_get_status_is_refused_despite_a_held_seed():
+    """Isolates the last_pid conjunct alone -- coordinator ruling on task-2-report.md's mutation 2,
+    which found that conjunct unpinned by every scenario in this file: dropping it left all seven
+    tests above passing regardless, because each one's seed.total_length happens to already agree
+    with what last_pid alone would have decided.
+
+    GET_STATUS is MASK_NONE (always reachable, this file's own module docstring) and
+    Xcp_CTOCmdStdGetStatus (source/Xcp_Std.c) never reads or writes Xcp_Internal.seed -- so it
+    leaves a just-issued seed exactly as GET_SEED left it. But it is a dispatch like any other, and
+    always answers positively, so Xcp_CanIfRxIndication's DD72 gate (source/Xcp.c), which advances
+    last_pid past any dispatch whose own response byte 0 is not XCP_PID_ERROR, advances it to
+    GET_STATUS's own pid (0xFD). The UNLOCK that follows therefore satisfies the seed.total_length
+    conjunct (a seed is genuinely held, untouched) and fails only the last_pid conjunct (0xFD is
+    outside {GET_SEED, UNLOCK}) -- the one scenario in this file where the two conjuncts disagree,
+    so only a gate that checks both refuses it. Confirmed empirically, not just by trace: with
+    task-2-report.md's mutation 2 reapplied (last_pid terms dropped, only seed.total_length !=
+    0x00u kept), this test fails -- see the report's update for that run.
+
+    xcp_calc_key is armed to succeed with a matching key, not left unconfigured: if the last_pid
+    conjunct were ever dropped, this UNLOCK would be admitted, reach Xcp_CalcKey and match,
+    answering a clean (0xFF, ...) -- an unambiguous positive, not an artifact of an unconfigured
+    mock -- so a broken gate cannot pass this test by accident."""
+    handle = cal_protected_handle()
+    handle.xcp_get_seed.side_effect = get_seed_side_effect_copy_ok(handle, SEED)
+    handle.xcp_calc_key.side_effect = calc_key_side_effect_copy_ok(handle, KEY)
+
+    assert exchange(handle, (0xF8, 0x00, 0x01))[0] == 0xFF, 'GET_SEED(mode=0, CAL_PAG)'
+    assert exchange(handle, GET_STATUS)[0] == 0xFF, 'GET_STATUS'
+
+    assert exchange(handle, (0xF7, len(KEY)) + tuple(KEY))[0:2] == (0xFE, 0x29), 'ERR_SEQUENCE'

--- a/test/seed_key_lifetime_test.py
+++ b/test/seed_key_lifetime_test.py
@@ -144,8 +144,12 @@ def test_a_legitimate_multi_frame_key_is_still_admitted():
 def test_an_unlock_after_get_status_is_refused_despite_a_held_seed():
     """Isolates the last_pid conjunct alone -- coordinator ruling on task-2-report.md's mutation 2,
     which found that conjunct unpinned by every scenario in this file: dropping it left all seven
-    tests above passing regardless, because each one's seed.total_length happens to already agree
-    with what last_pid alone would have decided.
+    tests above passing regardless. In six of them the two conjuncts simply agree, so
+    seed.total_length alone decides exactly what last_pid alone would have decided. In the seventh,
+    test_a_second_unlock_without_a_fresh_seed_is_refused, they disagree -- last_pid is still
+    UNLOCK's own pid and so admits, while the seed was discarded by the UNLOCK that consumed it --
+    but the AND is false there only because the seed conjunct dominates, which is again a refusal
+    seed.total_length produces on its own.
 
     GET_STATUS is MASK_NONE (always reachable, this file's own module docstring) and
     Xcp_CTOCmdStdGetStatus (source/Xcp_Std.c) never reads or writes Xcp_Internal.seed -- so it
@@ -154,8 +158,9 @@ def test_an_unlock_after_get_status_is_refused_despite_a_held_seed():
     last_pid past any dispatch whose own response byte 0 is not XCP_PID_ERROR, advances it to
     GET_STATUS's own pid (0xFD). The UNLOCK that follows therefore satisfies the seed.total_length
     conjunct (a seed is genuinely held, untouched) and fails only the last_pid conjunct (0xFD is
-    outside {GET_SEED, UNLOCK}) -- the one scenario in this file where the two conjuncts disagree,
-    so only a gate that checks both refuses it. Confirmed empirically, not just by trace: with
+    outside {GET_SEED, UNLOCK}) -- the one scenario in this file where they disagree in THIS
+    direction, last_pid refusing what the seed conjunct would have admitted, so only a gate that
+    checks both refuses it. Confirmed empirically, not just by trace: with
     task-2-report.md's mutation 2 reapplied (last_pid terms dropped, only seed.total_length !=
     0x00u kept), this test fails -- see the report's update for that run.
 
@@ -199,7 +204,20 @@ def test_get_status_reports_nothing_protected_when_nothing_is_configured_protect
     initial condition: byte 2 reads 0x00 before any unlock on the defective code too, so the first
     assertion alone passes either way. It is kept as a precondition -- an UNLOCK that is refused
     would leave 0x00 standing for the wrong reason -- and the second assertion is the one that
-    measures the defect. UNLOCK's own answer is asserted positive for the same reason."""
+    measures the defect. UNLOCK's own answer is asserted positive for the same reason.
+
+    That precondition checks TWO bytes, not just the PID. On a DD76-shaped regression -- UNLOCK's
+    handler writing nothing into the shared cto_response buffer while responseExpected stays TRUE
+    (source/Xcp_Std.c; the exact defect test/seed_key_defects_test.py's
+    test_an_unlock_whose_calc_key_fails_answers_an_error_instead_of_a_stale_positive_response
+    exists for) -- the frame transmitted here is the PREVIOUS command's, i.e. GET_SEED's own
+    (0xFF, 0x02, 0x11, 0x22, ...). Its byte 0 is 0xFF too, so a PID-only guard admits it, the
+    UNLOCK never ran, and the closing assertion below would then pass vacuously: on this build
+    byte 2 is 0x00 whether anything was granted or not, which is precisely the state this test is
+    supposed to be measuring against. exchange()'s own reset_mock cannot catch that -- the
+    staleness is in the C-side buffer, not the Python mock. UNLOCK's byte 1 is the remaining
+    protection mask, 0x00 on a build that protects nothing, while GET_SEED's byte 1 is len(SEED)
+    == 2, so the pair tells the two frames apart."""
     handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001))
     connect(handle)
 
@@ -208,8 +226,8 @@ def test_get_status_reports_nothing_protected_when_nothing_is_configured_protect
     handle.xcp_get_seed.side_effect = get_seed_side_effect_copy_ok(handle, SEED)
     handle.xcp_calc_key.side_effect = calc_key_side_effect_copy_ok(handle, KEY)
 
-    assert exchange(handle, (0xF8, 0x00, 0x10))[0] == 0xFF, 'GET_SEED(mode=0, PGM)'
-    assert exchange(handle, (0xF7, len(KEY)) + tuple(KEY))[0] == 0xFF, 'UNLOCK(PGM)'
+    assert exchange(handle, (0xF8, 0x00, 0x10))[0:2] == (0xFF, len(SEED)), 'GET_SEED(mode=0, PGM)'
+    assert exchange(handle, (0xF7, len(KEY)) + tuple(KEY))[0:2] == (0xFF, 0x00), 'UNLOCK(PGM)'
 
     assert exchange(handle, GET_STATUS, length=3)[2] == 0x00, \
         'PGM was reported protected on a build that does not protect it'

--- a/test/seed_key_lifetime_test.py
+++ b/test/seed_key_lifetime_test.py
@@ -171,3 +171,95 @@ def test_an_unlock_after_get_status_is_refused_despite_a_held_seed():
     assert exchange(handle, GET_STATUS)[0] == 0xFF, 'GET_STATUS'
 
     assert exchange(handle, (0xF7, len(KEY)) + tuple(KEY))[0:2] == (0xFE, 0x29), 'ERR_SEQUENCE'
+
+
+def test_get_status_reports_which_resources_are_still_protected():
+    """DD82. XCP part 2 1.0/1.6.1.1.3 defines the Current Resource Protection Status as a mask
+    where 1 = the group IS protected, and 1.6.1.2.5 makes UNLOCK's positive response carry that
+    same mask. The module reported the UNLOCKED set instead -- so after unlocking CAL_PAG it said
+    CAL_PAG was protected, at the moment it stopped being."""
+    handle = cal_protected_handle()
+
+    assert exchange(handle, GET_STATUS, length=3)[2] == 0x01, \
+        'CAL_PAG is configured protected and nothing has been unlocked'
+
+    unlock_cal_pag(handle)
+
+    assert exchange(handle, GET_STATUS, length=3)[2] == 0x00, \
+        'CAL_PAG was reported protected after being unlocked'
+
+
+def test_get_status_reports_nothing_protected_when_nothing_is_configured_protected():
+    """The domain half of the defect, not just the direction. In a build where no resource is
+    protected -- test/parameter.py's DefaultConfig, which is what almost the whole suite runs --
+    unlocking PGM used to make this byte report 0x10, claiming a protection the build does not
+    have.
+
+    The GET_SEED/UNLOCK round below is what makes this test the domain half rather than a restated
+    initial condition: byte 2 reads 0x00 before any unlock on the defective code too, so the first
+    assertion alone passes either way. It is kept as a precondition -- an UNLOCK that is refused
+    would leave 0x00 standing for the wrong reason -- and the second assertion is the one that
+    measures the defect. UNLOCK's own answer is asserted positive for the same reason."""
+    handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001))
+    connect(handle)
+
+    assert exchange(handle, GET_STATUS, length=3)[2] == 0x00
+
+    handle.xcp_get_seed.side_effect = get_seed_side_effect_copy_ok(handle, SEED)
+    handle.xcp_calc_key.side_effect = calc_key_side_effect_copy_ok(handle, KEY)
+
+    assert exchange(handle, (0xF8, 0x00, 0x10))[0] == 0xFF, 'GET_SEED(mode=0, PGM)'
+    assert exchange(handle, (0xF7, len(KEY)) + tuple(KEY))[0] == 0xFF, 'UNLOCK(PGM)'
+
+    assert exchange(handle, GET_STATUS, length=3)[2] == 0x00, \
+        'PGM was reported protected on a build that does not protect it'
+
+
+def test_unlock_answers_the_remaining_protection_mask():
+    """1.6.1.2.5: "The answer upon UNLOCK contains the Current Resource Protection Mask as
+    described at GET_STATUS." Byte 1 of UNLOCK's positive response, same polarity as above."""
+    handle = cal_protected_handle()
+    handle.xcp_get_seed.side_effect = get_seed_side_effect_copy_ok(handle, SEED)
+    handle.xcp_calc_key.side_effect = calc_key_side_effect_copy_ok(handle, KEY)
+
+    assert exchange(handle, (0xF8, 0x00, 0x01))[0] == 0xFF
+    assert exchange(handle, (0xF7, len(KEY)) + tuple(KEY))[0:2] == (0xFF, 0x00), \
+        'UNLOCK reported the granted resource instead of what remains protected'
+
+
+def test_unlocking_a_second_resource_keeps_the_first_one_granted():
+    """The mask ACCUMULATES grants: unlocking DAQ must clear only DAQ's own bit, leaving CAL_PAG's
+    grant standing. The inverted field's own writer was `|=` for exactly this reason (DD79); the
+    inversion turns that into `&= ~mask` (Xcp_UnlockResources, source/Xcp.c), and an implementation
+    that assigned instead would re-lock CAL_PAG here while still answering every single-resource
+    test in this file identically.
+
+    Both halves of "still granted" are checked, because they are two different readers of the same
+    mask and either could regress alone: the dispatch gate (a MASK_CAL_PAG command, DOWNLOAD, must
+    still be admitted) and GET_STATUS byte 2, which must read 0x00 -- nothing left protected -- and
+    not 0x01, CAL_PAG protected again.
+
+    Two full GET_SEED/UNLOCK rounds, not one seed stretched over two UNLOCKs: DD81 discards the
+    seed on every completed key, so the second unlock needs a seed of its own or it is refused
+    ERR_SEQUENCE before it ever reaches Xcp_CalcKey."""
+    handle = cal_protected_handle(resource_protection_data_acquisition=True)
+
+    assert exchange(handle, GET_STATUS, length=3)[2] == 0x05, \
+        'CAL_PAG (0x01) and DAQ (0x04) are both configured protected and nothing is unlocked yet'
+
+    unlock_cal_pag(handle)
+
+    assert exchange(handle, GET_STATUS, length=3)[2] == 0x04, \
+        'CAL_PAG was unlocked, so only DAQ must remain protected'
+
+    handle.xcp_get_seed.side_effect = get_seed_side_effect_copy_ok(handle, SEED)
+    handle.xcp_calc_key.side_effect = calc_key_side_effect_copy_ok(handle, KEY)
+
+    assert exchange(handle, (0xF8, 0x00, 0x04))[0] == 0xFF, 'GET_SEED(mode=0, DAQ)'
+    assert exchange(handle, (0xF7, len(KEY)) + tuple(KEY))[0:2] == (0xFF, 0x00), \
+        'UNLOCK(DAQ) must answer an empty remaining-protection mask, both groups now granted'
+
+    assert exchange(handle, DOWNLOAD)[0] == 0xFF, \
+        'the CAL_PAG grant was dropped by the DAQ unlock that followed it'
+    assert exchange(handle, GET_STATUS, length=3)[2] == 0x00, \
+        'GET_STATUS reported CAL_PAG protected again after DAQ was unlocked'

--- a/test/seed_key_lifetime_test.py
+++ b/test/seed_key_lifetime_test.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""DD79 (docs/superpowers/specs/2026-09-08-xcp-seed-key-hardening-design.md) -- a pre-existing
+defect in shipped code: a successful UNLOCK grants a resource for exactly ONE following command.
+
+source/Xcp.c cleared the whole granted set after every dispatched command except UNLOCK itself, so
+an unrelated GET_STATUS spent the grant just as a CAL command did. XCP part 2 - Protocol Layer
+Specification 1.0/1.6.1.2.5 says the opposite: "a repetition of an UNLOCK sequence with a correct
+key will have a positive response and no other effect", which presumes the grant is still standing.
+
+DOWNLOAD (0xF0) is the protected observable throughout this file: Xcp_PIDToCmdGroupTable
+(source/Xcp.c) maps it to MASK_CAL_PAG, while SET_MTA (0xF6) and GET_STATUS (0xFD) map to
+MASK_NONE, so the setup and the interloper both stay reachable while CAL_PAG is locked."""
+
+from .parameter import *
+from .conftest import XcpTest
+from .download_test import connect, set_mta
+from .seed_key_test import get_seed_side_effect_copy_ok, calc_key_side_effect_copy_ok
+from .seed_key_defects_test import exchange
+
+GET_STATUS = (0xFD,)
+DOWNLOAD = (0xF0, 0x03, 0x11, 0x22, 0x33)
+SEED = [0x11, 0x22]
+KEY = [0x33, 0x44]
+
+
+def cal_protected_handle(**kwargs):
+    """A slave whose CALibration/Paging group is protected, connected and with a valid MTA.
+
+    The MTA is set BEFORE any unlock deliberately: SET_MTA is MASK_NONE, so it must succeed while
+    CAL_PAG is still locked, and doing it here keeps every DOWNLOAD below a test of the protection
+    gate rather than of address setup."""
+    handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001,
+                                   resource_protection_calibration_paging=True,
+                                   **kwargs))
+    connect(handle)
+    set_mta(handle, 0x1000)
+    return handle
+
+
+def unlock_cal_pag(handle):
+    """A complete GET_SEED/UNLOCK sequence for CAL_PAG, asserting each half so a failure here is
+    never mistaken for the behaviour under test."""
+    handle.xcp_get_seed.side_effect = get_seed_side_effect_copy_ok(handle, SEED)
+    handle.xcp_calc_key.side_effect = calc_key_side_effect_copy_ok(handle, KEY)
+
+    assert exchange(handle, (0xF8, 0x00, 0x01))[0] == 0xFF, 'GET_SEED(mode=0, CAL_PAG)'
+    assert exchange(handle, (0xF7, len(KEY)) + tuple(KEY))[0] == 0xFF, 'UNLOCK'
+
+
+def test_a_protected_command_is_refused_before_any_unlock():
+    """The precondition every other test in this file rests on. Without it, a DOWNLOAD that
+    succeeds proves nothing -- it would succeed identically if the resource were never protected,
+    which is exactly the configuration the rest of the suite runs in."""
+    handle = cal_protected_handle()
+
+    assert exchange(handle, DOWNLOAD)[0:2] == (0xFE, 0x25), 'ERR_ACCESS_LOCKED'
+
+
+def test_an_unlock_survives_an_unrelated_command():
+    """DD79, the defect itself. GET_STATUS is MASK_NONE and has no side effects, so the only thing
+    it can do to the DOWNLOAD that follows is spend its grant -- which is what it used to do."""
+    handle = cal_protected_handle()
+    unlock_cal_pag(handle)
+
+    assert exchange(handle, DOWNLOAD)[0] == 0xFF, 'the first protected command after UNLOCK'
+    assert exchange(handle, GET_STATUS)[0] == 0xFF
+    assert exchange(handle, DOWNLOAD)[0] == 0xFF, \
+        'the grant was spent by an unrelated GET_STATUS'
+
+
+def test_an_unlock_survives_repeated_use_of_the_protected_resource():
+    """The grant must not be consumed by the protected command either -- a variant the
+    single-command lifetime also broke, and one a master doing a real calibration session hits
+    immediately."""
+    handle = cal_protected_handle()
+    unlock_cal_pag(handle)
+
+    for attempt in range(5):
+        assert exchange(handle, DOWNLOAD)[0] == 0xFF, \
+            'DOWNLOAD number {} was refused'.format(attempt + 1)
+
+
+def test_an_unlock_does_not_survive_a_reconnect():
+    """The other half of DD79: the grant lasts the SESSION, not forever. This is the same session
+    boundary DD77 established, and the reset joins that block."""
+    handle = cal_protected_handle()
+    unlock_cal_pag(handle)
+    assert exchange(handle, DOWNLOAD)[0] == 0xFF
+
+    connect(handle)
+    set_mta(handle, 0x1000)
+
+    assert exchange(handle, DOWNLOAD)[0:2] == (0xFE, 0x25), \
+        'the grant outlived the session that earned it'

--- a/test/seed_key_test.py
+++ b/test/seed_key_test.py
@@ -28,6 +28,22 @@ def calc_key_side_effect_copy_ok(handle, key):
     return wrapper
 
 
+# DD78. The resource_protection_* flag that makes each member of `resources` (test/parameter.py)
+# genuinely protected, so that a test parametrised over a resource can also configure that resource
+# -- what GET_STATUS byte 2 and UNLOCK response byte 1 report is the Current Resource Protection
+# Mask of XCP part 2 1.0/1.6.1.1.3 (1 = still protected), which says nothing about a group the build
+# never protected.
+#
+# All four are buildable on DefaultConfig, STIM included: script/source_cfg.c.jinja2 refuses
+# resource_protection.data_stimulation only when the build is `stim.capable`, which for a STATIC
+# configuration means at least one entry of `daqs` with a type other than 'DAQ'. DefaultConfig's own
+# single list is a plain DAQ list, so the refusal (DD41/DD48) does not fire here.
+RESOURCE_PROTECTION_FLAG = {0x01: 'resource_protection_calibration_paging',
+                            0x04: 'resource_protection_data_acquisition',
+                            0x08: 'resource_protection_data_stimulation',
+                            0x10: 'resource_protection_programming'}
+
+
 @pytest.mark.parametrize('resource', resources)
 @pytest.mark.parametrize('max_cto', max_ctos)
 @pytest.mark.parametrize('seed', seeds, indirect=True)
@@ -110,9 +126,24 @@ def test_get_seed_does_not_return_an_error_pid_if_the_first_part_of_the_seed_is_
 @pytest.mark.parametrize('max_cto', max_ctos)
 @pytest.mark.parametrize('seed', seeds, indirect=True)
 def test_unlock_unlocks_the_requested_resource_if_the_key_is_valid(resource, max_cto, seed):
+    """DD78. The resource under test is configured protected, and the two assertions below read the
+    Current Resource Protection Mask of XCP part 2 1.0/1.6.1.1.3 -- 1 = the group IS protected --
+    which 1.6.1.2.5 makes UNLOCK's positive response carry as well.
+
+    Both inverted with the field they read, and the pair still discriminates a partial key from a
+    complete one, in the opposite direction: while frames are still outstanding the resource is
+    reported STILL LOCKED (0xFF, resource), and only the frame that completes the key reports
+    (0xFF, 0x00) -- nothing left protected. Protecting the resource is what makes either byte mean
+    anything: on a build that protects nothing this mask is 0x00 from CONNECT onwards, so both
+    assertions would read 0x00 and neither would tell a granted resource from a refused one, nor a
+    partial frame from the final one.
+
+    That the byte reaches 0x00 also proves the RIGHT resource was released: `resource` is the only
+    bit in the mask, so any other group being cleared instead would leave it standing."""
     key = seed
 
-    handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001, max_cto=max_cto))
+    handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001, max_cto=max_cto,
+                                   **{RESOURCE_PROTECTION_FLAG[resource]: True}))
 
     handle.xcp_get_seed.side_effect = get_seed_side_effect_copy_ok(handle, seed)
     handle.xcp_calc_key.side_effect = calc_key_side_effect_copy_ok(handle, key)
@@ -141,9 +172,14 @@ def test_unlock_unlocks_the_requested_resource_if_the_key_is_valid(resource, max
         remaining_key_length -= len(key_slice)
 
         if remaining_key_length != 0:
-            assert tuple(handle.can_if_transmit.call_args[0][1].SduDataPtr[0:2]) == (0xFF, 0x00)
+            assert tuple(handle.can_if_transmit.call_args[0][1].SduDataPtr[0:2]) == (0xFF, resource), (
+                'an UNLOCK frame with {} key bytes still outstanding must report resource 0x{:02X} '
+                'STILL protected -- nothing is granted until the key is complete'.format(
+                        remaining_key_length, resource))
 
-    assert tuple(handle.can_if_transmit.call_args[0][1].SduDataPtr[0:2]) == (0xFF, resource)
+    assert tuple(handle.can_if_transmit.call_args[0][1].SduDataPtr[0:2]) == (0xFF, 0x00), (
+        'the UNLOCK completing the key must report an empty protection mask -- resource 0x{:02X} '
+        'was the only protected group on this build and has just been granted'.format(resource))
 
 
 @pytest.mark.parametrize('resource', resources)

--- a/test/session_teardown_test.py
+++ b/test/session_teardown_test.py
@@ -76,6 +76,7 @@ from .seed_key_test import get_seed_key_slices, get_seed_side_effect_copy_ok, ca
 from .seed_key_defects_test import exchange
 
 CAL_PAG = 0x01
+PGM = 0x10
 GET_STATUS = (0xFD,)
 
 
@@ -390,8 +391,21 @@ def test_a_normal_session_still_works_end_to_end_after_a_reconnect():
     the most likely way to get this task wrong: a teardown that clears too much breaks exactly the
     ordinary session it exists to protect. CONNECT, SET_MTA, DOWNLOAD, GET_SEED, UNLOCK -- a
     complete, legitimate sequence, run entirely in the SECOND of two sessions so that every one of
-    this task's own resets has already run at least once before any of these commands does."""
-    handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001, max_cto=8))
+    this task's own resets has already run at least once before any of these commands does.
+
+    DD78 configures PGM as protected and points the GET_SEED/UNLOCK round at PGM, so that UNLOCK's
+    own byte 1 -- the Current Resource Protection Mask of 1.0/1.6.1.1.3, 1 = still protected --
+    measures the grant rather than reading 0x00 on a build with nothing to protect. PGM rather than
+    CAL_PAG because DOWNLOAD above is MASK_CAL_PAG (Xcp_PIDToCmdGroupTable, source/Xcp.c) and is
+    deliberately sent BEFORE the unlock: protecting CAL_PAG would make it answer ERR_ACCESS_LOCKED
+    and turn this test into a protection test instead of the end-to-end session it is. No
+    PGM-group command is sent here, so the flag is inert apart from the mask -- which is the point.
+
+    The mask is also a genuine reconnect check now: Xcp_CTOCmdStdConnect (source/Xcp_Std.c)
+    re-seeds it from the configuration at the session boundary, so PGM being protected at all in
+    this second session is itself one of this task's own resets having run correctly."""
+    handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001, max_cto=8,
+                                   resource_protection_programming=True))
     connect(handle)
     disconnect(handle)
     connect(handle)
@@ -414,13 +428,14 @@ def test_a_normal_session_still_works_end_to_end_after_a_reconnect():
     handle.xcp_get_seed.side_effect = get_seed_side_effect_copy_ok(handle, key)
     handle.xcp_calc_key.side_effect = calc_key_side_effect_copy_ok(handle, key)
 
-    get_seed_response = exchange(handle, (0xF8, 0x00, CAL_PAG))
+    get_seed_response = exchange(handle, (0xF8, 0x00, PGM))
     assert get_seed_response[0:2] == (0xFF, len(key)), 'GET_SEED must still succeed'
 
     unlock_response = exchange(handle, (0xF7, len(key), *key))
-    assert unlock_response[0:2] == (0xFF, CAL_PAG), (
+    assert unlock_response[0:2] == (0xFF, 0x00), (
         'a legitimate GET_SEED/UNLOCK sequence must still grant the resource it requested after '
-        'a reconnect -- got {}'.format(unlock_response))
+        'a reconnect -- PGM is this build\'s only protected group, so an empty protection mask is '
+        'what a grant looks like; got {}'.format(unlock_response))
 
 
 def test_get_id_does_not_leak_the_previous_commands_address_extension():

--- a/test/session_teardown_test.py
+++ b/test/session_teardown_test.py
@@ -401,9 +401,12 @@ def test_a_normal_session_still_works_end_to_end_after_a_reconnect():
     and turn this test into a protection test instead of the end-to-end session it is. No
     PGM-group command is sent here, so the flag is inert apart from the mask -- which is the point.
 
-    The mask is also a genuine reconnect check now: Xcp_CTOCmdStdConnect (source/Xcp_Std.c)
-    re-seeds it from the configuration at the session boundary, so PGM being protected at all in
-    this second session is itself one of this task's own resets having run correctly."""
+    What the mask here does NOT show is that Xcp_CTOCmdStdConnect's own re-seed of it
+    (source/Xcp_Std.c) ran: the first session unlocks nothing, so locked_resource holds PGM's bit
+    from Xcp_Init onward and every assertion below reads the same with that re-seed deleted. The
+    re-seed is pinned elsewhere, by
+    test/seed_key_lifetime_test.py::test_an_unlock_does_not_survive_a_reconnect, which unlocks in
+    the first session and requires the second to refuse the protected command again."""
     handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001, max_cto=8,
                                    resource_protection_programming=True))
     connect(handle)


### PR DESCRIPTION
> **#17 has merged; this now targets `develop` directly and is mergeable.**
> It was opened stacked on `feature/xcp-pgm-sp4b`, because it imports from and
> substantially modifies files that existed only there
> (`test/seed_key_defects_test.py` alone changes by ~393 lines). No rebase was
> needed on retarget: `develop`'s merge-base with this branch is exactly the
> commit it was built on, so the seven commits below apply unchanged.

Three pre-existing defects in one subsystem, all shipped, all answering the
same question badly — **what does the resource-protection field mean, and how
long does it last?** Because they share one field they share one design, and
fixing any of them alone would have left its meaning half-changed.

**Design:** `docs/superpowers/specs/2026-09-08-xcp-seed-key-hardening-design.md`
(DD78–DD83). **Plan:** `docs/superpowers/plans/2026-09-08-xcp-seed-key-hardening.md`.

## The defects

**An unlock was spent by the next command — any command.** Not just one that
used the grant: an unrelated `GET_STATUS` consumed it identically.
§1.6.1.2.5's *"a repetition of an UNLOCK sequence with a correct key will have
a positive response and no other effect"* presumes the grant is still standing
to be re-granted. It now lasts the session, and `CONNECT` re-locks from
configuration.

**`UNLOCK` never asked whether a seed was held.** Its only gate was a sequence
test on `last_pid`. §1.6.1.2.5 is explicit — *"The master only can send an
UNLOCK sequence if previously there was a GET_SEED sequence… the slave returns
an ERR_SEQUENCE"* — and `ERR_SEQUENCE` needs no deviation: it is in `UNLOCK`'s
own §1.7.3.2.1 row, whose prescribed pre-action is literally `GET_SEED`. This
is the defect the predecessor branch measured and deliberately left, because
the remedy needed a design decision.

The enforcement mechanism already existed and nothing consulted it:
`Xcp_Std.c` zeroes `seed.total_length` on a complete key, under a comment
saying it *"enforces a new seed to be requested prior to unlock a next
resource"*.

**The protection mask was reported inverted, at three sites.** §1.6.1.1.3
defines the mask as `1 = the group IS protected`, and §1.6.1.2.5 makes
`UNLOCK`'s response carry the same mask. The module wrote the *unlocked* set
into both `UNLOCK` response paths and `GET_STATUS` byte 2. In the default
build, where nothing is configured protected, unlocking PGM made `GET_STATUS`
report `0x10` — **claiming PGM is protected in a build where it is not, at the
moment it was granted.** Wrong in direction and in domain.

## And a configuration that could not be built

`resource_protection.programming: true` **refused to generate at all**. The
generator argued the unlock was spent by `PROGRAM_START`, leaving
`PROGRAM_RESET` locked while `GET_SEED`/`UNLOCK` were refused
`ERR_PGM_ACTIVE` — a programming session with no exit. Every link depended on
the grant being spent, so the first fix dissolves it. The refusal is deleted
and **proved obsolete by a nine-step run** — `CONNECT` → `GET_SEED(PGM)` →
`UNLOCK` → `PROGRAM_START` → `PROGRAM_CLEAR` → `PROGRAM` → `PROGRAM_RESET`,
with a pre-unlock `ERR_ACCESS_LOCKED` probe proving the protection was live
rather than absent.

The second generator refusal, for `data_stimulation` (DD41/DD48), is
**untouched and still fires** — it is true for an unrelated reason.

## The design decision worth reviewing

The field is **renamed**, not just re-signed: `protection_status` →
`locked_resource`, storing the still-protected mask. The alternative was to
keep it meaning "unlocked" and compute the inverse at each reporting site —
rejected because that preserves exactly the property that caused the bug, a
field whose readers must remember to invert it. Storing the wire value gives
three chances to get polarity wrong and makes them zero, and the rename turned
every existing reader into a compile error rather than silently-wrong
arithmetic.

The dispatch gate collapses to one term as a consequence:

```c
if ((Xcp_PIDToCmdGroupTable[pid] & Xcp_Internal.locked_resource) == 0x00u)
```

Equivalence was **checked, not assumed**: every one of the table's 256 entries
carries exactly one group bit or `MASK_NONE`, so old and new agree for every
PID. They diverge only on a multi-bit entry, where the new reading is the safe
one — recorded as an invariant the table must keep.

## What the final review found

No authentication bypass — every route tried terminates in the key check. But
it found one thing no per-task review structurally could: **DD81's new
conjunct had silently un-pinned both of the predecessor branch's DD72
regression tests.** The module was not weaker (the new guard subsumes DD72 for
those scenarios), but reverting either DD72 leg left every asserted byte
unchanged, while the tests' names claimed to isolate them. Both are re-pinned,
each proven by applying its own mutation and watching it fail, and each
verified insensitive to the *other* leg.

Re-pinning leg 1 needed a new test double: `GET_SEED` zeroes
`seed.total_length` *before* calling the integrator, so the existing failure
double destroyed the seed the test needed held — the "double that cannot
observe the thing under test" trap, hit again.

## Testing

**12902 passed, 29 skipped, 0 failed**, both ctest targets, via `./test.sh` in
the CI container on the integration tree.

Ten pre-existing tests were migrated because their assertions inverted — and
the suite came out **stronger**, not merely adjusted. They had been asserting a
protection byte in builds where nothing was configured protected, so the value
they checked was meaningless there. Each now configures the resource under
test and asserts a value that can falsify it. The largest, at 3060 node ids,
gained the ability to prove the *right* resource was released.

Every fix is mutation-verified, including **per term** of the new compound
condition rather than per outcome.

## Known, and shipped deliberately

- The new test mapping's STIM entry is buildable only while `DefaultConfig`
  has no non-DAQ list; if it gains one, the DD41/DD48 refusal fires at
  generation. Documented at the mapping — the failure would be loud.
- `Xcp_Init` leaves a stale mask if re-called with an invalid configuration
  mid-session. Not reachable by any master-driven sequence.
- One commit (`64dba6b`) lacks its `Co-Authored-By` trailer; it is not the tip
  and rewriting history for a trailer was disproportionate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
