### PR TITLE
Reset SELECTED once the store it was made for completes

### DIFF
--- a/interface/Xcp.h
+++ b/interface/Xcp.h
@@ -497,6 +497,10 @@ extern Std_ReturnType Xcp_ClearDaqConfiguration(uint8 *pStatusCode);
  * @details XCP part 2 - Protocol Layer Specification 1.1/1.6.4.1.1.4: the master sets this flag
  * with START_STOP_DAQ_LIST's SELECT mode. An integrator implementing @ref Xcp_StoreDaqConfiguration
  * queries it per list to decide what to store.
+ * @note The selection is reset once the store it was made for completes (XCP part 2 - Protocol
+ * Layer Specification 1.0/1.6.4.1.1.6), so this reports TRUE throughout the call to
+ * @ref Xcp_StoreDaqConfiguration that persists it, and FALSE afterwards. A store reporting a
+ * non-zero status leaves the selection standing, since it persisted nothing.
  * @param [in] daqListNumber DAQ list number
  * @return TRUE if the list is selected, FALSE otherwise or if daqListNumber is out of range
  */

--- a/source/Xcp.c
+++ b/source/Xcp.c
@@ -1622,6 +1622,27 @@ void Xcp_MainFunction(void)
                 {
                     Xcp_Internal.session_configuration_id_read_state = XCP_NV_READ_COMPLETE;
                 }
+
+                /* XCP part 2 - Protocol Layer Specification 1.0/1.6.4.1.1.6 (1.1/1.6.4.1.1.4)
+                 * "The slave has to reset the SELECTED flag in the mode at GET_DAQ_LIST_MODE as
+                 * soon as the related START_STOP_SYNCH or SET_REQUEST have been acknowledged."
+                 * Select is how the master marks the lists a store is to persist -- the same
+                 * section calls it "preparing the slave for RESUME mode (ref. SET_REQUEST)" -- so
+                 * a completed store has consumed the selection and must stop reporting it.
+                 *
+                 * Here rather than in Xcp_DTOCmdStdSetRequest (source/Xcp_Std.c), which is where
+                 * "acknowledged" would put it: the integrator's own Xcp_StoreDaqConfiguration
+                 * reads the selection back through Xcp_GetDaqListSelectedState to learn which
+                 * lists to persist (DD94), and it is still running until the call above returns
+                 * E_OK. Clearing at acknowledgement time would hand it a slave with nothing
+                 * selected, and it would faithfully store an empty configuration.
+                 *
+                 * Inside the zero-status branch, so a store that reported a failure leaves the
+                 * selection standing: it persisted nothing, so the master can retry the
+                 * SET_REQUEST without walking the whole Select sequence again. The specification
+                 * says "acknowledged" rather than "succeeded", so this is a reading, and it is the
+                 * same one session_configuration_id above takes for the same reason. */
+                Xcp_DaqClearAllSelections();
             }
 
             /* Same reasoning as the STORE_CAL_REQ push above: only the push itself goes inside the

--- a/source/Xcp_Daq.c
+++ b/source/Xcp_Daq.c
@@ -364,6 +364,28 @@ static void Xcp_DaqSessionStatusUpdate(void)
  * the same unwind -- see this function's declaration in Xcp_Internal.h for why, and
  * Xcp_CTOCmdStdDisconnect (source/Xcp_Std.c) for the other call site.
  */
+void Xcp_DaqClearAllSelections(void)
+{
+    uint16 idx;
+
+    /* XCP part 2 - Protocol Layer Specification 1.0/1.6.4.1.1.6 (1.1/1.6.4.1.1.4)
+     * "The slave has to reset the SELECTED flag in the mode at GET_DAQ_LIST_MODE as soon as the
+     * related START_STOP_SYNCH or SET_REQUEST have been acknowledged." Xcp_DTOCmdDaqStartStopSynch
+     * below covers the first; this covers the second, called from Xcp_MainFunction (source/Xcp.c)
+     * once STORE_DAQ_REQ's integrator callback reports a clean completion.
+     *
+     * It lives here rather than in the SET_REQUEST handler because the list mode byte is DAQ state
+     * and its other readers are in this file (DD63): a command group may not write shared state
+     * whose readers live outside its own file.
+     *
+     * Unconditional over every list, not only the selected ones: clearing a bit that is already
+     * clear costs the same as testing it first, and the loop then has no branch to get wrong. */
+    for (idx = 0x0000u; idx < Xcp_Ptr->general->daqCount; idx++)
+    {
+        Xcp_DaqListRt(idx)->mode &= (uint8)(~XCP_DAQ_LIST_MODE_SELECTED);
+    }
+}
+
 void Xcp_DaqFreeAll(void)
 {
     uint16 daq_idx;
@@ -482,10 +504,12 @@ void Xcp_DaqFreeAll(void)
  * @brief see interface/Xcp.h.
  * @details Selection is XCP_DAQ_LIST_MODE_SELECTED in the list's runtime mode byte
  * (Xcp_DaqListRtType::mode, interface/Xcp_Types.h), set by START_STOP_DAQ_LIST's SELECT mode
- * (Xcp_DTOCmdDaqStartStopDaqList below). A START_STOP_SYNCH resets it, and so does anything that
- * resets the list itself: Xcp_DaqListReset (above) zeroes the whole mode byte, so CLEAR_DAQ_LIST,
- * FREE_DAQ and Xcp_Init (via Xcp_DaqFreeAll) clear it too -- an integrator caching selection across
- * any of those would be wrong.
+ * (Xcp_DTOCmdDaqStartStopDaqList below). Three things reset it. 1.0/1.6.4.1.1.6 names two:
+ * START_STOP_SYNCH, and a completed STORE_DAQ_REQ (Xcp_DaqClearAllSelections above, called from
+ * Xcp_MainFunction, source/Xcp.c) -- both are an acknowledgement of the request the selection was
+ * made for. The third is anything that resets the list itself: Xcp_DaqListReset (above) zeroes the
+ * whole mode byte, so CLEAR_DAQ_LIST, FREE_DAQ and Xcp_Init (via Xcp_DaqFreeAll) clear it too.
+ * An integrator caching selection across any of them would be wrong.
  * @note Xcp_DaqListClearEntries above already lives in this section despite external linkage,
  * because Xcp_Init needs it. This function and the three that follow it are external for a
  * different reason: they are public accessors an integrator calls directly (design doc DD94,

--- a/source/Xcp_Internal.h
+++ b/source/Xcp_Internal.h
@@ -1064,6 +1064,17 @@ uint8 Xcp_DTOCmdDaqClearDaqList(boolean *responseExpected, const PduInfoType *pP
  * to release, and clearing its generated DAQ entries on disconnect would be a behaviour change to
  * the static model that SP2d is required not to make (DD25).
  */
+/**
+ * @brief resets the SELECTED flag on every DAQ list.
+ * @details XCP part 2 - Protocol Layer Specification 1.0/1.6.4.1.1.6 (1.1/1.6.4.1.1.4) requires the
+ * SELECTED flag GET_DAQ_LIST_MODE reports to be reset "as soon as the related START_STOP_SYNCH or
+ * SET_REQUEST have been acknowledged". Xcp_MainFunction (source/Xcp.c) calls this once
+ * STORE_DAQ_REQ's callback reports a clean completion -- not when SET_REQUEST answers, because the
+ * integrator's own Xcp_StoreDaqConfiguration reads the selection through
+ * Xcp_GetDaqListSelectedState while it runs.
+ */
+void Xcp_DaqClearAllSelections(void);
+
 void Xcp_DaqFreeAll(void);
 
 /**

--- a/test/daq_nv_accessor_test.py
+++ b/test/daq_nv_accessor_test.py
@@ -30,8 +30,9 @@ def exchange(handle, request, length=8):
 def test_daq_list_selected_state_follows_start_stop_daq_list_select():
     """Selection is XCP_DAQ_LIST_MODE_SELECTED in the list's runtime mode byte
     (source/Xcp_Internal.h), set by START_STOP_DAQ_LIST's SELECT sub-mode (0x02,
-    XCP_DAQ_START_STOP_MODE_SELECT) and left set until a START_STOP_SYNCH resets it, so it is
-    still readable straight after the exchange below with no SYNCH in between. Two lists are
+    XCP_DAQ_START_STOP_MODE_SELECT) and left set until a START_STOP_SYNCH or a completed
+    STORE_DAQ_REQ resets it (1.0/1.6.4.1.1.6), so it is still readable straight after the exchange
+    below, which does neither. Two lists are
     allocated; list 1 is never selected, so a handler that reports TRUE for any valid list
     regardless of its own selection would still be caught by the assertions on it."""
     handle = dynamic_handle(daq_count=2, odt_count=1, odt_entries_count=1)

--- a/test/daq_nv_storage_test.py
+++ b/test/daq_nv_storage_test.py
@@ -686,3 +686,111 @@ def test_a_completed_clear_retires_a_still_outstanding_start_up_read():
 
     assert exchange(handle, (0xFD, 0x00, 0x00, 0x00))[4:6] == (0x00, 0x00)  # poll #4
     assert handle.xcp_read_stored_session_configuration_id.call_count == 1
+
+
+# ---------------------------------------------------------------------------------------------
+# Found while exploring RESUME, after SP5-NV merged. 1.0/1.6.4.1.1.6 (1.1/1.6.4.1.1.4),
+# "Start /stop/select DAQ list": "The slave has to reset the SELECTED flag in the mode at
+# GET_DAQ_LIST_MODE as soon as the related START_STOP_SYNCH or SET_REQUEST have been
+# acknowledged." START_STOP_SYNCH does this (Xcp_DTOCmdDaqStartStopSynch, source/Xcp_Daq.c);
+# SET_REQUEST did not. The requirement was vacuous while STORE_DAQ_REQ was refused outright --
+# there was no related SET_REQUEST to acknowledge -- and SP5-NV activated it by making the mode
+# acceptable without implementing the reset.
+# ---------------------------------------------------------------------------------------------
+
+def selected_dynamic_handle(**kwargs):
+    """A dynamic pool with list 0 configured and SELECTED, list 1 allocated and never selected.
+
+    Mirrors test/daq_nv_accessor_test.py's own allocation sequence. List 1 exists so an
+    implementation that cleared every list's mode byte wholesale -- rather than the SELECTED bit
+    of the lists that carried it -- is not indistinguishable from a correct one here."""
+    handle = XcpTest(dynamic_config(daq_count=2, odt_count=1, odt_entries_count=1, **kwargs))
+    connect(handle)
+    for request in ((0xD6,),                                      # FREE_DAQ
+                    (0xD5, 0x00, 0x02, 0x00),                     # ALLOC_DAQ(2)
+                    (0xD4, 0x00, 0x00, 0x00, 0x01),               # ALLOC_ODT(list 0, 1)
+                    (0xD3, 0x00, 0x00, 0x00, 0x00, 0x01),         # ALLOC_ODT_ENTRY(list 0, odt 0, 1)
+                    (0xE2, 0x00, 0x00, 0x00, 0x00, 0x00),         # SET_DAQ_PTR(list 0, odt 0, entry 0)
+                    # list 0 must hold a written entry, or Select answers ERR_DAQ_CONFIG.
+                    (0xE1, 0xFF, 0x01, 0x00, 0x00, 0x10, 0x00, 0x00)):  # WRITE_DAQ
+        assert exchange(handle, request)[0] == 0xFF, request
+
+    assert exchange(handle, (0xDE, 0x02, 0x00, 0x00))[0] == 0xFF  # START_STOP_DAQ_LIST(Select, 0)
+    assert handle.lib.Xcp_GetDaqListSelectedState(0) == 1, 'setup: list 0 must be selected'
+    return handle
+
+
+def selected_bit_on_the_wire(handle, daq_list_number):
+    """GET_DAQ_LIST_MODE's SELECTED, read where the specification puts the obligation -- byte 1
+    bit 0 of the response, not the internal mode byte. The positive-response guard matters: every
+    XCP error code is < 0x80 and ERR_OUT_OF_RANGE (0x22) has bit 0 clear, so an error response
+    would satisfy the bit test on its own."""
+    response = exchange(handle, (0xDF, 0x00, daq_list_number, 0x00))
+    assert response[0] == 0xFF, 'GET_DAQ_LIST_MODE must answer positively'
+    return response[1] & 0b00000001
+
+
+def test_a_successful_store_daq_req_resets_the_selected_flag():
+    """1.0/1.6.4.1.1.6. The store is what the selection was FOR -- 1.0/1.6.4.1.1.6 calls Select
+    "preparing the slave for RESUME mode (ref. SET_REQUEST)" -- so once it has been persisted the
+    selection has been consumed and must stop being reported."""
+    handle = selected_dynamic_handle(xcp_store_daq_configuration_api_enable=True)
+
+    def store_daq_configuration(session_configuration_id, p_status_code):
+        p_status_code[0] = 0x00  # zero status: a clean completion
+        return handle.define('E_OK')
+
+    handle.xcp_store_daq_configuration.side_effect = store_daq_configuration
+
+    assert selected_bit_on_the_wire(handle, 0) == 0x01, 'selected before the store'
+
+    exchange(handle, (0xF9, 0b00000100, 0x00, 0x00))              # SET_REQUEST(STORE_DAQ_REQ)
+    handle.lib.Xcp_CanIfTxConfirmation(0x0001, handle.define('E_OK'))  # drain EV_STORE_DAQ
+
+    assert selected_bit_on_the_wire(handle, 0) == 0x00, 'reset once the store completed'
+
+
+def test_the_store_callback_still_sees_the_selection_it_is_being_asked_to_persist():
+    """This is what forces the reset to happen on COMPLETION rather than on the acknowledgement.
+
+    SET_REQUEST answers 0xFF immediately and the store completes later, from Xcp_MainFunction, so
+    "acknowledged" could be read either way. It cannot be the response: the integrator's own
+    Xcp_StoreDaqConfiguration calls Xcp_GetDaqListSelectedState to learn WHICH lists to persist
+    (DD94). Clearing at acknowledgement time would hand it a slave with nothing selected, and it
+    would faithfully store an empty configuration."""
+    handle = selected_dynamic_handle(xcp_store_daq_configuration_api_enable=True)
+    seen = []
+
+    def store_daq_configuration(session_configuration_id, p_status_code):
+        seen.append(handle.lib.Xcp_GetDaqListSelectedState(0))
+        p_status_code[0] = 0x00
+        return handle.define('E_OK')
+
+    handle.xcp_store_daq_configuration.side_effect = store_daq_configuration
+
+    exchange(handle, (0xF9, 0b00000100, 0x00, 0x00))
+
+    assert seen == [1], 'the callback must see list 0 still selected while it stores it'
+
+
+def test_a_failed_store_daq_req_leaves_the_selection_standing():
+    """The specification says "acknowledged", not "succeeded", but a store that reported a failure
+    persisted nothing, so the selection has not been consumed. Leaving it lets the master retry the
+    SET_REQUEST without walking the whole Select sequence again; clearing it would silently discard
+    a configuration the master still believes it is holding.
+
+    Mirrors how session_configuration_id is adopted (DD99): a non-zero status leaves the previous
+    value standing. The request bit itself still clears on this path -- that is DD95, and it is not
+    what this test is about."""
+    handle = selected_dynamic_handle(xcp_store_daq_configuration_api_enable=True)
+
+    def store_daq_configuration(session_configuration_id, p_status_code):
+        p_status_code[0] = 0x01  # non-zero: finished, but failed
+        return handle.define('E_OK')
+
+    handle.xcp_store_daq_configuration.side_effect = store_daq_configuration
+
+    exchange(handle, (0xF9, 0b00000100, 0x00, 0x00))
+    handle.lib.Xcp_CanIfTxConfirmation(0x0001, handle.define('E_OK'))
+
+    assert selected_bit_on_the_wire(handle, 0) == 0x01, 'a failed store consumed nothing'


### PR DESCRIPTION
**A requirement SP5-NV activated without implementing.** Found while exploring RESUME, an hour after
SP5-NV merged.

1.0/§1.6.4.1.1.6 (1.1/§1.6.4.1.1.4), *Start /stop/select DAQ list*:

> The slave has to reset the SELECTED flag in the mode at GET_DAQ_LIST_MODE as soon as the related
> START_STOP_SYNCH or **SET_REQUEST** have been acknowledged.

`Xcp_DTOCmdDaqStartStopSynch` does this and quotes the requirement. `SET_REQUEST` did not — nothing
in `source/Xcp_Std.c` touches a list mode.

It was vacuous while `STORE_DAQ_REQ` was refused outright: with no related `SET_REQUEST` to
acknowledge, there was nothing to reset. SP5-NV made the mode acceptable and did not implement the
reset, so after a successful store the lists stayed SELECTED and `GET_DAQ_LIST_MODE` kept reporting
them. A master that stored a configuration and read the mode back saw a selection it had already
consumed, and a later `START_STOP_SYNCH` would have acted on it.

## Reset on completion, not on acknowledgement

`SET_REQUEST` answers `0xFF` immediately and the store finishes later from `Xcp_MainFunction`, so
"acknowledged" could be read either way. **It cannot be the response.** The integrator's own
`Xcp_StoreDaqConfiguration` calls `Xcp_GetDaqListSelectedState` to learn which lists to persist
(DD94). Clearing at acknowledgement time hands it a slave with nothing selected, and it faithfully
stores an empty configuration — the requirement would be met and the feature broken.

A store reporting a **non-zero** status leaves the selection standing. The specification says
"acknowledged" rather than "succeeded", so this one is a reading: a failed store persisted nothing,
the selection has not been consumed, and the master can retry the `SET_REQUEST` without walking the
whole Select sequence again. It is the same reading `session_configuration_id` already takes.

## Placement

The clearing is `Xcp_DaqClearAllSelections` in `source/Xcp_Daq.c`, not code in the `SET_REQUEST`
handler: the list mode byte is DAQ state whose other readers live in that file, and DD63 forbids a
command group writing shared state whose readers are outside its own.

## Tests

Three, one per decision, each mutation-verified to fail **alone** — so no single test is carrying
the others:

| Test | Mutation | Failure |
|---|---|---|
| a successful store resets the flag | (RED, before the fix) | `assert 1 == 0` |
| the callback still sees the selection while storing | clearing moved ahead of the callback | `assert [0] == [1]` |
| a failed store leaves it standing | clearing moved out of the zero-status branch | `assert 0 == 1` |

The fixture allocates two lists and selects only list 0, so an implementation that wiped every
list's mode byte wholesale is not indistinguishable from a correct one. Assertions read
`GET_DAQ_LIST_MODE` on the wire — where the specification puts the obligation — with a positive-
response guard, since `ERR_OUT_OF_RANGE` (`0x22`) has bit 0 clear and would otherwise satisfy the
bit test on its own.

**12926 passed, 29 skipped**, both ctest targets green.

Also corrects three places documenting the selection as lasting until a `START_STOP_SYNCH`, which is
no longer the whole story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
