### PR TITLE
Reset SELECTED after a completed CLEAR_DAQ_REQ too

### DIFF
--- a/source/Xcp.c
+++ b/source/Xcp.c
@@ -1691,6 +1691,22 @@ void Xcp_MainFunction(void)
                 {
                     Xcp_Internal.session_configuration_id_read_state = XCP_NV_READ_COMPLETE;
                 }
+
+                /* XCP part 2 - Protocol Layer Specification 1.0/1.6.4.1.1.6 (1.1/1.6.4.1.1.4)
+                 * The same reset the STORE_DAQ_REQ block above performs, and for the same
+                 * sentence: the requirement names SET_REQUEST without qualifying the mode, and the
+                 * section describes a selection as making a list "part of a configuration that
+                 * afterwards will be cleared or stored into non-volatile memory". Both modes.
+                 *
+                 * That the clear itself wipes every list in non-volatile memory regardless of what
+                 * is selected (1.0/1.6.1.1.3) is true and beside the point: the requirement governs
+                 * what the slave keeps REPORTING once the master's request has been acknowledged,
+                 * not what the clear reads. A master that selected lists and then cleared has
+                 * finished with that selection either way.
+                 *
+                 * Zero-status branch, so a failed clear leaves the selection standing -- the same
+                 * reading, for the same reason, as the store above. */
+                Xcp_DaqClearAllSelections();
             }
 
             /* Same reasoning as the STORE_CAL_REQ push above: only the push itself goes inside the

--- a/test/daq_nv_storage_test.py
+++ b/test/daq_nv_storage_test.py
@@ -794,3 +794,49 @@ def test_a_failed_store_daq_req_leaves_the_selection_standing():
     handle.lib.Xcp_CanIfTxConfirmation(0x0001, handle.define('E_OK'))
 
     assert selected_bit_on_the_wire(handle, 0) == 0x01, 'a failed store consumed nothing'
+
+
+def test_a_successful_clear_daq_req_also_resets_the_selected_flag():
+    """The STORE_DAQ_REQ fix above was under-scoped. 1.0/1.6.4.1.1.6 (1.1/1.6.4.1.1.4) names
+    SET_REQUEST without qualifying the mode -- "as soon as the related START_STOP_SYNCH or
+    SET_REQUEST have been acknowledged" -- and the same section says the selection makes a list
+    "part of a configuration that afterwards will be CLEARED or stored into non-volatile memory".
+    Both modes consume the selection.
+
+    The first reading was that CLEAR_DAQ_REQ wipes every list in non-volatile memory regardless of
+    what is selected (1.0/1.6.1.1.3), so the selection is not an input to it and nothing is
+    consumed. That is true of the clear's own behaviour and beside the point: the requirement is
+    about what the slave keeps REPORTING once the master's request has been acknowledged, and a
+    master that selected lists and then cleared has finished with that selection either way."""
+    handle = selected_dynamic_handle(xcp_clear_daq_configuration_api_enable=True)
+
+    def clear_daq_configuration(p_status_code):
+        p_status_code[0] = 0x00  # zero status: a clean completion
+        return handle.define('E_OK')
+
+    handle.xcp_clear_daq_configuration.side_effect = clear_daq_configuration
+
+    assert selected_bit_on_the_wire(handle, 0) == 0x01, 'selected before the clear'
+
+    exchange(handle, (0xF9, 0b00001000, 0x00, 0x00))              # SET_REQUEST(CLEAR_DAQ_REQ)
+    handle.lib.Xcp_CanIfTxConfirmation(0x0001, handle.define('E_OK'))  # drain EV_CLEAR_DAQ
+
+    assert selected_bit_on_the_wire(handle, 0) == 0x00, 'reset once the clear completed'
+
+
+def test_a_failed_clear_daq_req_leaves_the_selection_standing():
+    """Same reading as the failed store above: the specification says "acknowledged" rather than
+    "succeeded", and a clear that reported a failure changed nothing in non-volatile memory, so the
+    master can retry the SET_REQUEST without walking the Select sequence again."""
+    handle = selected_dynamic_handle(xcp_clear_daq_configuration_api_enable=True)
+
+    def clear_daq_configuration(p_status_code):
+        p_status_code[0] = 0x01  # non-zero: finished, but failed
+        return handle.define('E_OK')
+
+    handle.xcp_clear_daq_configuration.side_effect = clear_daq_configuration
+
+    exchange(handle, (0xF9, 0b00001000, 0x00, 0x00))
+    handle.lib.Xcp_CanIfTxConfirmation(0x0001, handle.define('E_OK'))
+
+    assert selected_bit_on_the_wire(handle, 0) == 0x01, 'a failed clear consumed nothing'


### PR DESCRIPTION
**Completes PR #23, which I scoped too narrowly.**

#23 reset the SELECTED flag after a completed `STORE_DAQ_REQ`. It should also reset after a completed
`CLEAR_DAQ_REQ`, and the same specification section says so — in a sentence I had read and
mis-weighted.

1.0/§1.6.4.1.1.6 (1.1/§1.6.4.1.1.4) requires the reset "as soon as the related `START_STOP_SYNCH` or
**`SET_REQUEST`** have been acknowledged" — `SET_REQUEST`, with no qualification of which mode. The
same section:

> If the next command is SET_REQUEST, this will make the DAQ list to be part of a configuration that
> afterwards will be **cleared or stored** into non-volatile memory.

Both revisions carry that identically.

## Why I got it wrong the first time

I reasoned that `CLEAR_DAQ_REQ` wipes every list in non-volatile memory regardless of what is
selected (1.0/§1.6.1.1.3), so the selection is not an input to the clear and nothing is consumed by
it. That is a true statement about the clear's behaviour and beside the point. The requirement
governs **what the slave keeps reporting** once the master's request has been acknowledged, not what
the clear reads. A master that selected lists and then cleared has finished with that selection
either way.

## Symmetry with the store side

Same two rules, so the paths do not diverge:

- **On completion, not on acknowledgement** — matching the store, where the integrator's callback
  reads the selection back while it runs.
- **Zero status only** — a clear that reported a failure changed nothing in non-volatile memory, so
  the selection stands and the master can retry the `SET_REQUEST` without walking the Select
  sequence again.

## Tests

**12928 passed, 29 skipped** (12926 + 2), both ctest targets green.

| | |
|---|---|
| RED, before the fix | `assert 1 == 0` — SELECTED survived a completed clear |
| reset moved out of the zero-status branch | `assert 0 == 1` — fails the failed-clear test alone |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
