### PR TITLE
Record the revision-divergence rule that three defects came from

### DIFF
--- a/docs/superpowers/specs/2026-08-29-xcp-part2-roadmap.md
+++ b/docs/superpowers/specs/2026-08-29-xcp-part2-roadmap.md
@@ -6,6 +6,33 @@
 Version 1.0 is kept alongside it: the two renumber §1.6.4 wholesale, so a citation is only
 unambiguous once it names its version.
 
+### The revision rule, and what it cost to learn twice
+
+**Before implementing a command, read its section in BOTH revisions — not only to resolve the
+section number, but to compare what the sections say.** 1.1 is the reference; 1.0 is readable via
+`pdftotext -layout`, while 1.1's text layer is enciphered (glyph substitution), which is why
+`XCP -Part 2- Protocol Layer Specification -1.1.ocr.txt` exists. The OCR carries the prose reliably
+and **misaligns table columns**, so a *bit position* read from it is not evidence. The cipher is
+recoverable from known word pairs when a table has to be read exactly.
+
+The rule started narrower — check both revisions for renumbering, and for error codes 1.1 adds to a
+command's row — and it kept being right about the wrong things. What it missed:
+
+| Divergence | Cost |
+|---|---|
+| 1.1 renumbers `§1.6.4.1.2.x` | caught in time; `GET_DAQ_PROCESSOR_INFO` is correct *only* because its citation says `1.1/` |
+| 1.1 adds `ERR_RESOURCE_TEMPORARY_NOT_ACCESSIBLE` (`0x33`) to STD rows | caught late in SP5-NV, and only because the user challenged a claim that nothing was reportable |
+| 1.1 **adds a mode bit and re-points an existing one** | missed. SP5-NV cited `1.0/§1.6.1.2.3` for `SET_REQUEST`, and three defects followed from that one choice |
+| 1.1 attaches an obligation to a command a phase newly enables | missed. `SET_REQUEST` acknowledging a store must reset `SELECTED` (§1.6.4.1.1.6) — vacuous while the mode was refused, live the moment it was accepted |
+
+The last two shipped and were fixed in PRs #23, #24 and #25. Two per-task reviews and a whole-branch
+review passed the middle one, because nothing in the diff looked wrong — the defect was in what the
+diff *enabled elsewhere*. So the rule has a second half:
+
+**When a phase makes a previously-refused command or mode acceptable, re-read every section that
+mentions it.** A requirement that was vacuous because nothing could reach it becomes live at that
+moment, and it will not appear in the diff.
+
 This document is a map, not an implementation spec. It records where the module stands
 against the ASAM specification, what remains, and how the remaining work decomposes into
 sub-projects. Each sub-project gets its own design document and implementation plan.


### PR DESCRIPTION
**Documentation only.** No source, no tests.

Three defects in one day came from a single choice: SP5-NV cited `1.0/§1.6.1.2.3` for `SET_REQUEST`
while the roadmap names 1.1 as the module's reference. Fixed in #23, #24 and #25. This writes the
rule that would have prevented all three into the roadmap's preamble, where the next phase will read
it.

## What the old rule covered, and what it didn't

The branch family already had a revision rule — but it was written for **renumbering** and for
**error codes 1.1 adds to a command's row**, and it kept being right about the wrong things:

| Divergence | Cost |
|---|---|
| 1.1 renumbers `§1.6.4.1.2.x` | caught; `GET_DAQ_PROCESSOR_INFO` is correct *only* because its citation says `1.1/` |
| 1.1 adds `0x33` to STD rows | caught late in SP5-NV, and only because the user challenged a claim |
| 1.1 **adds a mode bit and re-points an existing one** | missed — #25 |
| 1.1 attaches an obligation to a command a phase newly enables | missed — #23, #24 |

## The second half, which reviews cannot supply

> When a phase makes a previously-refused command or mode acceptable, re-read every section that
> mentions it.

Two per-task reviews and a whole-branch review passed the `SELECTED` defect, and none of them was
careless. Nothing in the diff looked wrong — the requirement was **vacuous while the mode was
refused** and went live the moment SP5-NV accepted it. A defect that exists in what a diff *enables
elsewhere* is not visible to anyone reviewing the diff.

## The practical note

1.1's text layer is enciphered (glyph substitution), which is why the `.ocr.txt` exists. The OCR
carries prose reliably and **misaligns table columns**, so a bit position read from it is not
evidence — that misalignment already defeated one grep during SP5-NV. The cipher is recoverable from
known word pairs when a table has to be read exactly; that is how 1.1's `SET_REQUEST` mode table was
resolved for #25, cross-checked against the ascending order of the flag descriptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
