### PR TITLE
Give the test container the stack headroom the template compiler needs

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,5 +1,23 @@
 #!/bin/sh
 
+# The generator compiles its jinja2 templates by exec'ing generated Python, and CPython's compiler
+# is recursive. On this image (alpine 3.10, musl) the default 8 MB stack is not enough headroom for
+# source_cfg.c.jinja2 at its current size, and the overflow does not segfault -- it corrupts, so
+# jinja2 emits impossible states instead of failing cleanly. Observed symptoms, all from the same
+# unchanged tree: "Tried to resolve a name to a reference that was unknown to the frame",
+# "'TokenStream' object has no attribute 'bool'", "type object 'object' has no attribute 't'", and
+# a SyntaxError in the template's own generated Python. A different test failed every run.
+#
+# Measured, 600 template compilations per run, this tree, this host:
+#   alpine image, 8 MB stack   -- failed 2 of 3 runs
+#   alpine image, 64 MB stack  -- 7 of 7 clean
+#   debian/glibc, 8 MB stack   -- 4 of 4 clean
+#
+# glibc survives the same depth at the same limit, which is why this only ever bit locally and in
+# this image. The hard limit here is unlimited, so an unprivileged user can raise the soft limit;
+# doing it here rather than at the `docker run` keeps every caller -- CI and local -- on one rule.
+ulimit -s 65536
+
 result=0
 mkdir -p build
 cd build || exit 1


### PR DESCRIPTION
**One line in `test.sh`.** The investigation behind it is the substance.

Full-suite runs had been failing nondeterministically on this image — a different test every run — with errors that are not possible in working Python:

```
AssertionError: Tried to resolve a name to a reference that was unknown to the frame ('configuration')
AttributeError: 'TokenStream' object has no attribute 'bool'
AttributeError: type object 'object' has no attribute 't'
SyntaxError: invalid syntax (source_cfg.c.jinja2, line 351)
```

`object` does not lose attributes. Those are corrupted states, not library bugs — which is why chasing them as a jinja2 problem went nowhere.

## Root cause

The generator compiles its jinja2 templates by `exec`-ing generated Python, and **CPython's compiler is recursive**. On alpine/musl the default 8 MB stack no longer clears `source_cfg.c.jinja2` at its current size. The overflow does not segfault — it **corrupts**, so the failure surfaces later as whatever jinja2 touches next. That is exactly why the symptom moved every run and why it read as flake for three branches.

It also explains the apparent "degradation over a day": the template kept growing.

## Evidence

Reduced to a **pure-Python reproduction** — no pytest, no CFFI, no C build, just this repo's own templates and config rendered in a loop — then measured at 600 compilations per run:

| Image | Stack | Result |
|---|---|---|
| alpine 3.10 / musl (`xcp-test:sp4b`) | 8 MB (default) | **failed 2 of 3** |
| alpine 3.10 / musl | 64 MB | **7 of 7 clean** |
| debian / glibc (`python:3.7-slim`) | 8 MB | **4 of 4 clean** |

glibc survives the same recursion at the same limit, which is why this only ever bit in this image and never in a stock one.

## Ruled out along the way

- **The branch under test** — reproduces on `develop` with no changes.
- **The configuration builder** — 500 constructions, byte-identical output.
- **`PYTHONHASHSEED`** — fixed seeds still vary run to run.
- **jinja2 itself** — 3.0.3 fails the same way, with its own impossible errors.
- **Host memory** — 2.5 GB pattern verification clean, no OOM, no pressure, load 0.93.

## The fix

`ulimit -s 65536` at the top of `test.sh`. The container's hard limit is `unlimited`, so raising the soft limit needs no privilege and no change to how anyone invokes Docker — one rule for CI and local alike, rather than a flag every caller has to remember.

Full suite now **12962 passed, 29 skipped**, twice consecutively on a clean build tree.

## Why this matters beyond the flake

Local full-suite runs had become untrustworthy, which meant CI was the only way to verify anything on this machine. Silent stack corruption is also the worst class of test infrastructure fault: it fails somewhere other than where it breaks, so every investigation starts in the wrong place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
