### PR TITLE
SP5-GETID — serve every GET_ID identification type the specification defines

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,7 +445,7 @@ refused `ERR_PGM_ACTIVE` while the session is open.
   would also require `CanIf_SetDynamicTxId` (SWS_CANIF_00189) and an integrator guarantee that every DAQ transmit
   PDU is configured as a *dynamic* L-PDU, neither of which this module can verify. `GET_DAQ_ID` (`0xFE`)
   consequently reports the identifier as fixed, which is the truthful answer for a slave that cannot change it.
-- The `GET_ID` command only supports the request identification type 0 (*ASCII text*).
+- The `GET_ID` command always transfers identification through the MTA — `TRANSFER_MODE` stays 0 for every type, because the request packet is two bytes and gives the master no field to ask for inline transfer. `COMPRESSED_ENCRYPTED` is not implemented; 1.1/1.6.1.2.2 puts its algorithm interface in XCP Part 4, a specification this module does not have access to. Identification types 0-4 and 128-255 are served through the optional `get_id_function` callback, with the configured `identification` string as type 0's fallback.
 - `SHORT_DOWNLOAD` can transfer no data at all when `MAX_CTO` is 8, as it is for XCP on CAN, because the command's
   own header fills the whole frame. The specification notes this. The stack still accepts the command, and rejects any
   element count above `(MAX_CTO - 8) / AG` with `ERR_OUT_OF_RANGE`.

--- a/config/xcp.json
+++ b/config/xcp.json
@@ -305,7 +305,7 @@
         "user_defined_checksum_function": null,
         "user_cmd_function": null,
         "trailing_value": 0,
-        "identification": "/path/to/database.a2l"
+        "identification": "/path/to/xcp.a2l"
       }
     }
   ]

--- a/config/xcp.json
+++ b/config/xcp.json
@@ -304,6 +304,7 @@
         "checksum_type": "XCP_CRC_16",
         "user_defined_checksum_function": null,
         "user_cmd_function": null,
+        "get_id_function": null,
         "trailing_value": 0,
         "identification": "/path/to/xcp.a2l"
       }

--- a/config/xcp.schema.json
+++ b/config/xcp.schema.json
@@ -615,6 +615,21 @@
                 ],
                 "default": null
               },
+              "get_id_function": {
+                "description": "Optional integrator callback supplying GET_ID identification data for any type. XCP part 2 - Protocol Layer Specification 1.1/1.6.1.2.2 leaves which types a slave supports implementation specific; this is how it decides. Returning E_NOT_OK means the type is not served, which answers Length = 0 -- except for type 0, which falls back to the configured identification string. null means only type 0 is served, from that string alone.",
+                "OneOf": [
+                  {
+                    "type": "null"
+                  },
+                  {
+                    "type": "string",
+                    "enum": [
+                      "Xcp_GetIdentificationFunction"
+                    ]
+                  }
+                ],
+                "default": null
+              },
               "trailing_value": {
                 "type": "integer",
                 "minimum": 0,
@@ -650,6 +665,7 @@
               "checksum_type",
               "user_defined_checksum_function",
               "user_cmd_function",
+              "get_id_function",
               "trailing_value",
               "identification"
             ]

--- a/config/xcp.schema.json
+++ b/config/xcp.schema.json
@@ -622,8 +622,9 @@
                 "default": 0
               },
               "identification": {
+                "description": "Identification type 0 (ASCII) returned by GET_ID, and the fallback for type 0 when no get_id_function is configured. XCP part 2 - Protocol Layer Specification 1.1/1.6.1.2.2 requires Length mod AG = 0, so its length must be a multiple of address_granularity; generation refuses a configuration where it is not. The default is 16 bytes, which conforms under BYTE, WORD and DWORD alike.",
                 "type": "string",
-                "default": "/path/to/database.a2l"
+                "default": "/path/to/xcp.a2l"
               },
               "timestamp": {
                 "description": "Data acquisition clock reported to the master through GET_DAQ_RESOLUTION_INFO, and transmitted in the first ODT of each cycle of a DAQ list the master has put into timestamped mode. Absent means the slave does not support timestamps: TIMESTAMP_SUPPORTED is reported clear and TIMESTAMP_MODE/TIMESTAMP_TICKS are invalid, which XCP part 2 - Protocol Layer Specification 1.1/1.6.4.1.2.5 permits explicitly. The module holds no clock; these values describe the counter the integrator supplies through Xcp_GetDaqTimestamp.",

--- a/config/xcp.schema.json
+++ b/config/xcp.schema.json
@@ -637,8 +637,10 @@
                 "default": 0
               },
               "identification": {
-                "description": "Identification type 0 (ASCII) returned by GET_ID. XCP part 2 - Protocol Layer Specification 1.1/1.6.1.2.2 requires Length mod AG = 0, so its length must be a multiple of address_granularity; generation refuses a configuration where it is not. The default is 16 bytes, which conforms under BYTE, WORD and DWORD alike.",
+                "description": "Identification type 0 (ASCII) returned by GET_ID. Printable ASCII only, 0x20-0x7E: XCP part 2 - Protocol Layer Specification 1.1/1.6.1.2.2 calls the identification \"a byte stream of plain ASCII text\", and at one byte per character its length in characters is its length in bytes. '\"' and '\\' are permitted -- 1.1/1.6.1.2.2's own second example is c:\\database\\test.a2l -- because script/source_cfg.c.jinja2 escapes both into the generated C string literal. 1.1/1.6.1.2.2 requires Length mod AG = 0, so its length must be a multiple of address_granularity; generation refuses a configuration where it is not. The default is 16 bytes, which conforms under BYTE, WORD and DWORD alike.",
+                "$comment": "The pattern ends in the lookahead (?![\\s\\S]) rather than in $: jsonschema evaluates patterns with Python's re, whose $ also matches just before a final line feed, so ^[\\x20-\\x7E]*$ would accept an identification ending in one. The lookahead asserts that no character at all follows, which is the end of the string under Python's re and ECMA-262 alike. * rather than +: an empty identification answers Length = 0 for type 0, which 1.1/1.6.1.2.2 defines as not available, and the generator accepts it.",
                 "type": "string",
+                "pattern": "^[\\x20-\\x7E]*(?![\\s\\S])",
                 "default": "/path/to/xcp.a2l"
               },
               "timestamp": {

--- a/config/xcp.schema.json
+++ b/config/xcp.schema.json
@@ -622,7 +622,7 @@
                 "default": 0
               },
               "identification": {
-                "description": "Identification type 0 (ASCII) returned by GET_ID, and the fallback for type 0 when no get_id_function is configured. XCP part 2 - Protocol Layer Specification 1.1/1.6.1.2.2 requires Length mod AG = 0, so its length must be a multiple of address_granularity; generation refuses a configuration where it is not. The default is 16 bytes, which conforms under BYTE, WORD and DWORD alike.",
+                "description": "Identification type 0 (ASCII) returned by GET_ID. XCP part 2 - Protocol Layer Specification 1.1/1.6.1.2.2 requires Length mod AG = 0, so its length must be a multiple of address_granularity; generation refuses a configuration where it is not. The default is 16 bytes, which conforms under BYTE, WORD and DWORD alike.",
                 "type": "string",
                 "default": "/path/to/xcp.a2l"
               },

--- a/docs/superpowers/plans/2026-09-11-xcp-get-id-types.md
+++ b/docs/superpowers/plans/2026-09-11-xcp-get-id-types.md
@@ -142,6 +142,17 @@ In `source/Xcp_Std.c`, replace the bare `Xcp_Internal.cto_response.pdu_info.SduD
 
 Do not write the value as an expression over the two masks. `0x00u` is what goes on the wire and the comment is what explains it; an expression contrived to evaluate to zero while mentioning both names is harder to read than either. The masks earn their place by being referenced from the tests and from the header's own documentation, not by appearing here.
 
+**Correction, made in the final review's fix wave**
+(`.superpowers/sdd/2026-09-11-xcp-get-id-types/final-fix-report.md`): the last sentence above
+describes something impossible. The tests cannot reference the masks at all: they live in
+`source/Xcp_Internal.h`, and the harness builds its cdef, and every `handle.define(...)` lookup,
+from `interface/Xcp.h` and the generated configuration headers, none of which includes
+`source/Xcp_Internal.h` — `interface/Xcp.h`'s own note on internal declarations says the same of
+functions declared only there. As shipped, the masks were referenced nowhere: not from the tests,
+and not at the build site either, whose comment named the two bits only in prose. That comment now
+names both macro identifiers. In code the masks remain unreferenced, a deliberate MISRA C:2012
+Rule 2.5 (advisory) deviation recorded in the design doc's DD111 correction.
+
 - [ ] **Step 5: Run the full suite**
 
 ```bash
@@ -1139,6 +1150,14 @@ covered. Corrected here rather than left standing, matching the same correction 
 1's own title above.
 
 Then check whether any *other* roadmap row is made stale by this phase before committing — §2.6 cross-cutting and the §3 defect list both mention `GET_ID`. Correct what you find; do not silently rewrite a claim that turns out to have been wrong, record the correction, as DD102 and DD105 do.
+
+**Correction, made in the final review's fix wave**
+(`.superpowers/sdd/2026-09-11-xcp-get-id-types/final-fix-report.md`): the premise of the step above
+is false. Neither §2.6 nor the §3 defect list mentions `GET_ID` — not at this plan's baseline
+(`38eb3ff`), and not after this phase's own roadmap edits. At the baseline the roadmap named
+`GET_ID` only in §2.1's command table and in §4's SP5 residue text, and neither section mentions
+the identification either. The instruction to check other rows still stands; the two sections it
+pointed at simply had nothing for it to find.
 
 - [ ] **Step 4: Commit, push, open the PR**
 

--- a/docs/superpowers/plans/2026-09-11-xcp-get-id-types.md
+++ b/docs/superpowers/plans/2026-09-11-xcp-get-id-types.md
@@ -960,6 +960,10 @@ def test_get_id_refuses_a_callback_length_that_is_not_a_multiple_of_the_granular
     handle = XcpTest(DefaultConfig(address_granularity=address_granularity, **_CALLBACK_CONFIG))
     _connect(handle)
     _serve(handle, b'x' * length)
+    # Everything asserted below is about GET_ID alone. Without this, a DET raised by CONNECT or by
+    # construction would be the call assert_called_once_with inspects, and the test would report on
+    # the wrong one -- passing or failing for a reason that has nothing to do with GET_ID.
+    handle.det_report_error.reset_mock()
 
     raw_data = _get_id(handle, 0x01)
 
@@ -980,6 +984,7 @@ def test_get_id_accepts_a_callback_length_that_is_a_multiple_of_the_granularity(
     handle = XcpTest(DefaultConfig(address_granularity=address_granularity, **_CALLBACK_CONFIG))
     _connect(handle)
     _serve(handle, b'x' * length)
+    handle.det_report_error.reset_mock()   # same reason as the test above
 
     raw_data = _get_id(handle, 0x01)
 
@@ -1039,6 +1044,12 @@ In `source/Xcp_Std.c`, immediately after the callback block in Task 4's Step 7 (
 ```
 
 Setting `served = FALSE` here deliberately does **not** fall through to the static string for type 0: a callback that answered `E_OK` has claimed the type, and silently substituting different data for a length it got wrong would hide the defect DET has just reported. Confirm this by checking that `test_get_id_falls_back_to_the_static_identification_when_the_callback_declines_type_zero` still passes — it declines with `E_NOT_OK` and must be unaffected. If the ordering makes a type-0 `E_OK` with a bad length fall back to the string, move this block after the static-fallback block instead.
+
+- [ ] **Step 4b: Give the generator guard its cross-reference, now that it is true**
+
+Task 3 deliberately worded `script/source_cfg.c.jinja2`'s `Length mod AG = 0` guard comment to describe only its own scope, naming no specific future check — because at that commit no run-time check existed, and claiming one would have been the defect class this branch has already shipped twice. That check now exists. Add the concrete cross-reference to the guard's comment: the configured string is validated here, and a callback-supplied length is validated in `Xcp_DTOCmdStdGetId`, which raises `XCP_E_IDENTIFICATION_NOT_GRANULAR` and answers `Length = 0`. Keep the scope sentence — it is still the reason the split exists.
+
+Read the comment as it stands before editing. Do not restore wording from any earlier draft; write what is true of the code in front of you.
 
 - [ ] **Step 5: Run the full suite and mutation-verify**
 

--- a/docs/superpowers/plans/2026-09-11-xcp-get-id-types.md
+++ b/docs/superpowers/plans/2026-09-11-xcp-get-id-types.md
@@ -1,0 +1,1095 @@
+# GET_ID Identification Types Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend `GET_ID` from identification type 0 (ASCII) alone to types 1–4 and the 128–255 user-defined range, served through an integrator callback.
+
+**Architecture:** `Xcp_DTOCmdStdGetId` keeps answering through the MTA (`TRANSFER_MODE = 0`). An optional `getIdentificationFunction` on `Xcp_GeneralType` supplies address, MTA extension and length for any type; the configured static `identification` string remains type 0's fallback. Types the specification does not define (5–127) answer `ERR_OUT_OF_RANGE`; defined types the slave does not serve answer a positive response with `Length = 0`.
+
+**Tech Stack:** C (AUTOSAR BSW module), Jinja2 code generation (`script/source_cfg.c.jinja2`), CFFI + pytest harness, CMake/ctest, Docker.
+
+**Spec:** `docs/superpowers/specs/2026-09-11-xcp-get-id-types-design.md` (DD108–DD113)
+
+## Global Constraints
+
+- **Reference revision is 1.1.** Every specification citation carries its revision prefix: `1.1/§1.6.1.2.2`, never a bare section number. Cite 1.0 only where it differs or is the readable copy.
+- **`GET_ID` is §1.6.1.2.2 in both revisions.** The error matrix is §1.7.3.2.1 in both.
+- **`TRANSFER_MODE` is bit 0, `COMPRESSED_ENCRYPTED` is bit 1** of the response Mode byte (1.1/§1.6.1.2.2). Both stay clear — DD111.
+- **Run the suite in Docker only.** `./test.sh` on the host dies at `cmake: not found`:
+  ```
+  docker run --rm --user "$(id -u):$(id -g)" --env HOME=/tmp --ulimit nofile=65536:524288 \
+    --volume "$PWD:/usr/project" --workdir /usr/project xcp-test:sp4b ./test.sh
+  ```
+  `--user` is load-bearing — a root run leaves root-owned files under `build/` that later runs cannot delete. A full run is ~7 minutes.
+- **`XCP_PYTEST_ARGS` is a CMake cache variable.** Seeding it scopes every later run until cleared to `""`.
+- **Never `rm -rf generated/*`** — it holds a tracked `generated/CMakeLists.txt`. Clearing `build/` is safe.
+- **`Xcp_GeneralType` is initialised positionally** by `script/source_cfg.c.jinja2`. New fields go strictly at the **tail** of both the struct and the initialiser, or every later field silently shifts.
+- **`Xcp_Internal` and file-`static` tables are unreachable** from the CFFI harness — `test/conftest.py` builds its cdef from `interface/Xcp.h` alone. Assert on transmitted bytes, callback arguments, DET calls, or exported return values.
+- **`Xcp_DaqQueuePeek` hands every transmission the same static `PduInfoType`.** Read each frame immediately after its own `CanIf_Transmit` call, never from `call_args_list` afterwards.
+- **`raise()` is not a registered Jinja global.** `{{ raise('...') }}` aborts rendering with `jinja2.exceptions.UndefinedError`; the message is documentation, never output. Guard tests assert `pytest.raises(UndefinedError)`, never a message match.
+- **Mutation-verify every behavioural claim:** change the code so the test *should* fail, confirm it does, and name the test. A passing suite is not evidence that a test pins anything.
+- **Commit trailer:** `Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>`
+- **Branch:** `feature/xcp-get-id-types`, already created, design doc already committed. Push as work progresses.
+
+---
+
+## File Structure
+
+| File | Responsibility | Tasks |
+|---|---|---|
+| `source/Xcp_Internal.h` | `XCP_GET_ID_MODE_*` masks, `XCP_GET_ID_TYPE_*` bounds | 1, 2 |
+| `source/Xcp_Std.c` | `Xcp_DTOCmdStdGetId` — the whole command | 1, 2, 4, 5 |
+| `interface/Xcp.h` | `XCP_E_IDENTIFICATION_NOT_GRANULAR` DET code | 5 |
+| `interface/Xcp_Types.h` | `getIdentificationFunction` at the tail of `Xcp_GeneralType` | 4 |
+| `config/xcp.schema.json` | `get_id_function` property; `identification` default | 3, 4 |
+| `config/xcp.json` | shipped default configuration | 3, 4 |
+| `script/source_cfg.c.jinja2` | AG guard; initialiser entry at the tail | 3, 4 |
+| `test/parameter.py` | `DefaultConfig` defaults for both new knobs | 3, 4 |
+| `test/conftest.py` | `Xcp_GetIdentificationFunction` extern registration | 4 |
+| `test/get_id_test.py` | Mode byte, `Length = 0`, callback behaviour | 1, 2, 4, 5 |
+| `test/asam_error_matrix_test.py` | narrowed `ERR_OUT_OF_RANGE` range | 2 |
+| `test/daq_configuration_test.py` | generator guard test | 3 |
+| `docs/superpowers/specs/2026-08-29-xcp-part2-roadmap.md` | conformance rows | 6 |
+
+---
+
+### Task 1: Name the Mode bits and repair the assertion that cannot fail
+
+Lands first and changes no behaviour. The existing test asserts `raw_data[1] == mode`, comparing the response's Mode bit mask against the request's Requested Identification Type — two different fields coinciding at zero against a hardcoded `0x00`. Until that is fixed, nothing later in this plan is pinned by it.
+
+**Files:**
+- Modify: `source/Xcp_Internal.h` (near `XCP_PID_CMD_GET_ID`, line 107)
+- Modify: `source/Xcp_Std.c:1264-1335` (`Xcp_DTOCmdStdGetId`)
+- Test: `test/get_id_test.py`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `XCP_GET_ID_MODE_TRANSFER_MODE`, `XCP_GET_ID_MODE_COMPRESSED_ENCRYPTED` — `uint8` masks used by Tasks 2, 4, 5.
+
+- [ ] **Step 1: Write the failing test**
+
+Replace the two assertions on `raw_data[1]` in `test_get_id_returns_identification_through_mta_when_mode_is_0` in `test/get_id_test.py`. Delete `# check Mode.` and `assert raw_data[1] == mode`, and put this in their place:
+
+```python
+    # check the response Mode bit mask. XCP part 2 - Protocol Layer Specification 1.1/1.6.1.2.2
+    # makes this byte a bit mask -- TRANSFER_MODE at bit 0, COMPRESSED_ENCRYPTED at bit 1, bits 2-7
+    # don't-care. 1.0/1.6.1.2.2 has the same byte and leaves it unnamed, which is why this was
+    # previously read as an echo of the request's Requested Identification Type. It is not one:
+    # request byte 1 and response byte 1 are different fields that both happen to be 0 here, so the
+    # old `assert raw_data[1] == mode` passed under every possible implementation.
+    # Both bits clear: the slave transfers through the MTA and does not compress (DD111).
+    assert raw_data[1] & 0x01 == 0x00, 'TRANSFER_MODE must be clear: this slave points the MTA'
+    assert raw_data[1] & 0x02 == 0x00, 'COMPRESSED_ENCRYPTED must be clear: nothing is compressed'
+    assert raw_data[1] == 0x00, 'no reserved bit of the Mode mask may be set'
+```
+
+- [ ] **Step 2: Run it and confirm it passes against unchanged code, then mutation-verify**
+
+```bash
+docker run --rm --user "$(id -u):$(id -g)" --env HOME=/tmp --ulimit nofile=65536:524288 --volume "$PWD:/usr/project" --workdir /usr/project xcp-test:sp4b ./test.sh
+```
+
+The new assertions pass against today's hardcoded `0x00`. That is expected — this step is not what proves them. **Mutation-verify now:** change `source/Xcp_Std.c` line 1323 from `SduDataPtr[0x01u] = 0x00u;` to `= 0x01u;` and re-run only this test. It must fail on the `TRANSFER_MODE` assertion. Then set `= 0x02u` and confirm it fails on `COMPRESSED_ENCRYPTED`. Revert both. Record in the commit message that the old assertion survived both mutations and the new one does not.
+
+- [ ] **Step 3: Add the named masks**
+
+In `source/Xcp_Internal.h`, immediately after `#define XCP_PID_CMD_GET_ID (0xFAu)`:
+
+```c
+/**
+ * @brief GET_ID positive response Mode bit mask.
+ * @note XCP part 2 - Protocol Layer Specification 1.1/1.6.1.2.2. 1.0/1.6.1.2.2 carries the same
+ * byte but leaves it an unnamed "Mode"; 1.1 makes it a bit mask and adds COMPRESSED_ENCRYPTED.
+ * @details Bit positions are asserted from the 1.1 PDF's own text layer, not from its OCR sidecar,
+ * which misaligns table columns. The glyph substitution was recovered from known-plaintext pairs
+ * and the prose decode agrees independently with the table's column geometry; the method is
+ * recorded in docs/superpowers/specs/2026-09-11-xcp-get-id-types-design.md section 0.
+ *
+ * Both bits are always clear in this module (DD111). TRANSFER_MODE stays 0 because the request
+ * packet is two bytes -- command code and Requested Identification Type -- so the master has no
+ * field in which to ask for inline transfer; the slave chooses and merely reports which mode it
+ * used, and 1.1/1.6.1.2.2 describes mode 0 as a complete answer. COMPRESSED_ENCRYPTED stays 0
+ * because its algorithm interface lives in XCP Part 4, which is not in docs/external/ -- and
+ * because the cleared state is always legal.
+ */
+#define XCP_GET_ID_MODE_TRANSFER_MODE (0x01u << 0x00u)
+#define XCP_GET_ID_MODE_COMPRESSED_ENCRYPTED (0x01u << 0x01u)
+```
+
+- [ ] **Step 4: Cite them at the build site**
+
+In `source/Xcp_Std.c`, replace the bare `Xcp_Internal.cto_response.pdu_info.SduDataPtr[0x01u] = 0x00u;` with:
+
+```c
+        /* Mode (1.1/1.6.1.2.2): TRANSFER_MODE and COMPRESSED_ENCRYPTED both clear. See DD111 and
+         * the masks' own note in source/Xcp_Internal.h for why neither is ever set here. */
+        Xcp_Internal.cto_response.pdu_info.SduDataPtr[0x01u] = 0x00u;
+```
+
+Do not write the value as an expression over the two masks. `0x00u` is what goes on the wire and the comment is what explains it; an expression contrived to evaluate to zero while mentioning both names is harder to read than either. The masks earn their place by being referenced from the tests and from the header's own documentation, not by appearing here.
+
+- [ ] **Step 5: Run the full suite**
+
+```bash
+docker run --rm --user "$(id -u):$(id -g)" --env HOME=/tmp --ulimit nofile=65536:524288 --volume "$PWD:/usr/project" --workdir /usr/project xcp-test:sp4b ./test.sh
+```
+Expected: 12962 passed, 29 skipped (baseline), both ctest targets green.
+
+- [ ] **Step 6: Commit and push**
+
+```bash
+git add source/Xcp_Internal.h source/Xcp_Std.c test/get_id_test.py
+git commit -m "test: pin GET_ID's response Mode byte as the bit mask 1.1 defines
+
+test_get_id_returns_identification_through_mta_when_mode_is_0 asserted
+raw_data[1] == mode, comparing the response's Mode bit mask against the
+request's Requested Identification Type. Two different fields that both
+happen to be 0, checked against a hardcoded 0x00 -- the assertion passed
+under every possible implementation.
+
+Mutation-verified: with SduDataPtr[0x01u] set to 0x01 or 0x02 the old
+assertion still passed and the new one fails on TRANSFER_MODE and
+COMPRESSED_ENCRYPTED respectively.
+
+No behaviour change; the byte is still 0x00.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+git push
+```
+
+---
+
+### Task 2: Answer `Length = 0` for defined-but-unserved types, `ERR_OUT_OF_RANGE` only for 5–127
+
+Implements DD110 and DD113 without the callback. After this task the module still serves only type 0, but it declines the other defined types the way the specification prescribes instead of erroring.
+
+**Files:**
+- Modify: `source/Xcp_Internal.h` (type bounds, after the Mode masks from Task 1)
+- Modify: `source/Xcp_Std.c` (`Xcp_DTOCmdStdGetId`)
+- Test: `test/get_id_test.py`, `test/asam_error_matrix_test.py:205-215`
+
+**Interfaces:**
+- Consumes: `XCP_GET_ID_MODE_*` from Task 1.
+- Produces: `XCP_GET_ID_TYPE_ASCII` (0), `XCP_GET_ID_TYPE_LAST_DEFINED` (4), `XCP_GET_ID_TYPE_FIRST_USER_DEFINED` (128) — used by Task 4.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `test/get_id_test.py`:
+
+```python
+def _connect(handle):
+    handle.lib.Xcp_CanIfRxIndication(0x0001, handle.get_pdu_info((0xFF, 0x00)))
+    handle.lib.Xcp_MainFunction()
+    handle.lib.Xcp_CanIfTxConfirmation(0x0001, handle.define('E_OK'))
+
+
+def _get_id(handle, identification_type):
+    """Issue GET_ID and return the response bytes, read immediately after the transmit call."""
+    handle.lib.Xcp_CanIfRxIndication(0x0001, handle.get_pdu_info((0xFA, identification_type)))
+    handle.lib.Xcp_MainFunction()
+    raw = tuple(handle.can_if_transmit.call_args[0][1].SduDataPtr[0:8])
+    handle.lib.Xcp_CanIfTxConfirmation(0x0001, handle.define('E_OK'))
+    return raw
+
+
+@pytest.mark.parametrize('byte_order', byte_orders)
+@pytest.mark.parametrize('identification_type', (0x01, 0x02, 0x03, 0x04, 0x80, 0xFF))
+def test_get_id_reports_length_zero_for_a_defined_type_it_does_not_serve(byte_order,
+                                                                        identification_type):
+    """XCP part 2 - Protocol Layer Specification 1.1/1.6.1.2.2 (1.0/1.6.1.2.2, identical wording):
+    "If length is 0, the requested identification type is not available." That is GET_ID's own
+    in-band way of declining, and it exists so a master can enumerate what a slave supports without
+    provoking errors. Types 1-4 and 128-255 are all types 1.1 defines as requestable, so naming one
+    is a valid parameter even on a slave with nothing to return for it -- DD110.
+
+    Type 255 is covered here deliberately: the ERR_OUT_OF_RANGE test this replaces ranged over
+    range(0x01, 0xFF), which stops at 254, so the top of the user-defined range was never exercised.
+    """
+    handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001, byte_order=byte_order))
+    _connect(handle)
+
+    raw_data = _get_id(handle, identification_type)
+
+    assert raw_data[0] == 0xFF, 'a declined type is still a positive response, not an error packet'
+    assert raw_data[1] == 0x00, 'Mode: TRANSFER_MODE and COMPRESSED_ENCRYPTED both clear'
+    assert u32_from_array(bytearray(raw_data[4:8]), byte_order) == 0, 'Length must be 0'
+
+
+@pytest.mark.parametrize('identification_type', (0x05, 0x40, 0x7F))
+def test_get_id_rejects_a_type_the_specification_does_not_define(identification_type):
+    """1.1/1.6.1.2.2 lists exactly 0, 1, 2, 3, 4 and 128..255 as the types that "may be requested".
+    5..127 name no identification type at all, so a master sending one has supplied an out-of-range
+    parameter -- which is what keeps 1.1/1.7.3.2.1's GET_ID ERR_OUT_OF_RANGE row reachable, given
+    that the identification type is GET_ID's only parameter. DD110."""
+    handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001))
+    _connect(handle)
+
+    raw_data = _get_id(handle, identification_type)
+
+    assert raw_data[0:2] == (0xFE, 0x22), 'expected ERR_OUT_OF_RANGE'
+
+
+def test_get_id_nulls_the_mta_when_it_reports_length_zero():
+    """DD113. A declined GET_ID must not leave an earlier SET_MTA's pointer standing: a master that
+    ignores Length = 0 and uploads anyway would then read through a pointer the slave never set for
+    this purpose -- the defect DD75 fixed for the extension half of the same pair, the other way
+    round. (NULL_PTR, 0) is this module's own vocabulary for "nothing meaningful on this pair":
+    Xcp_Init and Xcp_CTOCmdStdConnect both pair exactly that.
+
+    Observed through UPLOAD's own argument, because Xcp_Internal is not reachable from the harness.
+    """
+    handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001))
+    _connect(handle)
+
+    # Point the MTA somewhere recognisable first, so a pass cannot come from it never having moved.
+    handle.lib.Xcp_CanIfRxIndication(0x0001, handle.get_pdu_info((0xF6, 0x00, 0x00, 0x07,
+                                                                 0xDE, 0xAD, 0xBE, 0xEF)))
+    handle.lib.Xcp_MainFunction()
+    handle.lib.Xcp_CanIfTxConfirmation(0x0001, handle.define('E_OK'))
+
+    _get_id(handle, 0x03)
+
+    addresses = []
+    handle.xcp_read_slave_memory_u8.side_effect = lambda p_address, extension, _p_buffer: \
+        addresses.append((int(handle.ffi.cast('uintptr_t', p_address)), extension))
+
+    handle.lib.Xcp_CanIfRxIndication(0x0001, handle.get_pdu_info((0xF5, 0x01)))
+    handle.lib.Xcp_MainFunction()
+
+    assert addresses, 'UPLOAD did not read any memory'
+    assert addresses[0] == (0, 0), \
+        'a Length = 0 GET_ID left the MTA at {} instead of nulling it'.format(addresses[0])
+```
+
+
+- [ ] **Step 2: Run and verify they fail**
+
+```bash
+docker run --rm --user "$(id -u):$(id -g)" --env HOME=/tmp --ulimit nofile=65536:524288 --volume "$PWD:/usr/project" --workdir /usr/project xcp-test:sp4b ./test.sh
+```
+Expected: `test_get_id_reports_length_zero_for_a_defined_type_it_does_not_serve` fails — today every non-zero type answers `(0xFE, 0x22)`, so `raw_data[0]` is `0xFE` not `0xFF`. `test_get_id_nulls_the_mta_when_it_reports_length_zero` fails for the same reason. `test_get_id_rejects_a_type_the_specification_does_not_define` **passes already** — it is a regression guard on behaviour Task 2 must preserve, not a driver.
+
+- [ ] **Step 3: Add the type bounds**
+
+In `source/Xcp_Internal.h`, after the Mode masks from Task 1:
+
+```c
+/**
+ * @brief GET_ID Requested Identification Type values.
+ * @note XCP part 2 - Protocol Layer Specification 1.1/1.6.1.2.2 (1.0/1.6.1.2.2, identical list):
+ * 0 ASCII text, 1 ASAM-MC2 filename without path and extension, 2 with path and extension, 3 URL,
+ * 4 ASAM-MC2 file to upload, 128..255 user defined. 5..127 are not identification types.
+ */
+#define XCP_GET_ID_TYPE_ASCII (0x00u)
+#define XCP_GET_ID_TYPE_LAST_DEFINED (0x04u)
+#define XCP_GET_ID_TYPE_FIRST_USER_DEFINED (0x80u)
+```
+
+- [ ] **Step 4: Restructure the command**
+
+Replace the body of `Xcp_DTOCmdStdGetId` in `source/Xcp_Std.c`. Keep DD75's existing comment block attached to the `extension = 0x00u` assignment on the static path — do not delete it.
+
+```c
+uint8 Xcp_DTOCmdStdGetId(boolean *responseExpected, const PduInfoType *pPduInfo)
+{
+    Std_ReturnType result = E_OK;
+
+    *responseExpected = TRUE;
+
+    const uint8 identification_type = pPduInfo->SduDataPtr[0x01u];
+
+    if ((identification_type > XCP_GET_ID_TYPE_LAST_DEFINED) &&
+        (identification_type < XCP_GET_ID_TYPE_FIRST_USER_DEFINED))
+    {
+        /* 5..127 name no identification type at all: 1.1/1.6.1.2.2 lists 0..4 and 128..255 as the
+         * types that "may be requested". This is the only value range that can reach GET_ID's own
+         * ERR_OUT_OF_RANGE row in 1.1/1.7.3.2.1, the identification type being its only parameter.
+         * A defined type this slave simply does not serve is NOT an error -- it answers Length = 0
+         * below, which is what 1.1/1.6.1.2.2 defines that value to mean. DD110. */
+        Xcp_FillErrorPacket(XCP_E_ASAM_OUT_OF_RANGE, &Xcp_Internal.cto_response.pdu_info);
+    }
+    else
+    {
+        const void *identification = NULL_PTR;
+        uint8 extension = 0x00u;
+        uint32 identification_length = 0x00000000u;
+
+        if (identification_type == XCP_GET_ID_TYPE_ASCII)
+        {
+            identification = (const void *)Xcp_Ptr->general->identification;
+            /* <-- DD75's existing comment block moves here verbatim --> */
+            extension = 0x00u;
+
+            for (identification_length = 0x00000000u;
+                 identification_length < 0xFFFFFFFFu;
+                 identification_length++)
+            {
+                if (Xcp_Ptr->general->identification[identification_length] == 0x00u)
+                {
+                    break;
+                }
+            }
+        }
+
+        /* DD113: a declined type nulls the MTA rather than leaving an earlier SET_MTA's pointer
+         * standing for an UPLOAD that ignores Length = 0. (NULL_PTR, 0) is this module's own
+         * vocabulary for "nothing meaningful on this pair" -- Xcp_Init and Xcp_CTOCmdStdConnect
+         * both pair exactly that. */
+        Xcp_Internal.memory_transfer.address = (void *)identification;
+        Xcp_Internal.memory_transfer.extension = extension;
+
+        Xcp_Internal.cto_response.pdu_info.SduDataPtr[0x00u] = XCP_PID_RESPONSE;
+        /* Mode (1.1/1.6.1.2.2): TRANSFER_MODE and COMPRESSED_ENCRYPTED both clear. DD111. */
+        Xcp_Internal.cto_response.pdu_info.SduDataPtr[0x01u] = 0x00u;
+        Xcp_Internal.cto_response.pdu_info.SduDataPtr[0x02u] = 0x00u;
+        Xcp_Internal.cto_response.pdu_info.SduDataPtr[0x03u] = 0x00u;
+        Xcp_CopyFromU32WithOrder(identification_length,
+                                 &Xcp_Internal.cto_response.pdu_info.SduDataPtr[0x04u],
+                                 Xcp_Ptr->general->byteOrder);
+
+        Xcp_FinalizeResPacket(0x08u, &Xcp_Internal.cto_response.pdu_info);
+    }
+
+    return result;
+}
+```
+
+- [ ] **Step 5: Narrow the error-matrix test**
+
+In `test/asam_error_matrix_test.py`, change `test_returns_err_out_of_range`'s parametrisation from `range(0x01, 0xFF)` to `range(0x05, 0x80)` and add to the test body's docstring:
+
+```python
+    """1.1/1.6.1.2.2 defines identification types 0-4 and 128-255. Only 5-127 are out of range;
+    a defined type this slave does not serve answers a positive response with Length = 0 instead
+    (test/get_id_test.py::test_get_id_reports_length_zero_for_a_defined_type_it_does_not_serve),
+    which is what 1.1/1.6.1.2.2 defines Length = 0 to mean. DD110.
+
+    This previously ranged over range(0x01, 0xFF) -- every type but 0, and stopping short of 255.
+    """
+```
+
+- [ ] **Step 6: Run the full suite**
+
+```bash
+docker run --rm --user "$(id -u):$(id -g)" --env HOME=/tmp --ulimit nofile=65536:524288 --volume "$PWD:/usr/project" --workdir /usr/project xcp-test:sp4b ./test.sh
+```
+Expected: all green. Test count changes — `test_returns_err_out_of_range` drops from 254 to 123 parametrisations, and the new tests add 12 + 3 + 1. Record the new total.
+
+- [ ] **Step 7: Mutation-verify**
+
+Three mutations, each reverted after confirming the named test fails:
+1. Change `identification_type < XCP_GET_ID_TYPE_FIRST_USER_DEFINED` to `<= 0xFFu` → `test_get_id_reports_length_zero_for_a_defined_type_it_does_not_serve[0x80]` and `[0xFF]` must fail.
+2. Change `identification_type > XCP_GET_ID_TYPE_LAST_DEFINED` to `> 0x00u` → `test_get_id_reports_length_zero_for_a_defined_type_it_does_not_serve` must fail for types 1–4.
+3. Delete the `Xcp_Internal.memory_transfer.address = ...` assignment → `test_get_id_nulls_the_mta_when_it_reports_length_zero` must fail.
+
+- [ ] **Step 8: Commit and push**
+
+```bash
+git add source/Xcp_Internal.h source/Xcp_Std.c test/get_id_test.py test/asam_error_matrix_test.py
+git commit -m "feat: decline an unserved GET_ID type with Length = 0, not ERR_OUT_OF_RANGE
+
+XCP part 2 1.1/1.6.1.2.2 (1.0 identical): "If length is 0, the requested
+identification type is not available." GET_ID has its own in-band way to
+decline, so a master can enumerate support without provoking errors. The
+module answered ERR_OUT_OF_RANGE for every type but 0, which never let
+that mechanism fire.
+
+ERR_OUT_OF_RANGE is not dropped: 1.1/1.7.3.2.1 gives GET_ID its own row
+with recovery 'retry other parameter', and the identification type is its
+only parameter. It now covers 5-127, which 1.1/1.6.1.2.2 does not define
+as identification types at all. DD110.
+
+A declined type also nulls the MTA rather than leaving an earlier SET_MTA
+standing for an UPLOAD that ignores Length = 0 (DD113).
+
+The narrowed error-matrix test previously ranged over range(0x01, 0xFF),
+which never covered type 255; the new Length = 0 test does.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+git push
+```
+
+---
+
+### Task 3: Enforce `Length mod AG = 0` at generation time
+
+DD112's static half. 1.1/§1.6.1.2.2 adds `Length mod AG = 0`; 1.0 has no equivalent. The shipped default `identification` is 21 bytes and already violates it under `WORD` and `DWORD`, so the guard and the new default land together — the guard would otherwise reject the module's own default configuration.
+
+**Files:**
+- Modify: `script/source_cfg.c.jinja2` (near the existing guards at 748-750)
+- Modify: `config/xcp.json:308`, `config/xcp.schema.json:624-627`
+- Modify: `test/parameter.py:395`
+- Test: `test/daq_configuration_test.py`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `DefaultConfig(identification=...)` now defaults to `/path/to/xcp.a2l`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/daq_configuration_test.py`:
+
+```python
+@pytest.mark.parametrize('address_granularity, identification', (
+    ('WORD', '/path/to/database.a2l'),    # 21 bytes: 21 mod 2 == 1
+    ('DWORD', '/path/to/database.a2l'),   # 21 bytes: 21 mod 4 == 1
+    ('DWORD', '/path/to/xcp.a2ll'),       # 17 bytes: 17 mod 4 == 1
+))
+def test_generation_refuses_an_identification_that_is_not_a_multiple_of_the_granularity(
+        address_granularity, identification):
+    """XCP part 2 - Protocol Layer Specification 1.1/1.6.1.2.2 adds a rule 1.0/1.6.1.2.2 does not
+    have: "The following rule applies: Length mod AG = 0". It protects the UPLOAD that follows,
+    whose element count 1.1 defines as (Length GET_ID [BYTE]) / AG -- an inexact division leaves
+    the master unable to ask for the right number of elements. DD112.
+
+    The guard message is documentation, not output: raise() is not a registered Jinja global in
+    bsw_code_gen, so referencing it aborts rendering with UndefinedError and the string never
+    reaches the caller. This asserts that generation fails, never that a message matches.
+    """
+    with pytest.raises(UndefinedError):
+        XcpTest(DefaultConfig(address_granularity=address_granularity,
+                              identification=identification))
+
+
+@pytest.mark.parametrize('address_granularity', ('BYTE', 'WORD', 'DWORD'))
+def test_generation_accepts_the_default_identification_under_every_granularity(
+        address_granularity):
+    """The boundary above from the accepting side, and the reason the shipped default changed from
+    /path/to/database.a2l (21 bytes) to /path/to/xcp.a2l (16): without it the guard would reject
+    the module's own default configuration under WORD and DWORD."""
+    handle = XcpTest(DefaultConfig(address_granularity=address_granularity))
+
+    assert handle.config.lib.Xcp[0].general.addressGranularity == handle.define(
+        'XCP_ADDRESS_GRANULARITY_{}'.format(address_granularity))
+```
+
+If that last assertion's enum spelling does not match the generated header, assert on
+`handle.ffi.string(handle.config.lib.Xcp[0].general.identification) == b'/path/to/xcp.a2l'`
+instead — the point of the test is that generation succeeds at all.
+
+- [ ] **Step 2: Run and verify it fails**
+
+```bash
+docker run --rm --user "$(id -u):$(id -g)" --env HOME=/tmp --ulimit nofile=65536:524288 --volume "$PWD:/usr/project" --workdir /usr/project xcp-test:sp4b ./test.sh
+```
+Expected: `test_generation_refuses_an_identification_that_is_not_a_multiple_of_the_granularity` fails — no guard exists, so generation succeeds and `pytest.raises` sees nothing.
+
+- [ ] **Step 3: Add the generator guard**
+
+In `script/source_cfg.c.jinja2`, immediately after the `odt_entry_size_daq < 1` guard block (around line 750):
+
+```jinja
+{%- set ag_size = {'BYTE': 1, 'WORD': 2, 'DWORD': 4}[configuration.protocol_layer.address_granularity] %}
+{%- if (configuration.protocol_layer.identification | length) % ag_size != 0 %}
+    {#- XCP part 2 1.1/1.6.1.2.2 adds a rule 1.0/1.6.1.2.2 does not have: "The following rule
+        applies: Length mod AG = 0". GET_ID reports the identification's length in bytes, and
+        1.1 defines the initial UPLOAD's element count as (Length GET_ID [BYTE]) / AG -- an
+        inexact division leaves the master unable to ask for the right number of elements.
+        Refused here rather than at run time because for the configured string it is knowable
+        now, and an integrator should learn at build time rather than on the wire. Callback-
+        supplied identifications cannot be checked here and are checked in Xcp_DTOCmdStdGetId
+        instead. DD112. #}
+{{ raise('identification {!r} is {} bytes, which is not a multiple of the {}-byte {} address granularity; XCP part 2 1.1/1.6.1.2.2 requires Length mod AG = 0 because the initial UPLOAD element count is Length / AG'.format(configuration.protocol_layer.identification, configuration.protocol_layer.identification | length, ag_size, configuration.protocol_layer.address_granularity)) }}
+{%- endif %}
+```
+
+- [ ] **Step 4: Change the shipped default in all three places**
+
+`config/xcp.json:308`:
+```json
+        "identification": "/path/to/xcp.a2l"
+```
+
+`config/xcp.schema.json`, the `identification` property — add a description alongside the new default:
+```json
+              "identification": {
+                "description": "Identification type 0 (ASCII) returned by GET_ID, and the fallback for type 0 when no get_id_function is configured. XCP part 2 - Protocol Layer Specification 1.1/1.6.1.2.2 requires Length mod AG = 0, so its length must be a multiple of address_granularity; generation refuses a configuration where it is not. The default is 16 bytes, which conforms under BYTE, WORD and DWORD alike.",
+                "type": "string",
+                "default": "/path/to/xcp.a2l"
+              },
+```
+
+`test/parameter.py:395`:
+```python
+                 identification='/path/to/xcp.a2l',
+```
+
+- [ ] **Step 5: Run the full suite**
+
+```bash
+docker run --rm --user "$(id -u):$(id -g)" --env HOME=/tmp --ulimit nofile=65536:524288 --volume "$PWD:/usr/project" --workdir /usr/project xcp-test:sp4b ./test.sh
+```
+Expected: all green. `test_get_id_returns_identification_through_mta_when_mode_is_0` passes its own explicit `identification` and is unaffected; `test/session_teardown_test.py`'s GET_ID tests read whatever the default is and should follow the change without edits. If either asserts the old 21-byte string literally, update the expectation — do not revert the default.
+
+- [ ] **Step 6: Mutation-verify**
+
+Change the guard's `% ag_size != 0` to `% 1 != 0` (always false, guard never fires) and confirm `test_generation_refuses_an_identification_that_is_not_a_multiple_of_the_granularity` fails on all three rows. Revert.
+
+- [ ] **Step 7: Commit and push**
+
+```bash
+git add script/source_cfg.c.jinja2 config/xcp.json config/xcp.schema.json test/parameter.py test/daq_configuration_test.py
+git commit -m "feat: refuse an identification whose length is not a multiple of AG
+
+XCP part 2 1.1/1.6.1.2.2 adds a rule 1.0/1.6.1.2.2 does not have --
+'Length mod AG = 0' -- protecting the UPLOAD that follows, whose element
+count 1.1 defines as (Length GET_ID [BYTE]) / AG.
+
+The module already violated it: the default identification is 21 bytes,
+and 21 mod 2 and 21 mod 4 are both 1, so every configuration using WORD
+or DWORD granularity reported a non-conforming Length. Eleven test files
+exercise non-BYTE AG through the shared DefaultConfig.
+
+The default therefore changes from /path/to/database.a2l (21 bytes) to
+/path/to/xcp.a2l (16), which conforms under every granularity -- without
+it the new guard would reject the module's own default configuration.
+
+Callback-supplied identifications are not knowable at generation time and
+are checked at run time instead. DD112.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+git push
+```
+
+---
+
+### Task 4: The integrator callback
+
+DD108 and DD109. After this task every identification type can be served.
+
+**Files:**
+- Modify: `interface/Xcp_Types.h` (tail of `Xcp_GeneralType`, after `readStoredSessionConfigurationIdApiEnable`)
+- Modify: `config/xcp.schema.json` (new `get_id_function` property, added to `required`)
+- Modify: `config/xcp.json` (`"get_id_function": null`)
+- Modify: `script/source_cfg.c.jinja2:1233` area (initialiser tail)
+- Modify: `source/Xcp_Std.c` (`Xcp_DTOCmdStdGetId`)
+- Modify: `test/parameter.py`, `test/conftest.py`
+- Test: `test/get_id_test.py`
+
+**Interfaces:**
+- Consumes: `XCP_GET_ID_TYPE_*` from Task 2.
+- Produces:
+  ```c
+  Std_ReturnType (*const getIdentificationFunction)(uint8 identificationType,
+                                                    const void **pIdentification,
+                                                    uint8 *pExtension,
+                                                    uint32 *pLength);
+  ```
+  Harness attribute `handle.xcp_get_identification_function` (a `MagicMock`), config knob `DefaultConfig(get_id_function='Xcp_GetIdentificationFunction')`. Task 5 uses both.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `test/get_id_test.py`:
+
+```python
+_CALLBACK_CONFIG = dict(channel_rx_pdu_ref=0x0001,
+                        get_id_function='Xcp_GetIdentificationFunction')
+
+
+def _serve(handle, payload, extension=0x00):
+    """Make the configured callback answer `payload` for every type, and keep the buffer alive."""
+    buffer = handle.ffi.new('char[]', payload)
+    handle._pdu_info_keepalive.append(buffer)
+
+    def get_identification(_type, p_identification, p_extension, p_length):
+        p_identification[0] = handle.ffi.cast('void *', buffer)
+        p_extension[0] = extension
+        p_length[0] = len(payload)
+        return handle.define('E_OK')
+
+    handle.xcp_get_identification_function.side_effect = get_identification
+    return buffer
+
+
+@pytest.mark.parametrize('byte_order', byte_orders)
+@pytest.mark.parametrize('identification_type', (0x00, 0x01, 0x02, 0x03, 0x04, 0x80, 0xFF))
+def test_get_id_serves_every_defined_type_from_the_callback(byte_order, identification_type):
+    """DD108. Types 1-3 are strings an integrator could put in xcp.json, but type 4 is
+    "ASAM-MC2 file to upload" (1.1/1.6.1.2.2) -- a whole A2L file whose contents are not known when
+    the configuration is generated -- and 128..255 is an open user-defined range a fixed table
+    cannot enumerate. So identification data comes from a callback."""
+    handle = XcpTest(DefaultConfig(byte_order=byte_order, **_CALLBACK_CONFIG))
+    _connect(handle)
+    _serve(handle, b'abcd')
+
+    raw_data = _get_id(handle, identification_type)
+
+    assert raw_data[0] == 0xFF
+    assert u32_from_array(bytearray(raw_data[4:8]), byte_order) == 4
+    assert handle.xcp_get_identification_function.call_args[0][0] == identification_type, \
+        'the callback must be told which type was requested'
+
+
+def test_get_id_points_the_mta_at_the_callbacks_address_and_extension():
+    """DD109. DD75 fixed extension = 0 for the *static* identification, on the ground that it is
+    "plain, slave-owned descriptive data that lives entirely outside the page-switching model" --
+    an argument about Xcp_Ptr->general->identification that does not transfer to arbitrary
+    integrator data. Type 4 is the case that breaks it: an A2L file plausibly lives in memory the
+    integrator's Xcp_ReadSlaveMemory* reaches through a non-zero extension. Fixing the extension at
+    0 would advertise type 4 while only being able to serve it from extension-0 memory."""
+    handle = XcpTest(DefaultConfig(**_CALLBACK_CONFIG))
+    _connect(handle)
+    buffer = _serve(handle, b'wxyz', extension=0x07)
+
+    _get_id(handle, 0x04)
+
+    reads = []
+    handle.xcp_read_slave_memory_u8.side_effect = lambda p_address, extension, _p_buffer: \
+        reads.append((int(handle.ffi.cast('uintptr_t', p_address)), extension))
+
+    handle.lib.Xcp_CanIfRxIndication(0x0001, handle.get_pdu_info((0xF5, 0x04)))
+    handle.lib.Xcp_MainFunction()
+
+    assert reads, 'UPLOAD did not read any memory'
+    assert reads[0] == (int(handle.ffi.cast('uintptr_t', buffer)), 0x07), \
+        'UPLOAD read {} -- expected the callback\'s own address and extension 7'.format(reads[0])
+
+
+def test_get_id_falls_back_to_the_static_identification_when_the_callback_declines_type_zero():
+    """DD110. The callback is consulted for every defined type including 0, and E_NOT_OK means
+    "I do not serve that type" rather than an error. For type 0 the configured string is the
+    fallback, so an integrator who only wants types 1-4 returns E_NOT_OK for 0 and still gets the
+    behaviour that shipped before this phase."""
+    handle = XcpTest(DefaultConfig(identification='/path/to/xcp.a2l', **_CALLBACK_CONFIG))
+    _connect(handle)
+    handle.xcp_get_identification_function.side_effect = None
+    handle.xcp_get_identification_function.return_value = handle.define('E_NOT_OK')
+
+    raw_data = _get_id(handle, 0x00)
+
+    assert raw_data[0] == 0xFF
+    assert u32_from_array(bytearray(raw_data[4:8]), 'LITTLE_ENDIAN') == len('/path/to/xcp.a2l')
+
+
+@pytest.mark.parametrize('identification_type', (0x01, 0x04, 0x80, 0xFF))
+def test_get_id_reports_length_zero_when_the_callback_declines_a_non_ascii_type(
+        identification_type):
+    """The other half of the fallback: only type 0 has a static string behind it, so a declined
+    type 1-4 or 128-255 is simply not available -- Length = 0, per 1.1/1.6.1.2.2. DD110."""
+    handle = XcpTest(DefaultConfig(**_CALLBACK_CONFIG))
+    _connect(handle)
+    handle.xcp_get_identification_function.side_effect = None
+    handle.xcp_get_identification_function.return_value = handle.define('E_NOT_OK')
+
+    raw_data = _get_id(handle, identification_type)
+
+    assert raw_data[0] == 0xFF
+    assert u32_from_array(bytearray(raw_data[4:8]), 'LITTLE_ENDIAN') == 0
+
+
+@pytest.mark.parametrize('identification_type', (0x05, 0x7F))
+def test_get_id_does_not_consult_the_callback_for_an_undefined_type(identification_type):
+    """5..127 are refused before the callback is reached: they name no identification type at all,
+    so there is nothing for an integrator to be asked about. DD110."""
+    handle = XcpTest(DefaultConfig(**_CALLBACK_CONFIG))
+    _connect(handle)
+    _serve(handle, b'abcd')
+
+    raw_data = _get_id(handle, identification_type)
+
+    assert raw_data[0:2] == (0xFE, 0x22)
+    handle.xcp_get_identification_function.assert_not_called()
+```
+
+- [ ] **Step 2: Run and verify they fail**
+
+Expected: every new test errors in `XcpTest(...)` construction — `get_id_function` is not a `DefaultConfig` parameter yet.
+
+- [ ] **Step 3: Add the schema property**
+
+In `config/xcp.schema.json`, beside `user_cmd_function`, matching its shape exactly:
+
+```json
+              "get_id_function": {
+                "description": "Optional integrator callback supplying GET_ID identification data for any type. XCP part 2 - Protocol Layer Specification 1.1/1.6.1.2.2 leaves which types a slave supports implementation specific; this is how it decides. Returning E_NOT_OK means the type is not served, which answers Length = 0 -- except for type 0, which falls back to the configured identification string. null means only type 0 is served, from that string alone.",
+                "OneOf": [
+                  {
+                    "type": "null"
+                  },
+                  {
+                    "type": "string",
+                    "enum": [
+                      "Xcp_GetIdentificationFunction"
+                    ]
+                  }
+                ],
+                "default": null
+              },
+```
+
+Add `"get_id_function"` to the same `required` array that already lists `"user_cmd_function"` and `"identification"`.
+
+- [ ] **Step 4: Add the struct field at the tail**
+
+In `interface/Xcp_Types.h`, as the **last** member of `Xcp_GeneralType`, after `readStoredSessionConfigurationIdApiEnable`:
+
+```c
+    /**
+     * @brief supplies GET_ID identification data for any identification type.
+     * @param identificationType the Requested Identification Type from the GET_ID request: 0..4 or
+     * 128..255 (XCP part 2 - Protocol Layer Specification 1.1/1.6.1.2.2). 5..127 are refused before
+     * this is called.
+     * @param pIdentification set to the address the master will UPLOAD the identification from.
+     * @param pExtension set to the MTA address extension that address is reached through. 0 unless
+     * the data lives in a region the integrator's Xcp_ReadSlaveMemory* selects with a non-zero
+     * extension (DD109).
+     * @param pLength set to the identification's length in bytes. Must be a multiple of the
+     * configured address granularity -- 1.1/1.6.1.2.2's "Length mod AG = 0" -- or the module raises
+     * XCP_E_IDENTIFICATION_NOT_GRANULAR and answers Length = 0 (DD112).
+     * @return E_OK with all three out-parameters set, or E_NOT_OK meaning this slave does not serve
+     * that type. E_NOT_OK is not an error: it answers Length = 0, which 1.1/1.6.1.2.2 defines as
+     * "the requested identification type is not available". For type 0 it falls back to the
+     * configured identification string instead.
+     * @note not part of the specification. NULL_PTR means only type 0 is served, from the
+     * configured identification string.
+     */
+    Std_ReturnType (*const getIdentificationFunction)(uint8 identificationType,
+                                                      const void **pIdentification,
+                                                      uint8 *pExtension,
+                                                      uint32 *pLength); /* not part of the specification... */
+} Xcp_GeneralType;
+```
+
+- [ ] **Step 5: Add the initialiser entry at the tail**
+
+In `script/source_cfg.c.jinja2`, find the **last** entry of the `Xcp_GeneralType` initialiser — the one emitting `readStoredSessionConfigurationIdApiEnable` — and add immediately after it, following the `user_cmd_function` idiom at line 1231:
+
+```jinja
+    {% if configuration.protocol_layer.get_id_function %}&{{configuration.protocol_layer.get_id_function}}{% else %}NULL_PTR{% endif %}, /* getIdentificationFunction */
+```
+
+**Verify the position before running anything else:** generate once and diff the generated source against the previous revision. Exactly one line may be added, and no existing initialiser value may move to a different field. This struct is positional.
+
+- [ ] **Step 6: Wire the harness**
+
+In `test/conftest.py`, beside the `Xcp_UserCmdFunction` registration around line 594:
+
+```python
+        self.xcp_get_identification_function = MagicMock()
+        self.config.ffi.def_extern('Xcp_GetIdentificationFunction')(
+                self._guarded_callback('Xcp_GetIdentificationFunction',
+                                       self.xcp_get_identification_function))
+        self.xcp_get_identification_function.return_value = self.define('E_NOT_OK')
+```
+
+`E_NOT_OK` is the right default: a test that configures the callback without setting a `side_effect` gets "serves nothing", not a mock returning a truthy `MagicMock` that the module would read as `E_OK` with unset out-parameters.
+
+In `test/parameter.py`, add the parameter beside `user_cmd_function` (line 393) and the emitted key beside it (line 419):
+
+```python
+                 get_id_function=None,
+```
+```python
+            "get_id_function": get_id_function,
+```
+
+- [ ] **Step 7: Consult the callback in the command**
+
+In `source/Xcp_Std.c`, inside `Xcp_DTOCmdStdGetId`'s `else` branch, replace the type-0-only block from Task 2 with:
+
+```c
+        const void *identification = NULL_PTR;
+        uint8 extension = 0x00u;
+        uint32 identification_length = 0x00000000u;
+        boolean served = FALSE;
+
+        if (Xcp_Ptr->general->getIdentificationFunction != NULL_PTR)
+        {
+            /* Consulted for every defined type including 0, so an integrator who needs a
+             * runtime-varying type 0 can override the configured string. Declining it falls back
+             * to that string below, which is what makes a NULL_PTR callback and a callback that
+             * returns E_NOT_OK for type 0 behave identically. DD110. */
+            if (Xcp_Ptr->general->getIdentificationFunction(identification_type,
+                                                            &identification,
+                                                            &extension,
+                                                            &identification_length) == E_OK)
+            {
+                served = TRUE;
+            }
+            else
+            {
+                identification = NULL_PTR;
+                extension = 0x00u;
+                identification_length = 0x00000000u;
+            }
+        }
+
+        if ((served == FALSE) && (identification_type == XCP_GET_ID_TYPE_ASCII))
+        {
+            identification = (const void *)Xcp_Ptr->general->identification;
+            /* <-- DD75's existing comment block stays here --> */
+            extension = 0x00u;
+
+            for (identification_length = 0x00000000u;
+                 identification_length < 0xFFFFFFFFu;
+                 identification_length++)
+            {
+                if (Xcp_Ptr->general->identification[identification_length] == 0x00u)
+                {
+                    break;
+                }
+            }
+        }
+```
+
+The rest of the `else` branch — the MTA assignment, the response bytes and `Xcp_FinalizeResPacket` — is unchanged from Task 2.
+
+- [ ] **Step 8: Run the full suite**
+
+```bash
+docker run --rm --user "$(id -u):$(id -g)" --env HOME=/tmp --ulimit nofile=65536:524288 --volume "$PWD:/usr/project" --workdir /usr/project xcp-test:sp4b ./test.sh
+```
+Expected: all green.
+
+- [ ] **Step 9: Mutation-verify**
+
+1. Make the callback's `E_NOT_OK` path set `served = TRUE` → `test_get_id_falls_back_to_the_static_identification_when_the_callback_declines_type_zero` must fail.
+2. Hardcode `extension = 0x00u` after the callback returns → `test_get_id_points_the_mta_at_the_callbacks_address_and_extension` must fail.
+3. Move the callback consultation above the 5–127 refusal → `test_get_id_does_not_consult_the_callback_for_an_undefined_type` must fail.
+
+- [ ] **Step 10: Commit and push**
+
+```bash
+git add interface/Xcp_Types.h config/xcp.json config/xcp.schema.json script/source_cfg.c.jinja2 source/Xcp_Std.c test/conftest.py test/parameter.py test/get_id_test.py
+git commit -m "feat: serve every GET_ID identification type from an integrator callback
+
+XCP part 2 1.1/1.6.1.2.2 defines identification types 0-4 and a 128-255
+user-defined range, and leaves which of them a slave supports
+implementation specific. Types 1-3 are strings that could have gone in
+xcp.json; type 4 is 'ASAM-MC2 file to upload', a whole A2L file not known
+at generation time, and 128-255 is an open range no fixed table can
+enumerate. So the mechanism is an optional callback, following the
+existing user_cmd_function pattern. DD108.
+
+The callback returns the MTA address extension alongside the address.
+DD75 fixed extension = 0 for the static identification specifically
+because it lives outside the page-switching model; that argument does not
+transfer to an A2L file in a region reached through a non-zero extension,
+and fixing it at 0 would advertise type 4 while only being able to serve
+it from extension-0 memory. DD109.
+
+The callback is consulted for every defined type including 0, with the
+configured string as type 0's fallback, so a NULL_PTR callback behaves
+exactly as the module did before this phase.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+git push
+```
+
+---
+
+### Task 5: Check callback lengths against the address granularity
+
+DD112's runtime half. Task 3 covered the configured string; a callback-supplied length is not knowable at generation time.
+
+**Files:**
+- Modify: `interface/Xcp.h` (new DET code after `XCP_E_DAQ_LIST_NOT_IDENTIFIABLE`)
+- Modify: `source/Xcp_Std.c` (`Xcp_DTOCmdStdGetId`)
+- Test: `test/get_id_test.py`
+
+**Interfaces:**
+- Consumes: everything from Task 4.
+- Produces: `XCP_E_IDENTIFICATION_NOT_GRANULAR` (`0x09u`).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/get_id_test.py`:
+
+```python
+@pytest.mark.parametrize('address_granularity, length', (('WORD', 3), ('DWORD', 5), ('DWORD', 7)))
+def test_get_id_refuses_a_callback_length_that_is_not_a_multiple_of_the_granularity(
+        address_granularity, length):
+    """DD112's runtime half. XCP part 2 1.1/1.6.1.2.2's "Length mod AG = 0" protects the UPLOAD that
+    follows, whose element count 1.1 defines as (Length GET_ID [BYTE]) / AG. The configured string
+    is checked at generation time; a callback's length is not knowable then.
+
+    The module cannot emit a non-conforming Length, and reporting the type unavailable is the honest
+    alternative to truncating the data or padding it with the NULs 1.1 explicitly says the string
+    does not carry. The integrator hears about it through DET, which is the only channel available:
+    the master is simply told the type is not there.
+    """
+    handle = XcpTest(DefaultConfig(address_granularity=address_granularity, **_CALLBACK_CONFIG))
+    _connect(handle)
+    _serve(handle, b'x' * length)
+
+    raw_data = _get_id(handle, 0x01)
+
+    assert raw_data[0] == 0xFF, 'still a positive response'
+    assert u32_from_array(bytearray(raw_data[4:8]), 'LITTLE_ENDIAN') == 0, \
+        'a non-conforming length must be reported as unavailable, not emitted'
+    handle.det_report_error.assert_called_once_with(
+        ANY, ANY,
+        handle.define('XCP_MAIN_FUNCTION_API_ID'),
+        handle.define('XCP_E_IDENTIFICATION_NOT_GRANULAR'))
+
+
+@pytest.mark.parametrize('address_granularity, length', (('BYTE', 3), ('WORD', 4), ('DWORD', 8)))
+def test_get_id_accepts_a_callback_length_that_is_a_multiple_of_the_granularity(
+        address_granularity, length):
+    """The boundary above from the accepting side, including BYTE, where the rule is vacuous:
+    every length is a multiple of 1, so no conforming configuration is ever refused by it."""
+    handle = XcpTest(DefaultConfig(address_granularity=address_granularity, **_CALLBACK_CONFIG))
+    _connect(handle)
+    _serve(handle, b'x' * length)
+
+    raw_data = _get_id(handle, 0x01)
+
+    assert u32_from_array(bytearray(raw_data[4:8]), 'LITTLE_ENDIAN') == length
+    handle.det_report_error.assert_not_called()
+```
+
+`test/get_id_test.py` needs `from unittest.mock import ANY` added at the top: `from .parameter import *` does not re-export it. The four-argument shape above matches the existing caller at `test/asam_protocol_layer_test.py:17` — module id, instance id, api id, error id.
+
+- [ ] **Step 2: Run and verify it fails**
+
+Expected: the refusing test fails — the module reports the true length and calls no DET.
+
+- [ ] **Step 3: Add the DET code**
+
+In `interface/Xcp.h`, after `XCP_E_DAQ_LIST_NOT_IDENTIFIABLE (0x08u)`:
+
+```c
+/**
+ * @brief A GET_ID callback returned a length that is not a multiple of the address granularity.
+ * @details XCP part 2 - Protocol Layer Specification 1.1/1.6.1.2.2 requires "Length mod AG = 0",
+ * protecting the UPLOAD that follows: 1.1 defines its element count as
+ * (Length GET_ID [BYTE]) / AG, and an inexact division leaves the master unable to ask for the
+ * right number of elements. The configured identification string is checked at generation time
+ * instead (script/source_cfg.c.jinja2); this covers what getIdentificationFunction returns, which
+ * is not knowable then.
+ * @note This error is not part of the specification, and Det is the only channel it has: the master
+ * is told the type is unavailable (Length = 0), which is indistinguishable on the wire from a slave
+ * that simply does not serve it. DD112.
+ */
+#define XCP_E_IDENTIFICATION_NOT_GRANULAR (0x09u)
+```
+
+- [ ] **Step 4: Check the length**
+
+In `source/Xcp_Std.c`, immediately after the callback block in Task 4's Step 7 (before the static fallback), add:
+
+```c
+        if (served == TRUE)
+        {
+            const uint8 element_size =
+                Xcp_ElementSizeForAddressGranularity(Xcp_Ptr->general->addressGranularity);
+
+            if ((identification_length % (uint32)element_size) != 0x00000000u)
+            {
+                /* 1.1/1.6.1.2.2: "Length mod AG = 0". The module cannot emit a non-conforming
+                 * Length, so the type is reported unavailable and the integrator hears about it
+                 * through Det -- the master has no channel for this distinction. DD112. */
+                Xcp_ReportError(0x00u, XCP_MAIN_FUNCTION_API_ID,
+                                XCP_E_IDENTIFICATION_NOT_GRANULAR);
+                identification = NULL_PTR;
+                extension = 0x00u;
+                identification_length = 0x00000000u;
+                served = FALSE;
+            }
+        }
+```
+
+Setting `served = FALSE` here deliberately does **not** fall through to the static string for type 0: a callback that answered `E_OK` has claimed the type, and silently substituting different data for a length it got wrong would hide the defect DET has just reported. Confirm this by checking that `test_get_id_falls_back_to_the_static_identification_when_the_callback_declines_type_zero` still passes — it declines with `E_NOT_OK` and must be unaffected. If the ordering makes a type-0 `E_OK` with a bad length fall back to the string, move this block after the static-fallback block instead.
+
+- [ ] **Step 5: Run the full suite and mutation-verify**
+
+```bash
+docker run --rm --user "$(id -u):$(id -g)" --env HOME=/tmp --ulimit nofile=65536:524288 --volume "$PWD:/usr/project" --workdir /usr/project xcp-test:sp4b ./test.sh
+```
+
+Mutations, each reverted:
+1. Change `% (uint32)element_size` to `% 1u` → the refusing test must fail on all three rows.
+2. Delete the `Xcp_ReportError` call, keep the rest → the refusing test must fail on the DET assertion while still passing on `Length == 0`. This is what proves the DET assertion is not riding on the length assertion.
+
+- [ ] **Step 6: Commit and push**
+
+```bash
+git add interface/Xcp.h source/Xcp_Std.c test/get_id_test.py
+git commit -m "feat: refuse a callback identification length that violates Length mod AG
+
+DD112's runtime half. The configured string is checked at generation time,
+but what getIdentificationFunction returns is not knowable then.
+
+XCP part 2 1.1/1.6.1.2.2's 'Length mod AG = 0' protects the UPLOAD that
+follows, whose element count 1.1 defines as (Length GET_ID [BYTE]) / AG.
+The module cannot emit a non-conforming Length, and reporting the type
+unavailable is the honest alternative to truncating the data or padding
+it with the NULs 1.1 explicitly says the string does not carry.
+
+Det is the only channel this has: on the wire, Length = 0 is
+indistinguishable from a slave that simply does not serve the type.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+git push
+```
+
+---
+
+### Task 6: Update the roadmap and open the PR
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-08-29-xcp-part2-roadmap.md:100`, `:373`, `:560`, `:651`
+
+- [ ] **Step 1: Update the `GET_ID` coverage row**
+
+Line 100 currently reads:
+```
+| 0xFA | GET_ID | partial — identification type 0 (ASCII) only; §1.6.1.2.2 defines 0–4 plus 128–255 user-defined, all implementation-specific |
+```
+Replace with:
+```
+| 0xFA | GET_ID | complete — types 0–4 and 128–255 served through `getIdentificationFunction`, type 0 falling back to the configured string; a defined type the slave does not serve answers `Length = 0` per 1.1/§1.6.1.2.2, 5–127 answer `ERR_OUT_OF_RANGE`. `TRANSFER_MODE` deliberately stays 0 (DD111) |
+```
+
+- [ ] **Step 2: Update the three SP5 residue sentences**
+
+At lines 373, 560 and 651, remove `GET_ID` identification types from the lists of remaining residue. Line 651's "the interleaved model, `EV_CMD_PENDING`, `GET_ID` types and the `SERV_*` codes are genuinely independent" needs `EV_CMD_PENDING` checked too — the SP5 section already records it as done, so verify before editing whether that sentence is stale in more than one way and correct what you find rather than only the `GET_ID` clause.
+
+- [ ] **Step 3: Add an SP5-GETID sub-project entry**
+
+After the `SP5-RESUME` entry, matching that entry's shape — a `#### SP5-GETID — GET_ID identification types — **complete**` heading, then paragraphs covering:
+
+- **What it built:** every identification type 1.1/§1.6.1.2.2 defines, served through `getIdentificationFunction`, with the configured string as type 0's fallback.
+- **Design:** `2026-09-11-xcp-get-id-types-design.md` (DD108–DD113).
+- **What 1.1 changed and 1.0 did not have:** the response Mode byte becoming a named bit mask (`TRANSFER_MODE` bit 0, `COMPRESSED_ENCRYPTED` bit 1), plus `Length mod AG = 0` and the initial-UPLOAD element count. Record that bit positions came from the 1.1 PDF's own text layer, not its OCR sidecar, and point at §0 of the design doc for the method — this is the second time the 1.0-vs-1.1 mode-byte pattern has appeared, after `SET_REQUEST`.
+- **Two pre-existing defects it fixed:** the Mode-byte assertion that could not fail, and the 21-byte default identification that violated `Length mod AG = 0` under WORD and DWORD.
+- **What it deliberately did not build:** inline transfer (DD111) and compression (XCP Part 4 absent), both reversible and both now documented rather than forgotten.
+
+Then check whether any *other* roadmap row is made stale by this phase before committing — §2.6 cross-cutting and the §3 defect list both mention `GET_ID`. Correct what you find; do not silently rewrite a claim that turns out to have been wrong, record the correction, as DD102 and DD105 do.
+
+- [ ] **Step 4: Commit, push, open the PR**
+
+```bash
+git add docs/superpowers/specs/2026-08-29-xcp-part2-roadmap.md
+git commit -m "docs: record SP5-GETID in the conformance roadmap
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+git push
+gh pr create --base develop --title "feat: GET_ID identification types 1-4 and 128-255" --body "$(cat <<'BODY'
+Extends GET_ID beyond identification type 0 (ASCII), the last small well-defined item on the SP5 residue list.
+
+Design: `docs/superpowers/specs/2026-09-11-xcp-get-id-types-design.md` (DD108-DD113).
+
+## What this adds
+
+- An optional `get_id_function` callback supplying identification data, MTA address and extension for any type. Type 4 is a whole A2L file and 128-255 is an open range, so neither fits in `xcp.json`.
+- `Length = 0` for a defined type the slave does not serve, which is 1.1/§1.6.1.2.2's own way of declining. `ERR_OUT_OF_RANGE` narrows to 5-127, the values that name no identification type at all, keeping §1.7.3.2.1's GET_ID row reachable.
+- Enforcement of 1.1's `Length mod AG = 0`, at generation time for the configured string and at run time for callback data.
+
+## Two defects found while reading the specification
+
+- `test_get_id_returns_identification_through_mta_when_mode_is_0` asserted `raw_data[1] == mode`, comparing the response's Mode bit mask against the request's Requested Identification Type -- two different fields coinciding at zero against a hardcoded `0x00`. The assertion passed under every possible implementation. Fixed first, as its own commit.
+- The default identification is 21 bytes, so the module already reported a `Length` violating 1.1's `Length mod AG = 0` under WORD or DWORD granularity. The default changes to a 16-byte string.
+
+## Deliberately not built
+
+`TRANSFER_MODE = 1` (inline transfer). The request packet is two bytes, so the master cannot ask for it; the slave chooses, and mode 0 is a complete answer in both revisions. Both mode bits are given named constants anyway, at positions recovered from the 1.1 PDF rather than its OCR sidecar. `COMPRESSED_ENCRYPTED` additionally depends on XCP Part 4, which is not in `docs/external/`.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+BODY
+)"
+```
+
+- [ ] **Step 5: Confirm CI is green**
+
+CI is the authoritative verification. Confirm the PR actually merged (`gh pr view N --json state,mergedAt`) before deleting the branch.

--- a/docs/superpowers/plans/2026-09-11-xcp-get-id-types.md
+++ b/docs/superpowers/plans/2026-09-11-xcp-get-id-types.md
@@ -994,6 +994,8 @@ def test_get_id_accepts_a_callback_length_that_is_a_multiple_of_the_granularity(
 
 `test/get_id_test.py` needs `from unittest.mock import ANY` added at the top: `from .parameter import *` does not re-export it. The four-argument shape above matches the existing caller at `test/asam_protocol_layer_test.py:17` — module id, instance id, api id, error id.
 
+**Correction, made during Task 5's fix round 1** (`.superpowers/sdd/2026-09-11-xcp-get-id-types/task-5-report.md`, "Fix round 1"): both `handle.define('XCP_MAIN_FUNCTION_API_ID')` calls in the test code above name the wrong API. See the fuller correction after Step 4, where the same wrong value appears in the implementation this test code was written against.
+
 - [ ] **Step 2: Run and verify it fails**
 
 Expected: the refusing test fails — the module reports the true length and calls no DET.
@@ -1044,6 +1046,8 @@ In `source/Xcp_Std.c`, immediately after the callback block in Task 4's Step 7 (
 ```
 
 Setting `served = FALSE` here deliberately does **not** fall through to the static string for type 0: a callback that answered `E_OK` has claimed the type, and silently substituting different data for a length it got wrong would hide the defect DET has just reported. Confirm this by checking that `test_get_id_falls_back_to_the_static_identification_when_the_callback_declines_type_zero` still passes — it declines with `E_NOT_OK` and must be unaffected. If the ordering makes a type-0 `E_OK` with a bad length fall back to the string, move this block after the static-fallback block instead.
+
+**Correction, made during Task 5's fix round 1** (`.superpowers/sdd/2026-09-11-xcp-get-id-types/task-5-report.md`, "Fix round 1"): the `Xcp_ReportError` call above, and the two `handle.define('XCP_MAIN_FUNCTION_API_ID')` calls in Step 1's test code, all name the wrong API. `Xcp_DTOCmdStdGetId` does not run inside `Xcp_MainFunction`: the command table's one dispatch site, `result = Xcp_PIDTable[pid](&response_expected, pPduInfo);`, is at `source/Xcp.c:2161`, inside `Xcp_CanIfRxIndication` (`source/Xcp.c:1807–2285`); `Xcp_MainFunction` (`source/Xcp.c:1501–1806`) never calls it. The module's convention reports the exported API in whose call chain a DET fires — `Xcp_DTOCmdStdBuildChecksum`, another command dispatched through the same table, already reports under `XCP_CAN_IF_RX_INDICATION_API_ID` (`source/Xcp_Std.c:638`) — so the correct value here is `XCP_CAN_IF_RX_INDICATION_API_ID`. `XCP_MAIN_FUNCTION_API_ID` was this plan's own unchecked assumption about where commands dispatch; both the shipped code and the two tests asserting it inherited that assumption from this code block and Step 1's, which is why the tests could not catch the error — implementation and expectation shared one wrong source. Not rewritten in place, per this repository's convention (DD102, DD105) of recording a correction rather than silently editing history.
 
 - [ ] **Step 4b: Give the generator guard its cross-reference, now that it is true**
 

--- a/docs/superpowers/plans/2026-09-11-xcp-get-id-types.md
+++ b/docs/superpowers/plans/2026-09-11-xcp-get-id-types.md
@@ -53,7 +53,17 @@
 
 ---
 
-### Task 1: Name the Mode bits and repair the assertion that cannot fail
+### Task 1: Name the Mode bits and repair the assertion that pinned an echo, not a bit mask
+
+**Correction, made after Task 1's implementer disproved it empirically**
+(`.superpowers/sdd/2026-09-11-xcp-get-id-types/task-1-report.md`): this title originally read
+"repair the assertion that cannot fail." The old assertion could fail — with this test's `mode`
+pinned at 0, mutating the response byte away from 0 broke the old assertion exactly as it broke the
+new one, for the unrelated reason that the two sides then read different numbers. Its real weakness
+was that it could not tell a correct bit-mask implementation from an incorrect echo of the request
+at mode 0, not that it was immune to a wrong byte on the wire. Retitled here rather than left
+standing; see the two corrections below for how the same overstatement reached this task's own step
+text and commit message.
 
 Lands first and changes no behaviour. The existing test asserts `raw_data[1] == mode`, comparing the response's Mode bit mask against the request's Requested Identification Type — two different fields coinciding at zero against a hardcoded `0x00`. Until that is fixed, nothing later in this plan is pinned by it.
 

--- a/docs/superpowers/plans/2026-09-11-xcp-get-id-types.md
+++ b/docs/superpowers/plans/2026-09-11-xcp-get-id-types.md
@@ -75,8 +75,10 @@ Replace the two assertions on `raw_data[1]` in `test_get_id_returns_identificati
     # makes this byte a bit mask -- TRANSFER_MODE at bit 0, COMPRESSED_ENCRYPTED at bit 1, bits 2-7
     # don't-care. 1.0/1.6.1.2.2 has the same byte and leaves it unnamed, which is why this was
     # previously read as an echo of the request's Requested Identification Type. It is not one:
-    # request byte 1 and response byte 1 are different fields that both happen to be 0 here, so the
-    # old `assert raw_data[1] == mode` passed under every possible implementation.
+    # request byte 1 and response byte 1 are different fields that both happen to be 0 here. The
+    # old `assert raw_data[1] == mode` pinned the right value only because this test's parametrize
+    # list has one row at zero; it would demand a wrong thing -- that the response echo the
+    # request -- as soon as a second identification type is covered.
     # Both bits clear: the slave transfers through the MTA and does not compress (DD111).
     assert raw_data[1] & 0x01 == 0x00, 'TRANSFER_MODE must be clear: this slave points the MTA'
     assert raw_data[1] & 0x02 == 0x00, 'COMPRESSED_ENCRYPTED must be clear: nothing is compressed'
@@ -89,7 +91,9 @@ Replace the two assertions on `raw_data[1]` in `test_get_id_returns_identificati
 docker run --rm --user "$(id -u):$(id -g)" --env HOME=/tmp --ulimit nofile=65536:524288 --volume "$PWD:/usr/project" --workdir /usr/project xcp-test:sp4b ./test.sh
 ```
 
-The new assertions pass against today's hardcoded `0x00`. That is expected — this step is not what proves them. **Mutation-verify now:** change `source/Xcp_Std.c` line 1323 from `SduDataPtr[0x01u] = 0x00u;` to `= 0x01u;` and re-run only this test. It must fail on the `TRANSFER_MODE` assertion. Then set `= 0x02u` and confirm it fails on `COMPRESSED_ENCRYPTED`. Revert both. Record in the commit message that the old assertion survived both mutations and the new one does not.
+The new assertions pass against today's hardcoded `0x00`. That is expected — this step is not what proves them. **Mutation-verify now:** change `source/Xcp_Std.c` line 1323 from `SduDataPtr[0x01u] = 0x00u;` to `= 0x01u;` and re-run only this test. It must fail on the `TRANSFER_MODE` assertion. Then set `= 0x02u` and confirm it fails on `COMPRESSED_ENCRYPTED`. Revert both.
+
+**Correction, made after Task 1's implementer disproved it empirically** (`.superpowers/sdd/2026-09-11-xcp-get-id-types/task-1-report.md`): this step originally ended "Record in the commit message that the old assertion survived both mutations and the new one does not." It does not survive either mutation — this test's `mode` is pinned at 0, so a mutated response byte breaks `raw_data[1] == mode` too, for the same coincidental reason it used to pass. Commit `1a6144c` carries that since-disproven wording verbatim, because it was written before the mutation-verify step above was actually run against it; the fix landed in a follow-up commit rather than rewriting the pushed one. See the design doc's DD-adjacent correction in `2026-09-11-xcp-get-id-types-design.md` §1 for the accurate characterisation.
 
 - [ ] **Step 3: Add the named masks**
 
@@ -156,6 +160,17 @@ No behaviour change; the byte is still 0x00.
 Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
 git push
 ```
+
+**Correction, made after Task 1's implementer disproved it empirically**
+(`.superpowers/sdd/2026-09-11-xcp-get-id-types/task-1-report.md`): the commit message above, as
+actually committed at `1a6144c`, claims twice that the old assertion "passed under every possible
+implementation" and "still passed" under both mutations. Neither holds — with this test's `mode`
+pinned at 0, mutating the response byte away from 0 breaks the old assertion exactly as it breaks a
+correct one, for the unrelated reason that the two sides then read different numbers. The old
+assertion's real weakness is that it cannot tell a correct bit-mask implementation from an incorrect
+echo of the request at mode 0, not that it survives a corrupted byte on the wire. `1a6144c` is not
+rewritten — this correction landed in a follow-up commit instead, per this repository's convention
+(DD102, DD105) of recording a correction rather than silently editing history.
 
 ---
 
@@ -1078,7 +1093,7 @@ Design: `docs/superpowers/specs/2026-09-11-xcp-get-id-types-design.md` (DD108-DD
 
 ## Two defects found while reading the specification
 
-- `test_get_id_returns_identification_through_mta_when_mode_is_0` asserted `raw_data[1] == mode`, comparing the response's Mode bit mask against the request's Requested Identification Type -- two different fields coinciding at zero against a hardcoded `0x00`. The assertion passed under every possible implementation. Fixed first, as its own commit.
+- `test_get_id_returns_identification_through_mta_when_mode_is_0` asserted `raw_data[1] == mode`, comparing the response's Mode bit mask against the request's Requested Identification Type -- two different fields coinciding at zero against a hardcoded `0x00`, pinned only by this test's single-row parametrize list at mode 0. Fixed first, as its own commit.
 - The default identification is 21 bytes, so the module already reported a `Length` violating 1.1's `Length mod AG = 0` under WORD or DWORD granularity. The default changes to a 16-byte string.
 
 ## Deliberately not built

--- a/docs/superpowers/plans/2026-09-11-xcp-get-id-types.md
+++ b/docs/superpowers/plans/2026-09-11-xcp-get-id-types.md
@@ -1126,8 +1126,17 @@ After the `SP5-RESUME` entry, matching that entry's shape — a `#### SP5-GETID 
 - **What it built:** every identification type 1.1/§1.6.1.2.2 defines, served through `getIdentificationFunction`, with the configured string as type 0's fallback.
 - **Design:** `2026-09-11-xcp-get-id-types-design.md` (DD108–DD113).
 - **What 1.1 changed and 1.0 did not have:** the response Mode byte becoming a named bit mask (`TRANSFER_MODE` bit 0, `COMPRESSED_ENCRYPTED` bit 1), plus `Length mod AG = 0` and the initial-UPLOAD element count. Record that bit positions came from the 1.1 PDF's own text layer, not its OCR sidecar, and point at §0 of the design doc for the method — this is the second time the 1.0-vs-1.1 mode-byte pattern has appeared, after `SET_REQUEST`.
-- **Two pre-existing defects it fixed:** the Mode-byte assertion that could not fail, and the 21-byte default identification that violated `Length mod AG = 0` under WORD and DWORD.
+- **Two pre-existing defects it fixed:** the Mode-byte assertion that pinned an echo of the request rather than the response's bit mask, and the 21-byte default identification that violated `Length mod AG = 0` under WORD and DWORD.
 - **What it deliberately did not build:** inline transfer (DD111) and compression (XCP Part 4 absent), both reversible and both now documented rather than forgotten.
+
+**Correction, made after Task 1's implementer disproved it empirically**
+(`.superpowers/sdd/2026-09-11-xcp-get-id-types/task-1-report.md`): the bullet above originally read
+"the Mode-byte assertion that could not fail." The old assertion could fail — it compared the
+response's Mode bit mask against the request's Requested Identification Type, two different fields,
+and pinned the correct value only because its parametrize list held a single row at mode 0. It would
+have demanded the wrong thing, an echo of the request, once a second identification type was
+covered. Corrected here rather than left standing, matching the same correction already made to Task
+1's own title above.
 
 Then check whether any *other* roadmap row is made stale by this phase before committing — §2.6 cross-cutting and the §3 defect list both mention `GET_ID`. Correct what you find; do not silently rewrite a claim that turns out to have been wrong, record the correction, as DD102 and DD105 do.
 

--- a/docs/superpowers/plans/2026-09-11-xcp-get-id-types.md
+++ b/docs/superpowers/plans/2026-09-11-xcp-get-id-types.md
@@ -244,45 +244,78 @@ def test_get_id_rejects_a_type_the_specification_does_not_define(identification_
     assert raw_data[0:2] == (0xFE, 0x22), 'expected ERR_OUT_OF_RANGE'
 
 
-def test_get_id_nulls_the_mta_when_it_reports_length_zero():
-    """DD113. A declined GET_ID must not leave an earlier SET_MTA's pointer standing: a master that
-    ignores Length = 0 and uploads anyway would then read through a pointer the slave never set for
-    this purpose -- the defect DD75 fixed for the extension half of the same pair, the other way
-    round. (NULL_PTR, 0) is this module's own vocabulary for "nothing meaningful on this pair":
-    Xcp_Init and Xcp_CTOCmdStdConnect both pair exactly that.
-
-    Observed through UPLOAD's own argument, because Xcp_Internal is not reachable from the harness.
-    """
-    handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001))
-    _connect(handle)
-
-    # Point the MTA somewhere recognisable first, so a pass cannot come from it never having moved.
-    handle.lib.Xcp_CanIfRxIndication(0x0001, handle.get_pdu_info((0xF6, 0x00, 0x00, 0x07,
-                                                                 0xDE, 0xAD, 0xBE, 0xEF)))
+def _set_mta(handle, address_bytes, extension=0x00):
+    """SET_MTA. Copy the exact framing from test/session_teardown_test.py, which already issues a
+    SET_MTA(0xDEADBEEF) for the neighbouring DD75 case -- do not reconstruct the byte order here."""
+    handle.lib.Xcp_CanIfRxIndication(0x0001, handle.get_pdu_info(
+        (0xF6, 0x00, 0x00, extension) + address_bytes))
     handle.lib.Xcp_MainFunction()
     handle.lib.Xcp_CanIfTxConfirmation(0x0001, handle.define('E_OK'))
 
-    _get_id(handle, 0x03)
 
+def _upload_addresses(handle, element_count):
+    """Issue UPLOAD and return the raw pointers Xcp_ReadSlaveMemory was asked to read.
+
+    Returns cdata pointers, not integers: the harness idiom for "is this pointer null" is a direct
+    comparison against handle.ffi.NULL (test/clear_daq_list_test.py:40), which needs no cast to an
+    integer type the cdef may not carry.
+    """
     addresses = []
-    handle.xcp_read_slave_memory_u8.side_effect = lambda p_address, extension, _p_buffer: \
-        addresses.append((int(handle.ffi.cast('uintptr_t', p_address)), extension))
-
-    handle.lib.Xcp_CanIfRxIndication(0x0001, handle.get_pdu_info((0xF5, 0x01)))
+    handle.xcp_read_slave_memory_u8.side_effect = \
+        lambda p_address, _extension, _p_buffer: addresses.append(p_address)
+    handle.lib.Xcp_CanIfRxIndication(0x0001, handle.get_pdu_info((0xF5, element_count)))
     handle.lib.Xcp_MainFunction()
+    return addresses
 
-    assert addresses, 'UPLOAD did not read any memory'
-    assert addresses[0] == (0, 0), \
-        'a Length = 0 GET_ID left the MTA at {} instead of nulling it'.format(addresses[0])
+
+def test_a_length_zero_get_id_does_not_leave_an_earlier_set_mta_standing():
+    """DD113. A declined GET_ID must not leave an earlier SET_MTA's pointer in place: a master that
+    ignores Length = 0 and uploads anyway would then read through a pointer the slave never set for
+    this purpose -- the defect DD75 fixed for the extension half of the same pair, arriving the
+    other way round.
+
+    Paired with its own positive control below. "This address was never read" is vacuous alone: such
+    a test passes just as happily if UPLOAD read nothing at all, or if SET_MTA never worked. The
+    control shows the same SET_MTA address IS reached when no GET_ID intervenes, so the difference
+    here is caused by GET_ID and by nothing else. test/session_teardown_test.py uses the same
+    pairing for the neighbouring DD75 case.
+    """
+    handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001))
+    _connect(handle)
+    _set_mta(handle, (0xDE, 0xAD, 0xBE, 0xEF))
+
+    _get_id(handle, 0x03)   # a type 1.1/1.6.1.2.2 defines but this slave does not serve
+
+    addresses = _upload_addresses(handle, 0x01)
+
+    assert addresses, 'UPLOAD read no memory at all -- see the note below before changing this'
+    assert addresses[0] == handle.ffi.NULL, \
+        'a Length = 0 GET_ID left the earlier SET_MTA standing for the following UPLOAD'
+
+
+def test_an_upload_with_no_intervening_get_id_still_reads_the_set_mta_address():
+    """The positive control for the test above: same SET_MTA, same UPLOAD, no GET_ID between them.
+    If this ever fails, the absence the test above asserts proves nothing."""
+    handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001))
+    _connect(handle)
+    _set_mta(handle, (0xDE, 0xAD, 0xBE, 0xEF))
+
+    addresses = _upload_addresses(handle, 0x01)
+
+    assert addresses, 'setup: UPLOAD must read memory'
+    assert addresses[0] != handle.ffi.NULL, \
+        'setup: UPLOAD must reach the address SET_MTA just set, or the paired test is vacuous'
 ```
 
+
+**If UPLOAD turns out not to call `Xcp_ReadSlaveMemory` at all when the MTA is null**, that also satisfies DD113 — the stale pointer was not used — but it is different behaviour from what these tests assert. Do not weaken the assertion to accept both. Find out which it is, assert the one that is true, say so in your report, and keep the positive control either way.
 
 - [ ] **Step 2: Run and verify they fail**
 
 ```bash
 docker run --rm --user "$(id -u):$(id -g)" --env HOME=/tmp --ulimit nofile=65536:524288 --volume "$PWD:/usr/project" --workdir /usr/project xcp-test:sp4b ./test.sh
 ```
-Expected: `test_get_id_reports_length_zero_for_a_defined_type_it_does_not_serve` fails — today every non-zero type answers `(0xFE, 0x22)`, so `raw_data[0]` is `0xFE` not `0xFF`. `test_get_id_nulls_the_mta_when_it_reports_length_zero` fails for the same reason. `test_get_id_rejects_a_type_the_specification_does_not_define` **passes already** — it is a regression guard on behaviour Task 2 must preserve, not a driver.
+Expected: `test_get_id_reports_length_zero_for_a_defined_type_it_does_not_serve` fails — today every non-zero type answers `(0xFE, 0x22)`, so `raw_data[0]` is `0xFE` not `0xFF`. `test_a_length_zero_get_id_does_not_leave_an_earlier_set_mta_standing` fails for the same reason. Two of the new tests **pass already** and are regression guards on behaviour Task 2 must preserve, not drivers: `test_get_id_rejects_a_type_the_specification_does_not_define`, and the positive control `test_an_upload_with_no_intervening_get_id_still_reads_the_set_mta_address`.
 
 - [ ] **Step 3: Add the type bounds**
 
@@ -395,7 +428,8 @@ Expected: all green. Test count changes — `test_returns_err_out_of_range` drop
 Three mutations, each reverted after confirming the named test fails:
 1. Change `identification_type < XCP_GET_ID_TYPE_FIRST_USER_DEFINED` to `<= 0xFFu` → `test_get_id_reports_length_zero_for_a_defined_type_it_does_not_serve[0x80]` and `[0xFF]` must fail.
 2. Change `identification_type > XCP_GET_ID_TYPE_LAST_DEFINED` to `> 0x00u` → `test_get_id_reports_length_zero_for_a_defined_type_it_does_not_serve` must fail for types 1–4.
-3. Delete the `Xcp_Internal.memory_transfer.address = ...` assignment → `test_get_id_nulls_the_mta_when_it_reports_length_zero` must fail.
+3. Delete the `Xcp_Internal.memory_transfer.address = ...` assignment → `test_a_length_zero_get_id_does_not_leave_an_earlier_set_mta_standing` must fail.
+4. Mutate the positive control's own premise: with the code unmodified, change `_set_mta` in the control test to set address 0 → `test_an_upload_with_no_intervening_get_id_still_reads_the_set_mta_address` must fail. This is what proves the control is load-bearing rather than decorative, and therefore that mutation 3's absence assertion means something. Revert.
 
 - [ ] **Step 8: Commit and push**
 

--- a/docs/superpowers/specs/2026-08-29-xcp-part2-roadmap.md
+++ b/docs/superpowers/specs/2026-08-29-xcp-part2-roadmap.md
@@ -97,7 +97,7 @@ positive response without doing anything, which was defect D2, fixed in SP1.
 | 0xFD | GET_STATUS | yes | reports the session configuration id held in `Xcp_Internal.session_configuration_id` — 0 until a master's `SET_REQUEST` stores one, thereafter what was stored, and reloaded from non-volatile memory at start-up (SP5-NV, DD99–DD101); answers `ERR_RESOURCE_TEMPORARY_NOT_ACCESSIBLE` instead while that start-up read is outstanding (`Xcp_CTOCmdStdGetStatus`, `source/Xcp_Std.c`). This row previously read a hardcoded 0, accurate only before SP5-NV shipped; corrected here. See defect D9 |
 | 0xFC | SYNCH | done |
 | 0xFB | GET_COMM_MODE_INFO | done |
-| 0xFA | GET_ID | partial — identification type 0 (ASCII) only; §1.6.1.2.2 defines 0–4 plus 128–255 user-defined, all implementation-specific |
+| 0xFA | GET_ID | complete — types 0–4 and 128–255 served through `getIdentificationFunction`, type 0 falling back to the configured string; a defined type the slave does not serve answers `Length = 0` per 1.1/§1.6.1.2.2, 5–127 answer `ERR_OUT_OF_RANGE`. `TRANSFER_MODE` deliberately stays 0 (DD111) |
 | 0xF9 | SET_REQUEST | yes | STORE_CAL_REQ implemented. STORE_DAQ_REQ (`STORE_DAQ_REQ_NO_RESUME`/`STORE_DAQ_REQ_RESUME`) and CLEAR_DAQ_REQ are each accepted once their own non-volatile storage callback is configured in, refused with `ERR_OUT_OF_RANGE` otherwise — this row's "refused ... as unsupported modes" was true before SP5-NV and is stale since (DD94-DD102); requesting both DAQ store modes together is refused too, a deliberate choice where 1.1 is silent rather than something it requires (SP5-RESUME). See §2.6's RESUME mode row and defect D9 |
 | 0xF8 | GET_SEED | done |
 | 0xF7 | UNLOCK | done |
@@ -367,11 +367,12 @@ Ordered. Each sub-project is independently shippable and leaves the suite green.
 complete (#6), with a hygiene pass in #7. SP2d is complete (#12). SP3 is complete. SP4a is complete
 (#16), SP4b is complete (#17), and SP4c is complete — **so SP4, and with it the whole PGM command
 group, is complete: all eleven PGM commands are implemented.** **SP2c remains deferred — see its
-own entry below for why, which is unchanged.** **SP5-NV is complete and SP5-RESUME is complete —
-see their own entries below. This paragraph previously ended "so SP5 is next" as though SP5 had
-not started, which stopped being true once those two sub-projects shipped; corrected here. What
-is left of SP5 is its residue: the interleaved communication model, `GET_ID` identification types
-1–4/128–255, and the remaining `SERV_*` codes.**
+own entry below for why, which is unchanged.** **SP5-NV is complete, SP5-RESUME is complete and
+SP5-GETID is complete — see their own entries below. This paragraph previously ended "so SP5 is
+next" as though SP5 had not started, which stopped being true once those sub-projects shipped;
+corrected here. What is left of SP5 is its residue: the interleaved communication model and the
+remaining `SERV_*` codes — `GET_ID` identification types 1–4/128–255 were the third residue item
+until SP5-GETID shipped them.**
 
 ### SP1 — Calibration and page switching (CAL + PAG) — **complete**
 
@@ -557,8 +558,12 @@ cases on that one term, so it would not notice the other two being deleted.
 
 ### SP5 — Protocol completion
 
-The residue: the interleaved communication model (§1.7.2.3), `GET_ID` identification types 1–4 and
-128–255 (§1.6.1.2.2), the remaining `EV_*` event codes and the `SERV_*` service request codes.
+The residue: the interleaved communication model (§1.7.2.3), the remaining `EV_*` event codes and
+the `SERV_*` service request codes.
+
+`GET_ID` identification types 1–4 and 128–255 (§1.6.1.2.2) were listed here too and are now
+**done** — SP5-GETID (below) shipped them, served through an integrator callback; see §2.1's
+`GET_ID` row.
 
 `EV_CMD_PENDING` was listed here and is **done** — SP4 shipped it for deferred programming
 operations; see §2.6. Interleaved mode remains unbuilt, but is no longer advertisable: the
@@ -648,8 +653,16 @@ Three things this had to get right, all of them discovered by D9:
 depending on SP2 alone. With SP5-NV complete and RESUME still not built, that symmetry no longer
 holds: RESUME now depends on SP5-NV as well, not only on SP2 — the persistence and the session
 configuration id this phase built are exactly what RESUME needs something to resume *from*. Only
-the interleaved model, `EV_CMD_PENDING`, `GET_ID` types and the `SERV_*` codes are genuinely
-independent and can be pulled forward if one of them blocks an integration.
+the interleaved model and the `SERV_*` codes are genuinely independent and can be pulled forward if
+one of them blocks an integration.
+
+**Corrected a second time.** "RESUME still not built," two sentences above, was true only at the
+moment this paragraph was first written — SP5-RESUME is complete now (below), so RESUME's
+dependency on SP5-NV is history rather than a live blocker. The residue list at the end of that
+same paragraph was wrong independent of tense, in two more ways, and has been edited above rather
+than left standing: `EV_CMD_PENDING` was never genuinely independent of anything — it is **done**,
+shipped in SP4 (§2.6) — and `GET_ID` types are **done** too, now that SP5-GETID (below) has shipped
+them.
 
 #### SP5-RESUME — starting DAQ from non-volatile memory — **complete**
 
@@ -689,6 +702,37 @@ DAQ list infrastructure. Four tasks, each building on the last: the setters and 
 wire reporting (`GET_STATUS`, `GET_DAQ_LIST_MODE`, `EV_RESUME_MODE`); and finally arming it from
 `SET_REQUEST` and advertising `RESUME_SUPPORTED` — deliberately last, so no commit on the branch
 ever advertised or accepted a capability the code behind it did not yet have.
+
+#### SP5-GETID — GET_ID identification types — **complete**
+
+**What it built.** Every identification type 1.1/§1.6.1.2.2 defines — 0 through 4, and the
+128–255 user-defined range — served through an optional `getIdentificationFunction` callback,
+with the configured `identification` string as type 0's fallback when no callback is configured
+or the callback declines. A defined type the slave does not serve answers `Length = 0`, which is
+1.1/§1.6.1.2.2's own way of declining; 5–127 name no identification type at all and answer
+`ERR_OUT_OF_RANGE`. See §2.1's `GET_ID` row.
+
+Design: `2026-09-11-xcp-get-id-types-design.md` (DD108–DD113).
+
+**What 1.1 changed and 1.0 did not have.** The response Mode byte becomes a named bit mask —
+`TRANSFER_MODE` at bit 0, `COMPRESSED_ENCRYPTED` at bit 1 — and 1.1 adds `Length mod AG = 0` plus
+the initial UPLOAD's element count, `Length / AG`. This is the second time the 1.0-vs-1.1
+mode-byte pattern has appeared, after `SET_REQUEST` (see the table in the introduction above). The
+bit positions come from the 1.1 PDF's own text layer, not its OCR sidecar, which misaligns table
+columns — see §0 of the design doc for the decipherment method.
+
+**Two pre-existing defects it fixed.** The Mode-byte assertion,
+`test_get_id_returns_identification_through_mta_when_mode_is_0`, asserted `raw_data[1] == mode`,
+comparing the response's Mode bit mask against the request's Requested Identification Type — two
+different fields. It pinned the correct value only by the coincidence that its parametrize list
+held a single row at mode 0; it would have demanded the wrong thing, that the response echo the
+request, the moment a second identification type was covered. And the default `identification`
+was 21 bytes, so the module already reported a `Length` violating 1.1's `Length mod AG = 0` under
+WORD and DWORD granularity — the default is now a 16-byte string.
+
+**What it deliberately did not build.** Inline transfer (`TRANSFER_MODE = 1`, DD111) and
+compression (`COMPRESSED_ENCRYPTED`, DD111 — its algorithm interface lives in XCP Part 4, which is
+not in `docs/external/`). Both are reversible, and both are now documented rather than forgotten.
 
 ---
 

--- a/docs/superpowers/specs/2026-09-11-xcp-get-id-types-design.md
+++ b/docs/superpowers/specs/2026-09-11-xcp-get-id-types-design.md
@@ -59,7 +59,7 @@ MTA *extension* for that pointer — 0, because the identification is not part o
 and so there is no page for a non-zero extension to select. That reasoning is intact and this
 phase does not disturb it.
 
-**Wrong thing 1 — a test that cannot fail.** `test_get_id_returns_identification_through_mta_when_
+**Wrong thing 1 — a test that pinned an echo, not a bit mask.** `test_get_id_returns_identification_through_mta_when_
 mode_is_0` (`test/get_id_test.py`) asserts `raw_data[1] == mode`, where `mode` is the *request's*
 Requested Identification Type and `raw_data[1]` is the *response's* Mode bit mask. These are two
 different fields that happen to coincide at zero, and the response byte is a hardcoded `0x00`. The

--- a/docs/superpowers/specs/2026-09-11-xcp-get-id-types-design.md
+++ b/docs/superpowers/specs/2026-09-11-xcp-get-id-types-design.md
@@ -63,8 +63,18 @@ phase does not disturb it.
 mode_is_0` (`test/get_id_test.py`) asserts `raw_data[1] == mode`, where `mode` is the *request's*
 Requested Identification Type and `raw_data[1]` is the *response's* Mode bit mask. These are two
 different fields that happen to coincide at zero, and the response byte is a hardcoded `0x00`. The
-assertion passes under any implementation. This is recurring defect class 1 from the roadmap
-(expected value coinciding with a default).
+assertion pins the right value only because this test's parametrize list has a single row at mode
+0, and it demands the wrong thing — that the response echo the request — the moment a second
+identification type is covered. This is recurring defect class 1 from the roadmap (expected value
+coinciding with a default).
+
+**Correction, made after Task 1's implementer disproved the original wording empirically**
+(`.superpowers/sdd/2026-09-11-xcp-get-id-types/task-1-report.md`): this paragraph previously
+claimed "The assertion passes under any implementation," which does not hold — with `mode` pinned
+at 0, mutating the response byte away from 0 breaks the old assertion too, for the unrelated
+reason that the two sides then stop reading the same number by coincidence. The assertion's real
+weakness is the one now stated above: it cannot tell a correct implementation from an incorrect
+echo at mode 0, not that it is immune to a wrong byte on the wire.
 
 **Wrong thing 2 — a latent 1.1 violation already shipping.** The default `identification` is
 `/path/to/database.a2l`, 21 bytes. 21 mod 2 = 1 and 21 mod 4 = 1, so under `address_granularity` of

--- a/docs/superpowers/specs/2026-09-11-xcp-get-id-types-design.md
+++ b/docs/superpowers/specs/2026-09-11-xcp-get-id-types-design.md
@@ -1,0 +1,254 @@
+# SP5-GETID — GET_ID identification types
+
+**Date:** 2026-09-11
+**Baseline:** `develop` at `38eb3ff`
+**Reference:** *XCP -Part 2- Protocol Layer Specification -1.1*, ASAM e.V. (`docs/external/`).
+1.0 is cited wherever it says something different, and wherever it is simply the readable copy.
+
+**Depends on:** nothing. The roadmap's §4 names `GET_ID` types as one of four residue items that are
+"genuinely independent and can be pulled forward if one of them blocks an integration".
+
+`GET_ID` is §1.6.1.2.2 in **both** revisions — this command is not caught by the §1.6.4 renumbering.
+
+---
+
+## 0. What 1.1 changes, and how its tables were actually read
+
+Both revisions were read before anything was designed. They are not the same, and the difference is
+in the one byte this module already writes.
+
+| | 1.0/§1.6.1.2.2 | 1.1/§1.6.1.2.2 |
+|---|---|---|
+| response byte 1 | `Mode` — an unnamed byte | `Mode` — **a bit mask**, `TRANSFER_MODE` (bit 0), `COMPRESSED_ENCRYPTED` (bit 1), bits 2–7 don't-care |
+| identification offset | "7+…" | 8 (1.0's "7+…" contradicts its own `4..7 DWORD Length`) |
+| AG rule on `Length` | absent | **"The following rule applies: Length mod AG = 0"** |
+| initial UPLOAD rule | absent | **`Number of Data Elements UPLOAD [AG] = (Length GET_ID [BYTE]) / AG`** |
+| compression | absent | `COMPRESSED_ENCRYPTED`, "only allowed for Identification Type 4", interface in **XCP Part 4** |
+| identification string | "is ASCII text format" | "is a byte stream of plain ASCII text" |
+
+So 1.1 does to `GET_ID`'s response byte what it did to `SET_REQUEST`'s mode byte: it turns an opaque
+field into a named bit mask and adds a flag. That pattern cost three PRs (#23, #24, #25) when it was
+missed once. It is recorded here so the next reader does not have to rediscover it.
+
+**How the bit positions were established.** 1.1's PDF text layer is enciphered by glyph
+substitution, and its OCR sidecar misaligns table columns — a bit position read from the OCR is not
+evidence. The substitution was recovered from known-plaintext pairs (`IPQB`→`BYTE`, `KBQX@A`→
+`GET_ID`, `A[HYA`→`DWORD`, `SBQXYB^RBSQ`→`SET_REQUEST`) and applied to the page's own text layer.
+Two independent readings agree:
+
+1. **Prose.** `QYNGSJBYXDHAB` deciphers to `TRANSFER_MODE` and `CHDVYBSSBAXBGCYPVQBA` to
+   `COMPRESSED_ENCRYPTED`, in the two sentences immediately below the table.
+2. **Column geometry.** The bit-number row places bit 1 at character offset 87 and bit 0 at 95. The
+   two stacked (rotated) labels sit at offsets 91 and 100. The six don't-care `x` marks sit at
+   +4 to +6 from their own bit numbers, so the same rightward rendering offset maps 91→bit 1 and
+   100→bit 0.
+
+**`TRANSFER_MODE` is bit 0; `COMPRESSED_ENCRYPTED` is bit 1.** This is asserted from the PDF, not
+from the OCR.
+
+`Length mod AG = 0` was likewise read from the PDF text layer directly (`Ebgktl dha NK 4 6`), not
+from the OCR.
+
+---
+
+## 1. What the existing code already does, and two things it gets wrong
+
+`Xcp_DTOCmdStdGetId` (`source/Xcp_Std.c`) serves identification type 0 by pointing the MTA at
+`Xcp_Ptr->general->identification` and reporting its NUL-scanned length. DD75 already settled the
+MTA *extension* for that pointer — 0, because the identification is not part of any CAL/PAG segment
+and so there is no page for a non-zero extension to select. That reasoning is intact and this
+phase does not disturb it.
+
+**Wrong thing 1 — a test that cannot fail.** `test_get_id_returns_identification_through_mta_when_
+mode_is_0` (`test/get_id_test.py`) asserts `raw_data[1] == mode`, where `mode` is the *request's*
+Requested Identification Type and `raw_data[1]` is the *response's* Mode bit mask. These are two
+different fields that happen to coincide at zero, and the response byte is a hardcoded `0x00`. The
+assertion passes under any implementation. This is recurring defect class 1 from the roadmap
+(expected value coinciding with a default).
+
+**Wrong thing 2 — a latent 1.1 violation already shipping.** The default `identification` is
+`/path/to/database.a2l`, 21 bytes. 21 mod 2 = 1 and 21 mod 4 = 1, so under `address_granularity` of
+`WORD` or `DWORD` the module already reports a `Length` that violates 1.1's `Length mod AG = 0`.
+Eleven test files exercise non-BYTE AG, through the shared `DefaultConfig` in `test/parameter.py`. This
+predates the phase and is fixed by it.
+
+---
+
+## 2. Design decisions
+
+### DD108 — identification data comes from an integrator callback, not a widened configuration table
+
+Types 1–3 are strings an integrator could plausibly put in `xcp.json`. Type 4 is not: 1.1/§1.6.1.2.2
+defines it as "ASAM-MC2 file to upload", a whole A2L file whose contents are not known when the
+configuration is generated. Neither is the 128–255 range, which 1.1 leaves entirely to the
+integrator ("User defined") and which a fixed table cannot enumerate.
+
+So the mechanism is an optional callback, following the `user_cmd_function` /
+`user_defined_checksum_function` pattern this module already has — a nullable name in `xcp.json`
+emitted as `&Name` or `NULL_PTR` into `Xcp_GeneralType`, null-checked at the call site:
+
+```c
+Std_ReturnType (*const getIdentificationFunction)(uint8 identificationType,
+                                                  const void **pIdentification,
+                                                  uint8 *pExtension,
+                                                  uint32 *pLength);
+```
+
+`E_OK` means the out-parameters are set. `E_NOT_OK` means "this slave does not serve that type" and
+is not an error — see DD110.
+
+The field goes at the **tail** of both `Xcp_GeneralType` and the generated initialiser in
+`script/source_cfg.c.jinja2`. That struct is initialised positionally; a field inserted anywhere
+else silently shifts every later one.
+
+### DD109 — the callback carries the MTA extension, and DD75 still stands
+
+The callback returns an extension alongside the address. DD75 fixed `extension = 0` for the *static*
+identification, and its reasoning was specific: that string is "plain, slave-owned descriptive data
+that lives entirely outside the page-switching model", so no SEGMENT exists for an extension to
+name. That argument is about `Xcp_Ptr->general->identification` and does not automatically transfer
+to arbitrary integrator data.
+
+Type 4 is the case that breaks it. An A2L file plausibly lives in external flash or a memory region
+the integrator's `Xcp_ReadSlaveMemory*` reaches through a non-zero extension. Fixing the extension
+at 0 for callback data would let the module advertise type 4 while only being able to serve it from
+extension-0 memory — recurring defect class 3, advertising what you cannot honour.
+
+Type 0 served from the static string keeps extension 0, unchanged, by DD75's own reasoning.
+
+### DD110 — an unserved type answers `Length = 0`; only an *undefined* type is an error
+
+Both revisions say, of the response: "If length is 0, the requested identification type is not
+available." That is `GET_ID`'s own in-band mechanism for declining, and it exists so a master can
+enumerate what a slave supports without provoking errors. Today the module answers
+`ERR_OUT_OF_RANGE` for every type other than 0, which never lets that mechanism fire.
+
+But `ERR_OUT_OF_RANGE` cannot simply be dropped either: §1.7.3.2.1's error matrix (identical in both
+revisions) gives `GET_ID` its own `ERR_OUT_OF_RANGE` row with recovery "retry other parameter", and
+`GET_ID`'s only parameter is the identification type. Answering `Length = 0` for everything would
+leave that row dead.
+
+Both sentences are honoured by splitting on whether the specification defines the type at all:
+
+```
+type in 5..127                              -> ERR_OUT_OF_RANGE   (not an identification type)
+type in 0..4 or 128..255:
+    callback configured and returns E_OK    -> serve: set MTA, report Length
+    else if type == 0                       -> serve static identification (DD75 path, unchanged)
+    else                                    -> positive response, Length = 0 ("not available")
+```
+
+1.1/§1.6.1.2.2 lists exactly 0, 1, 2, 3, 4 and 128..255 as the types that "may be requested"; 5–127
+are not identification types, so a master naming one has supplied an out-of-range parameter and
+"retry other parameter" is the right recovery. A master naming type 3 on a slave that has no URL has
+supplied a perfectly valid parameter, and `Length = 0` tells it so.
+
+**The callback is consulted first for every defined type, including 0.** With no callback configured
+the type-0 path is byte-for-byte what ships today. With one configured, an integrator who needs a
+runtime-varying type 0 can override it, and one who does not simply returns `E_NOT_OK` and gets the
+static string. The alternative — reserving type 0 to the static string and giving the callback only
+1–4 and 128–255 — is a marginally simpler contract that forecloses that case for no benefit.
+
+### DD111 — `TRANSFER_MODE` stays 0, and both mode bits are named anyway
+
+The slave keeps answering `TRANSFER_MODE = 0` and pointing the MTA, for every type.
+
+This is a deliberate omission, not a gap. The request packet is two bytes — command code and
+Requested Identification Type — so **the master has no field in which to ask for inline transfer**.
+The slave chooses the transfer mode and merely reports which it used, and both revisions describe
+mode 0 as a complete answer. A slave that never sets the bit is conformant.
+
+It is also unreachable at the shipped defaults: the response header occupies all 8 bytes, so inline
+transfer requires `max_cto > 8` before it can carry a single byte.
+
+`COMPRESSED_ENCRYPTED` stays 0 for a second, independent reason: 1.1/§1.6.1.2.2 puts its algorithm
+interface in **XCP Part 4**, which is not in `docs/external/`. `COMPRESSED_ENCRYPTED = 0` (plain,
+uncompressed) is always legal, so this costs nothing.
+
+Both bits nevertheless get named constants at their PDF-verified positions, cited where the response
+byte is built. The decipherment in §0 was expensive; committing its result to the source means it is
+never redone, and it makes the hardcoded `0x00` legible as two cleared flags rather than a magic
+number.
+
+### DD112 — `Length mod AG = 0` is enforced where each half of it is knowable
+
+1.1 adds the rule; 1.0 has no equivalent. It protects the UPLOAD that follows, whose element count
+1.1 defines as `Length / AG` — an inexact division leaves the master unable to ask for the right
+number of elements.
+
+Enforced in two places, because the two sources of identification data are knowable at different
+times:
+
+- **Generation time**, for the configured static string: `script/source_cfg.c.jinja2` raises when
+  `len(identification) mod AG != 0`, matching the existing `raise()` guards around
+  `source_cfg.c.jinja2:749`. An integrator learns at build time, not on the wire.
+- **Run time**, for callback data: a returned length with `length mod AG != 0` raises DET and the
+  command answers `Length = 0`. The module cannot emit a non-conforming `Length`, and reporting the
+  type unavailable is the honest alternative to truncating the data or padding it with the NULs
+  1.1 explicitly says the string does not carry.
+
+The shipped default `identification` changes from `/path/to/database.a2l` (21 bytes) to
+`/path/to/xcp.a2l` (16), which conforms under BYTE, WORD and DWORD alike. Without that change the
+new generator check would reject the module's own default configuration under non-BYTE AG.
+
+---
+
+## 3. What this does not change
+
+- **The MTA/UPLOAD path.** Identification is still read by the master through the MTA, through the
+  integrator's `Xcp_ReadSlaveMemory*`. The module never copies identification bytes; with
+  `TRANSFER_MODE = 0` it never needs to read them at all, only their address and length.
+- **DD75.** The static identification keeps extension 0, for DD75's own stated reason.
+- **`xcp_get_id_api_enable`.** Disabling the command still answers `ERR_CMD_UNKNOWN` ahead of any of
+  this.
+- **Type 0 behaviour with no callback configured** — byte for byte.
+
+---
+
+## 4. Test strategy
+
+**The existing assertion is repaired first, before anything is added.** `assert raw_data[1] == mode`
+becomes an assertion that byte 1 is the response Mode bit mask with `TRANSFER_MODE` (bit 0) and
+`COMPRESSED_ENCRYPTED` (bit 1) both clear, citing 1.1/§1.6.1.2.2. Landing this ahead of the feature
+means the phase starts from a test that can actually fail.
+
+`test_returns_err_out_of_range` (`test/asam_error_matrix_test.py`) narrows from `range(0x01, 0xFF)`
+to 5–127. Note its old range stopped at `0xFE`: **type 255 was never covered**, and it is in the
+user-defined range.
+
+New coverage:
+
+| Claim | Test |
+|---|---|
+| defined-but-unserved types answer `Length = 0` | types 1, 2, 3, 4, 128, 255 with no callback |
+| undefined types answer `ERR_OUT_OF_RANGE` | 5–127 |
+| a callback serves each defined type | parametrised over 0–4, 128, 255 |
+| a declining callback falls back to the static string for type 0 | callback returns `E_NOT_OK` |
+| a declining callback answers `Length = 0` for other types | |
+| the callback's extension reaches the MTA | UPLOAD reads through the returned extension |
+| a non-AG-multiple callback length raises DET and answers `Length = 0` | AG = WORD and DWORD |
+| the generator rejects a non-conforming configured identification | AG = WORD and DWORD |
+
+**Every behavioural claim is mutation-verified** — the code is changed so the test should fail, and
+the failure is confirmed and the test named. A passing suite is not evidence that a test pins
+anything.
+
+Two harness facts apply. `Xcp_DaqQueuePeek` hands every transmission the same static `PduInfoType`,
+so each frame is read immediately after its own `CanIf_Transmit` call, never from
+`call_args_list` afterwards. And `Xcp_GeneralType` is initialised positionally, so the generator
+change is checked to move exactly the intended field and nothing else.
+
+---
+
+## 5. Open questions and deliberate omissions
+
+- **Inline transfer (`TRANSFER_MODE = 1`) is not built** — DD111. Reversible: the bit positions are
+  now recorded, and the work is a packing branch plus a `max_cto` check.
+- **`COMPRESSED_ENCRYPTED` is not built** and cannot be until **XCP Part 4** is available. Unlike
+  Part 1, this one blocks nothing: the flag's cleared state is always legal.
+- **Type 4 is servable but untestable end-to-end here.** The harness can assert that the MTA and
+  `Length` are set from the callback; it cannot supply a real A2L file. The distinction between
+  type 4 and types 1–3 is entirely the integrator's, which is what 1.1 means by "Which types are
+  supported by the slave device is implementation specific".
+- **XCP Part 1 (Overview) is still missing from `docs/external/`.** Unrelated to this phase, still
+  open, still blocking the SP5-RESUME assumption that depends on its §2.3.

--- a/docs/superpowers/specs/2026-09-11-xcp-get-id-types-design.md
+++ b/docs/superpowers/specs/2026-09-11-xcp-get-id-types-design.md
@@ -191,6 +191,22 @@ The shipped default `identification` changes from `/path/to/database.a2l` (21 by
 `/path/to/xcp.a2l` (16), which conforms under BYTE, WORD and DWORD alike. Without that change the
 new generator check would reject the module's own default configuration under non-BYTE AG.
 
+### DD113 — a `Length = 0` answer still points the MTA at `(NULL_PTR, 0)`
+
+Writing the plan surfaced a case §2 left open: what the MTA holds when the answer is "type not
+available".
+
+It is not left untouched. A `GET_ID` that returns without assigning the MTA leaves whatever an
+earlier, unrelated `SET_MTA` put there, and a master that ignores `Length = 0` and issues `UPLOAD`
+anyway then reads through a stale pointer it never set for this purpose — the same defect DD75
+fixed for the extension half of the identical pair, arriving the other way round.
+
+So a `Length = 0` response assigns `(NULL_PTR, 0x00u)`, which is already this module's vocabulary
+for "nothing meaningful on this pair": `Xcp_Init` and `Xcp_CTOCmdStdConnect` both pair exactly that,
+and DD75 cites 1.1/§1.6.1.2.3's "All ODT entries reset to address = 0, extension = 0" for the same
+idiom. The master is told the type is unavailable; if it uploads regardless it reads from a pointer
+the slave deliberately nulled rather than one it forgot to update.
+
 ---
 
 ## 3. What this does not change

--- a/docs/superpowers/specs/2026-09-11-xcp-get-id-types-design.md
+++ b/docs/superpowers/specs/2026-09-11-xcp-get-id-types-design.md
@@ -180,6 +180,17 @@ byte is built. The decipherment in §0 was expensive; committing its result to t
 never redone, and it makes the hardcoded `0x00` legible as two cleared flags rather than a magic
 number.
 
+**Correction, made in the final review's fix wave**
+(`.superpowers/sdd/2026-09-11-xcp-get-id-types/final-fix-report.md`): "cited where the response
+byte is built" was not true as shipped. Neither `XCP_GET_ID_MODE_TRANSFER_MODE` nor
+`XCP_GET_ID_MODE_COMPRESSED_ENCRYPTED` was referenced anywhere; the comment at the build site in
+`Xcp_DTOCmdStdGetId` named the two bits only in prose. That comment now names both macro
+identifiers. In code the constants remain unreferenced: a deliberate deviation from MISRA C:2012
+Rule 2.5 (advisory), which asks that a project contain no unused macro declarations, kept because
+the two are the source-level record of the bit positions §0 recovered from the PDF. The byte itself
+stays the literal `0x00u`, not an expression contrived to evaluate to zero while mentioning both
+names.
+
 ### DD112 — `Length mod AG = 0` is enforced where each half of it is knowable
 
 1.1 adds the rule; 1.0 has no equivalent. It protects the UPLOAD that follows, whose element count

--- a/docs/superpowers/specs/2026-09-11-xcp-get-id-types-design.md
+++ b/docs/superpowers/specs/2026-09-11-xcp-get-id-types-design.md
@@ -217,6 +217,38 @@ and DD75 cites 1.1/§1.6.1.2.3's "All ODT entries reset to address = 0, extensio
 idiom. The master is told the type is unavailable; if it uploads regardless it reads from a pointer
 the slave deliberately nulled rather than one it forgot to update.
 
+**Where the rule is enforced.** `Xcp_DTOCmdStdGetId` decides it on the Length alone, immediately
+before assigning the MTA: whenever the Length it is about to report is 0, it points the MTA at
+`(NULL_PTR, 0x00u)`, whichever route produced that 0. There are five:
+
+1. no callback, and a defined type other than 0 — nothing is ever assigned to the pair;
+2. a callback that answers `E_NOT_OK` for a type other than 0, whatever it wrote to its
+   out-parameters first — the decline path discards the length it wrote. (For type 0 the static
+   fallback overwrites all three instead, DD110.)
+3. a callback length that DD112's run-time check refuses — the check raises
+   `XCP_E_IDENTIFICATION_NOT_GRANULAR` and discards the length;
+4. a callback that answers `E_OK` with a length of 0;
+5. an empty configured identification, served for type 0.
+
+Routes 2 and 3 reset the length and nothing else: the length is what brings them under the rule,
+and the rule nulls the pair. Routes 4 and 5 reset nothing; their Length is 0 as served.
+
+**Correction, made in the final review's fix wave**
+(`.superpowers/sdd/2026-09-11-xcp-get-id-types/final-fix-report.md`): as first shipped, this
+decision's heading was false for routes 4 and 5. The code nulled the pair route by route, in the
+decline path and in the granularity check, so a callback answering `E_OK` with `*pLength = 0`, and
+an empty configured string for type 0, both reported `Length = 0` while the MTA pointed at real
+memory — the callback's buffer, or the empty string's own address — for an UPLOAD that ignored
+`Length = 0` to read through. The decision's only test took route 1, which never assigns the pair,
+so it could not tell per-route nulling from none. The rule has been enforced on the Length since
+that fix, and the test covers all five routes, each after a `SET_MTA` with extension 7 and each
+checking the `(address, extension)` pair UPLOAD reads. With the rule in place, the address and
+extension resets in routes 2 and 3 could no longer be told from their absence by any test, and were
+removed, along with the granularity check's `served = FALSE`, a store nothing read afterwards. Each
+route's length reset stayed: it is what routes 2 and 3 depend on. The static fallback's
+`extension = 0x00u` (DD75) is thereby the only thing standing between a declining callback's
+extension and the MTA for type 0, and has a test of its own.
+
 ---
 
 ## 3. What this does not change

--- a/interface/Xcp.h
+++ b/interface/Xcp.h
@@ -287,6 +287,20 @@ extern "C" {
  */
 #define XCP_E_DAQ_LIST_NOT_IDENTIFIABLE (0x08u)
 
+/**
+ * @brief A GET_ID callback returned a length that is not a multiple of the address granularity.
+ * @details XCP part 2 - Protocol Layer Specification 1.1/1.6.1.2.2 requires "Length mod AG = 0",
+ * protecting the UPLOAD that follows: 1.1 defines its element count as
+ * (Length GET_ID [BYTE]) / AG, and an inexact division leaves the master unable to ask for the
+ * right number of elements. The configured identification string is checked at generation time
+ * instead (script/source_cfg.c.jinja2); this covers what getIdentificationFunction returns, which
+ * is not knowable then.
+ * @note This error is not part of the specification, and Det is the only channel it has: the master
+ * is told the type is unavailable (Length = 0), which is indistinguishable on the wire from a slave
+ * that simply does not serve it. DD112.
+ */
+#define XCP_E_IDENTIFICATION_NOT_GRANULAR (0x09u)
+
 /** @} */
 
 /**

--- a/interface/Xcp.h
+++ b/interface/Xcp.h
@@ -57,6 +57,8 @@ extern "C" {
 
 #include "Xcp_UserCmd.h"
 
+#include "Xcp_GetId.h"
+
 #include "Xcp_MemoryAccess.h"
 
 #include "SchM_Xcp.h"

--- a/interface/Xcp_Types.h
+++ b/interface/Xcp_Types.h
@@ -639,6 +639,32 @@ typedef struct
     const boolean storeDaqConfigurationApiEnable; /* not part of the specification... */
     const boolean clearDaqConfigurationApiEnable; /* not part of the specification... */
     const boolean readStoredSessionConfigurationIdApiEnable; /* not part of the specification... */
+    /**
+     * @brief supplies GET_ID identification data for any identification type.
+     * @param identificationType the Requested Identification Type from the GET_ID request: 0..4 or
+     * 128..255 (XCP part 2 - Protocol Layer Specification 1.1/1.6.1.2.2). 5..127 are refused before
+     * this is called.
+     * @param pIdentification set to the address the master will UPLOAD the identification from.
+     * @param pExtension set to the MTA address extension that address is reached through. 0 unless
+     * the data lives in a region the integrator's Xcp_ReadSlaveMemory* selects with a non-zero
+     * extension (DD109).
+     * @param pLength set to the identification's length in bytes. XCP part 2 - Protocol Layer
+     * Specification 1.1/1.6.1.2.2 requires "Length mod AG = 0" against the configured address
+     * granularity, so that the initial UPLOAD's element count (Length / AG) divides exactly
+     * (DD112) -- this callback must uphold that itself. Unlike the configured static string,
+     * whose length script/source_cfg.c.jinja2 checks at generation time, a length this callback
+     * returns is not validated by the module at this commit.
+     * @return E_OK with all three out-parameters set, or E_NOT_OK meaning this slave does not serve
+     * that type. E_NOT_OK is not an error: it answers Length = 0, which 1.1/1.6.1.2.2 defines as
+     * "the requested identification type is not available". For type 0 it falls back to the
+     * configured identification string instead.
+     * @note not part of the specification. NULL_PTR means only type 0 is served, from the
+     * configured identification string.
+     */
+    Std_ReturnType (*const getIdentificationFunction)(uint8 identificationType,
+                                                      const void **pIdentification,
+                                                      uint8 *pExtension,
+                                                      uint32 *pLength); /* not part of the specification... */
 } Xcp_GeneralType;
 
 /**

--- a/interface/Xcp_Types.h
+++ b/interface/Xcp_Types.h
@@ -653,7 +653,9 @@ typedef struct
      * granularity, so that the initial UPLOAD's element count (Length / AG) divides exactly
      * (DD112) -- this callback must uphold that itself. Unlike the configured static string,
      * whose length script/source_cfg.c.jinja2 checks at generation time, a length this callback
-     * returns is not validated by the module at this commit.
+     * returns is checked by the module at run time: Xcp_DTOCmdStdGetId (source/Xcp_Std.c) raises
+     * XCP_E_IDENTIFICATION_NOT_GRANULAR and reports the type unavailable, Length = 0, when the
+     * length is not a multiple of AG.
      * @return E_OK with all three out-parameters set, or E_NOT_OK meaning this slave does not serve
      * that type. E_NOT_OK is not an error: it answers Length = 0, which 1.1/1.6.1.2.2 defines as
      * "the requested identification type is not available". For type 0 it falls back to the

--- a/script/header_cfg.h.jinja2
+++ b/script/header_cfg.h.jinja2
@@ -155,6 +155,10 @@
 #include "Xcp_UserCmd.h"
 #endif /* #ifndef XCP_USER_CMD_H */
 
+#ifndef XCP_GET_ID_H
+#include "Xcp_GetId.h"
+#endif /* #ifndef XCP_GET_ID_H */
+
 #define Xcp_START_SEC_CONST_UNSPECIFIED
 #include "Xcp_MemMap.h"
 

--- a/script/source_cfg.c.jinja2
+++ b/script/source_cfg.c.jinja2
@@ -756,11 +756,12 @@ static Xcp_ConfigType Xcp_ConfigConfig{{'%02X' % loop.index0}} = {
         inexact division leaves the master unable to ask for the right number of elements.
         Refused here rather than at run time because for the configured string it is knowable
         now, and an integrator should learn at build time rather than on the wire. Scope: only
-        this configured string, the sole identification source that exists at this commit. A
-        value arriving some other way, at run time rather than through this configuration, is
-        invisible to the generator and cannot be validated here: a callback-supplied length is
-        validated in Xcp_DTOCmdStdGetId (source/Xcp_Std.c) instead, which raises
-        XCP_E_IDENTIFICATION_NOT_GRANULAR and answers Length = 0 rather than emit it. DD112. #}
+        this configured string -- the generator can see only what is configured, so it can
+        validate only that. A value arriving some other way, at run time rather than through
+        this configuration, is invisible to the generator and cannot be validated here: a
+        callback-supplied length is validated in Xcp_DTOCmdStdGetId (source/Xcp_Std.c) instead,
+        which raises XCP_E_IDENTIFICATION_NOT_GRANULAR and answers Length = 0 rather than emit
+        it. DD112. #}
 {{ raise('identification {!r} is {} bytes, which is not a multiple of the {}-byte {} address granularity; XCP part 2 1.1/1.6.1.2.2 requires Length mod AG = 0 because the initial UPLOAD element count is Length / AG'.format(configuration.protocol_layer.identification, configuration.protocol_layer.identification | length, ag_size, configuration.protocol_layer.address_granularity)) }}
 {%- endif %}
 {%- set ts = configuration.protocol_layer.timestamp %}

--- a/script/source_cfg.c.jinja2
+++ b/script/source_cfg.c.jinja2
@@ -755,9 +755,11 @@ static Xcp_ConfigType Xcp_ConfigConfig{{'%02X' % loop.index0}} = {
         1.1 defines the initial UPLOAD's element count as (Length GET_ID [BYTE]) / AG -- an
         inexact division leaves the master unable to ask for the right number of elements.
         Refused here rather than at run time because for the configured string it is knowable
-        now, and an integrator should learn at build time rather than on the wire. Callback-
-        supplied identifications cannot be checked here and are checked in Xcp_DTOCmdStdGetId
-        instead. DD112. #}
+        now, and an integrator should learn at build time rather than on the wire. Scope: only
+        this configured string, the sole identification source that exists at this commit. A
+        value arriving some other way, at run time rather than through this configuration, is
+        invisible to the generator and cannot be validated here -- whatever introduces such a
+        value later is responsible for validating it at the point it enters. DD112. #}
 {{ raise('identification {!r} is {} bytes, which is not a multiple of the {}-byte {} address granularity; XCP part 2 1.1/1.6.1.2.2 requires Length mod AG = 0 because the initial UPLOAD element count is Length / AG'.format(configuration.protocol_layer.identification, configuration.protocol_layer.identification | length, ag_size, configuration.protocol_layer.address_granularity)) }}
 {%- endif %}
 {%- set ts = configuration.protocol_layer.timestamp %}

--- a/script/source_cfg.c.jinja2
+++ b/script/source_cfg.c.jinja2
@@ -758,8 +758,9 @@ static Xcp_ConfigType Xcp_ConfigConfig{{'%02X' % loop.index0}} = {
         now, and an integrator should learn at build time rather than on the wire. Scope: only
         this configured string, the sole identification source that exists at this commit. A
         value arriving some other way, at run time rather than through this configuration, is
-        invisible to the generator and cannot be validated here -- whatever introduces such a
-        value later is responsible for validating it at the point it enters. DD112. #}
+        invisible to the generator and cannot be validated here: a callback-supplied length is
+        validated in Xcp_DTOCmdStdGetId (source/Xcp_Std.c) instead, which raises
+        XCP_E_IDENTIFICATION_NOT_GRANULAR and answers Length = 0 rather than emit it. DD112. #}
 {{ raise('identification {!r} is {} bytes, which is not a multiple of the {}-byte {} address granularity; XCP part 2 1.1/1.6.1.2.2 requires Length mod AG = 0 because the initial UPLOAD element count is Length / AG'.format(configuration.protocol_layer.identification, configuration.protocol_layer.identification | length, ag_size, configuration.protocol_layer.address_granularity)) }}
 {%- endif %}
 {%- set ts = configuration.protocol_layer.timestamp %}

--- a/script/source_cfg.c.jinja2
+++ b/script/source_cfg.c.jinja2
@@ -748,6 +748,18 @@ static Xcp_ConfigType Xcp_ConfigConfig{{'%02X' % loop.index0}} = {
 {%- if odt_entry_size_daq < 1 %}
 {{ raise('MAX_DTO {} leaves no room for data after a {}-byte {} identification field'.format(configuration.protocol_layer.max_dto, identification_field_size[identification_field_type], identification_field_type)) }}
 {%- endif %}
+{%- set ag_size = {'BYTE': 1, 'WORD': 2, 'DWORD': 4}[configuration.protocol_layer.address_granularity] %}
+{%- if (configuration.protocol_layer.identification | length) % ag_size != 0 %}
+    {#- XCP part 2 1.1/1.6.1.2.2 adds a rule 1.0/1.6.1.2.2 does not have: "The following rule
+        applies: Length mod AG = 0". GET_ID reports the identification's length in bytes, and
+        1.1 defines the initial UPLOAD's element count as (Length GET_ID [BYTE]) / AG -- an
+        inexact division leaves the master unable to ask for the right number of elements.
+        Refused here rather than at run time because for the configured string it is knowable
+        now, and an integrator should learn at build time rather than on the wire. Callback-
+        supplied identifications cannot be checked here and are checked in Xcp_DTOCmdStdGetId
+        instead. DD112. #}
+{{ raise('identification {!r} is {} bytes, which is not a multiple of the {}-byte {} address granularity; XCP part 2 1.1/1.6.1.2.2 requires Length mod AG = 0 because the initial UPLOAD element count is Length / AG'.format(configuration.protocol_layer.identification, configuration.protocol_layer.identification | length, ag_size, configuration.protocol_layer.address_granularity)) }}
+{%- endif %}
 {%- set ts = configuration.protocol_layer.timestamp %}
 {%- if ts is defined and ts %}
     {#- The timestamp (XCP part 2 1.1/1.1.2.2, Diagram 10) shares ODT 0 with the identification

--- a/script/source_cfg.c.jinja2
+++ b/script/source_cfg.c.jinja2
@@ -1345,6 +1345,7 @@ static Xcp_GeneralType Xcp_GeneralConfig{{'%02X' % loop.index0}} = {
     clearDaqConfigurationApiEnable immediately above: a dedicated boolean, not a ctoInfo bit, since
     this is not a command PID a master ever sends. #}
     {% if configuration.apis.xcp_read_stored_session_configuration_id_api_enable.enabled %}TRUE{% else %}FALSE{% endif %}, /* readStoredSessionConfigurationIdApiEnable */
+    {% if configuration.protocol_layer.get_id_function %}&{{configuration.protocol_layer.get_id_function}}{% else %}NULL_PTR{% endif %}, /* getIdentificationFunction */
 };
 
 #define Xcp_STOP_SEC_CONST_UNSPECIFIED

--- a/script/source_cfg.c.jinja2
+++ b/script/source_cfg.c.jinja2
@@ -748,6 +748,20 @@ static Xcp_ConfigType Xcp_ConfigConfig{{'%02X' % loop.index0}} = {
 {%- if odt_entry_size_daq < 1 %}
 {{ raise('MAX_DTO {} leaves no room for data after a {}-byte {} identification field'.format(configuration.protocol_layer.max_dto, identification_field_size[identification_field_type], identification_field_type)) }}
 {%- endif %}
+{%- for character in configuration.protocol_layer.identification if character < ' ' or character > '~' %}
+    {#- Printable ASCII only, 0x20-0x7E. XCP part 2 1.1/1.6.1.2.2 defines the identification as
+        "a byte stream of plain ASCII text", and the Length mod AG = 0 guard below counts
+        characters, which are one byte each only in this range: U+00E9 is one character and two
+        UTF-8 bytes, so '/path/to/xcp.a2' followed by it passes that guard at 16 and compiles to
+        17. Control characters are refused as a class: a raw line feed would split the C literal
+        in the initialiser further down, and a NUL would end the string Xcp_DTOCmdStdGetId
+        (source/Xcp_Std.c) measures by scanning for one. Checked ahead of the length guard, whose
+        message calls the count bytes -- true once this has passed. config/xcp.schema.json refuses
+        the same characters with a pattern, but a configuration reaches this template through
+        BSWCodeGen's Python API without passing that schema at all, so this is the check every
+        configuration meets. #}
+{{ raise('identification {!r} contains {!r}, which is not printable ASCII (0x20-0x7E); XCP part 2 1.1/1.6.1.2.2 defines the identification as a byte stream of plain ASCII text, and the Length mod AG = 0 check below counts one byte per character'.format(configuration.protocol_layer.identification, character)) }}
+{%- endfor %}
 {%- set ag_size = {'BYTE': 1, 'WORD': 2, 'DWORD': 4}[configuration.protocol_layer.address_granularity] %}
 {%- if (configuration.protocol_layer.identification | length) % ag_size != 0 %}
     {#- XCP part 2 1.1/1.6.1.2.2 adds a rule 1.0/1.6.1.2.2 does not have: "The following rule
@@ -761,7 +775,11 @@ static Xcp_ConfigType Xcp_ConfigConfig{{'%02X' % loop.index0}} = {
         this configuration, is invisible to the generator and cannot be validated here: a
         callback-supplied length is validated in Xcp_DTOCmdStdGetId (source/Xcp_Std.c) instead,
         which raises XCP_E_IDENTIFICATION_NOT_GRANULAR and answers Length = 0 rather than emit
-        it. DD112. #}
+        it. DD112.
+
+        This measures the configured string itself, not the escaped spelling the initialiser
+        further down emits. There, each backslash and double quote is written as a two-character
+        escape that compiles to one byte, and the compiled string is what GET_ID reports. #}
 {{ raise('identification {!r} is {} bytes, which is not a multiple of the {}-byte {} address granularity; XCP part 2 1.1/1.6.1.2.2 requires Length mod AG = 0 because the initial UPLOAD element count is Length / AG'.format(configuration.protocol_layer.identification, configuration.protocol_layer.identification | length, ag_size, configuration.protocol_layer.address_granularity)) }}
 {%- endif %}
 {%- set ts = configuration.protocol_layer.timestamp %}
@@ -1246,7 +1264,13 @@ static Xcp_GeneralType Xcp_GeneralConfig{{'%02X' % loop.index0}} = {
     {% if configuration.protocol_layer.user_defined_checksum_function %}&{{configuration.protocol_layer.user_defined_checksum_function}}{% else %}NULL_PTR{% endif %}, /* userDefinedChecksumFunction */
     {% if configuration.protocol_layer.user_cmd_function %}&{{configuration.protocol_layer.user_cmd_function}}{% else %}NULL_PTR{% endif %}, /* userCmdFunction */
     {{'0x%02Xu' % configuration.protocol_layer.trailing_value}}, /* trailingValue */
-    "{{configuration.protocol_layer.identification}}", /* identification */
+{#- Escaped for the C literal: backslashes first, so that the backslash each escaped quote gains is
+    not itself doubled, then double quotes. Backslashes are escaped rather than refused -- XCP
+    part 2 1.1/1.6.1.2.2's own second example identification is c:\database\test.a2l. Pasted raw,
+    C would read \t, \n and the like as single escape characters: D:\temp\new1.a2l is 16
+    characters but a 14-byte C string, a Length the Length mod AG = 0 guard never saw. Each escape
+    written here compiles to exactly one byte. #}
+    "{{configuration.protocol_layer.identification | replace('\\', '\\\\') | replace('"', '\\"')}}", /* identification */
     {{'0x%02Xu' % (configuration.segments | default([]))|length}}, /* maxSegment */
 {#- MAX_SECTOR (SP4c Task 2, DD87): the sectors array's own length, so GET_PGM_PROCESSOR_INFO and
     GET_SECTOR_INFO cannot disagree about how many sectors exist. Final review F5 adds the

--- a/source/Xcp_Internal.h
+++ b/source/Xcp_Internal.h
@@ -123,6 +123,15 @@ extern "C" {
  */
 #define XCP_GET_ID_MODE_TRANSFER_MODE (0x01u << 0x00u)
 #define XCP_GET_ID_MODE_COMPRESSED_ENCRYPTED (0x01u << 0x01u)
+/**
+ * @brief GET_ID Requested Identification Type values.
+ * @note XCP part 2 - Protocol Layer Specification 1.1/1.6.1.2.2 (1.0/1.6.1.2.2, identical list):
+ * 0 ASCII text, 1 ASAM-MC2 filename without path and extension, 2 with path and extension, 3 URL,
+ * 4 ASAM-MC2 file to upload, 128..255 user defined. 5..127 are not identification types.
+ */
+#define XCP_GET_ID_TYPE_ASCII (0x00u)
+#define XCP_GET_ID_TYPE_LAST_DEFINED (0x04u)
+#define XCP_GET_ID_TYPE_FIRST_USER_DEFINED (0x80u)
 #define XCP_PID_CMD_GET_COMM_MOD_INFO (0xFBu)
 #define XCP_PID_CMD_SYNCH (0xFCu)
 #define XCP_PID_CMD_GET_STATUS (0xFDu)

--- a/source/Xcp_Internal.h
+++ b/source/Xcp_Internal.h
@@ -105,6 +105,24 @@ extern "C" {
 #define XCP_PID_CMD_GET_SEED (0xF8u)
 #define XCP_PID_CMD_SET_REQUEST (0xF9u)
 #define XCP_PID_CMD_GET_ID (0xFAu)
+/**
+ * @brief GET_ID positive response Mode bit mask.
+ * @note XCP part 2 - Protocol Layer Specification 1.1/1.6.1.2.2. 1.0/1.6.1.2.2 carries the same
+ * byte but leaves it an unnamed "Mode"; 1.1 makes it a bit mask and adds COMPRESSED_ENCRYPTED.
+ * @details Bit positions are asserted from the 1.1 PDF's own text layer, not from its OCR sidecar,
+ * which misaligns table columns. The glyph substitution was recovered from known-plaintext pairs
+ * and the prose decode agrees independently with the table's column geometry; the method is
+ * recorded in docs/superpowers/specs/2026-09-11-xcp-get-id-types-design.md section 0.
+ *
+ * Both bits are always clear in this module (DD111). TRANSFER_MODE stays 0 because the request
+ * packet is two bytes -- command code and Requested Identification Type -- so the master has no
+ * field in which to ask for inline transfer; the slave chooses and merely reports which mode it
+ * used, and 1.1/1.6.1.2.2 describes mode 0 as a complete answer. COMPRESSED_ENCRYPTED stays 0
+ * because its algorithm interface lives in XCP Part 4, which is not in docs/external/ -- and
+ * because the cleared state is always legal.
+ */
+#define XCP_GET_ID_MODE_TRANSFER_MODE (0x01u << 0x00u)
+#define XCP_GET_ID_MODE_COMPRESSED_ENCRYPTED (0x01u << 0x01u)
 #define XCP_PID_CMD_GET_COMM_MOD_INFO (0xFBu)
 #define XCP_PID_CMD_SYNCH (0xFCu)
 #define XCP_PID_CMD_GET_STATUS (0xFDu)

--- a/source/Xcp_Std.c
+++ b/source/Xcp_Std.c
@@ -1265,71 +1265,90 @@ uint8 Xcp_DTOCmdStdGetId(boolean *responseExpected, const PduInfoType *pPduInfo)
 {
     Std_ReturnType result = E_OK;
 
-    uint32 identification_length;
-
     *responseExpected = TRUE;
 
     const uint8 identification_type = pPduInfo->SduDataPtr[0x01u];
-    const char *identification = Xcp_Ptr->general->identification;
 
-    for (identification_length = 0x00000000u; identification_length < 0xFFFFFFFFu; identification_length++)
+    if ((identification_type > XCP_GET_ID_TYPE_LAST_DEFINED) &&
+        (identification_type < XCP_GET_ID_TYPE_FIRST_USER_DEFINED))
     {
-        if (identification[identification_length] == 0x00u)
-        {
-            break;
-        }
-    }
-
-    if (identification_type == 0x00u)
-    {
-        /* DD75 (docs/superpowers/specs/2026-09-07-xcp-shared-state-defects-design.md). XCP part 2
-         * - Protocol Layer Specification 1.1/1.6.1.2.2 (1.0/1.6.1.2.2, identical wording): with
-         * mode 0, "the slave device sets the Memory Transfer Address (MTA) to the location from
-         * which the master device may upload the requested identification". 1.1/1.6.1.2.6
-         * (1.0/1.6.1.2.6, same wording) defines the MTA itself as one complete pointer -- "32Bit
-         * address + 8Bit extension" -- not an address alone, so setting it means setting both
-         * members. Only .address used to be assigned here, leaving .extension holding whatever an
-         * earlier, unrelated SET_MTA last left there for the UPLOAD that follows this command to
-         * read the identification through -- source/Xcp.c and the checksum helpers in this file
-         * both read the pair, never .address alone.
-         *
-         * GET_ID's own text never states which extension value to use here -- the specification
-         * does not settle it, the same kind of gap already found for the MTA's pre-SET_MTA value
-         * (this file, Xcp_CTOCmdStdConnect). What the specification does define is what a
-         * non-zero extension is FOR: 1.1/1.6.3.1.4 (1.0/1.6.3.2.2, identical wording,
-         * GET_SEGMENT_INFO) reads "ADDRESS_EXTENSION is used in SET_MTA, SHORT_UPLOAD and
-         * SHORT_DOWNLOAD when accessing a PAGE within this SEGMENT" -- a non-zero extension
-         * selects a PAGE within a configured CAL/PAG SEGMENT. Xcp_Ptr->general->identification is
-         * not part of any segments[] entry; it is plain, slave-owned descriptive data that lives
-         * entirely outside the page-switching model, so there is no SEGMENT for a non-zero
-         * extension to name here.
-         * 0x00u is also the specification's own vocabulary for "nothing meaningful on this pair":
-         * 1.1/1.6.1.2.3 (1.0/1.6.1.2.3, SET_REQUEST) reads "All ODT entries reset to address = 0,
-         * extension = 0" for the identical kind of pointer with nothing of its own to report. And
-         * it is what this module already uses whenever it hands the MTA a plain descriptive
-         * pointer of its own rather than an address the master supplied: Xcp_Init and
-         * Xcp_CTOCmdStdConnect both pair NULL_PTR with extension = 0x00u, and
-         * Xcp_DTOCmdDaqGetDaqEventInfo (source/Xcp_Daq.c) sets this exact pair when it points the
-         * MTA at an event channel's name for a following UPLOAD -- checked to actually apply here,
-         * not copied on sight: that pointer and this one are the same category of thing for the
-         * same structural reason above, neither living in a CAL/PAG segment. */
-        Xcp_Internal.memory_transfer.address = (void *)Xcp_Ptr->general->identification;
-        Xcp_Internal.memory_transfer.extension = 0x00u;
-
-        Xcp_Internal.cto_response.pdu_info.SduDataPtr[0x00u] = XCP_PID_RESPONSE;
-
-        /* Mode (1.1/1.6.1.2.2): TRANSFER_MODE and COMPRESSED_ENCRYPTED both clear. See DD111 and
-         * the masks' own note in source/Xcp_Internal.h for why neither is ever set here. */
-        Xcp_Internal.cto_response.pdu_info.SduDataPtr[0x01u] = 0x00u;
-        Xcp_Internal.cto_response.pdu_info.SduDataPtr[0x02u] = 0x00u;
-        Xcp_Internal.cto_response.pdu_info.SduDataPtr[0x03u] = 0x00u;
-        Xcp_CopyFromU32WithOrder(identification_length, &Xcp_Internal.cto_response.pdu_info.SduDataPtr[0x04u], Xcp_Ptr->general->byteOrder);
-
-        Xcp_FinalizeResPacket(0x08u, &Xcp_Internal.cto_response.pdu_info);
+        /* 5..127 name no identification type at all: 1.1/1.6.1.2.2 lists 0..4 and 128..255 as the
+         * types that "may be requested". This is the only value range that can reach GET_ID's own
+         * ERR_OUT_OF_RANGE row in 1.1/1.7.3.2.1, the identification type being its only parameter.
+         * A defined type this slave simply does not serve is NOT an error -- it answers Length = 0
+         * below, which is what 1.1/1.6.1.2.2 defines that value to mean. DD110. */
+        Xcp_FillErrorPacket(XCP_E_ASAM_OUT_OF_RANGE, &Xcp_Internal.cto_response.pdu_info);
     }
     else
     {
-        Xcp_FillErrorPacket(XCP_E_ASAM_OUT_OF_RANGE, &Xcp_Internal.cto_response.pdu_info);
+        const void *identification = NULL_PTR;
+        uint8 extension = 0x00u;
+        uint32 identification_length = 0x00000000u;
+
+        if (identification_type == XCP_GET_ID_TYPE_ASCII)
+        {
+            identification = (const void *)Xcp_Ptr->general->identification;
+            /* DD75 (docs/superpowers/specs/2026-09-07-xcp-shared-state-defects-design.md). XCP part 2
+             * - Protocol Layer Specification 1.1/1.6.1.2.2 (1.0/1.6.1.2.2, identical wording): with
+             * mode 0, "the slave device sets the Memory Transfer Address (MTA) to the location from
+             * which the master device may upload the requested identification". 1.1/1.6.1.2.6
+             * (1.0/1.6.1.2.6, same wording) defines the MTA itself as one complete pointer -- "32Bit
+             * address + 8Bit extension" -- not an address alone, so setting it means setting both
+             * members. Only .address used to be assigned here, leaving .extension holding whatever an
+             * earlier, unrelated SET_MTA last left there for the UPLOAD that follows this command to
+             * read the identification through -- source/Xcp.c and the checksum helpers in this file
+             * both read the pair, never .address alone.
+             *
+             * GET_ID's own text never states which extension value to use here -- the specification
+             * does not settle it, the same kind of gap already found for the MTA's pre-SET_MTA value
+             * (this file, Xcp_CTOCmdStdConnect). What the specification does define is what a
+             * non-zero extension is FOR: 1.1/1.6.3.1.4 (1.0/1.6.3.2.2, identical wording,
+             * GET_SEGMENT_INFO) reads "ADDRESS_EXTENSION is used in SET_MTA, SHORT_UPLOAD and
+             * SHORT_DOWNLOAD when accessing a PAGE within this SEGMENT" -- a non-zero extension
+             * selects a PAGE within a configured CAL/PAG SEGMENT. Xcp_Ptr->general->identification is
+             * not part of any segments[] entry; it is plain, slave-owned descriptive data that lives
+             * entirely outside the page-switching model, so there is no SEGMENT for a non-zero
+             * extension to name here.
+             * 0x00u is also the specification's own vocabulary for "nothing meaningful on this pair":
+             * 1.1/1.6.1.2.3 (1.0/1.6.1.2.3, SET_REQUEST) reads "All ODT entries reset to address = 0,
+             * extension = 0" for the identical kind of pointer with nothing of its own to report. And
+             * it is what this module already uses whenever it hands the MTA a plain descriptive
+             * pointer of its own rather than an address the master supplied: Xcp_Init and
+             * Xcp_CTOCmdStdConnect both pair NULL_PTR with extension = 0x00u, and
+             * Xcp_DTOCmdDaqGetDaqEventInfo (source/Xcp_Daq.c) sets this exact pair when it points the
+             * MTA at an event channel's name for a following UPLOAD -- checked to actually apply here,
+             * not copied on sight: that pointer and this one are the same category of thing for the
+             * same structural reason above, neither living in a CAL/PAG segment. */
+            extension = 0x00u;
+
+            for (identification_length = 0x00000000u;
+                 identification_length < 0xFFFFFFFFu;
+                 identification_length++)
+            {
+                if (Xcp_Ptr->general->identification[identification_length] == 0x00u)
+                {
+                    break;
+                }
+            }
+        }
+
+        /* DD113: a declined type nulls the MTA rather than leaving an earlier SET_MTA's pointer
+         * standing for an UPLOAD that ignores Length = 0. (NULL_PTR, 0) is this module's own
+         * vocabulary for "nothing meaningful on this pair" -- Xcp_Init and Xcp_CTOCmdStdConnect
+         * both pair exactly that. */
+        Xcp_Internal.memory_transfer.address = (void *)identification;
+        Xcp_Internal.memory_transfer.extension = extension;
+
+        Xcp_Internal.cto_response.pdu_info.SduDataPtr[0x00u] = XCP_PID_RESPONSE;
+        /* Mode (1.1/1.6.1.2.2): TRANSFER_MODE and COMPRESSED_ENCRYPTED both clear. DD111. */
+        Xcp_Internal.cto_response.pdu_info.SduDataPtr[0x01u] = 0x00u;
+        Xcp_Internal.cto_response.pdu_info.SduDataPtr[0x02u] = 0x00u;
+        Xcp_Internal.cto_response.pdu_info.SduDataPtr[0x03u] = 0x00u;
+        Xcp_CopyFromU32WithOrder(identification_length,
+                                 &Xcp_Internal.cto_response.pdu_info.SduDataPtr[0x04u],
+                                 Xcp_Ptr->general->byteOrder);
+
+        Xcp_FinalizeResPacket(0x08u, &Xcp_Internal.cto_response.pdu_info);
     }
 
     return result;

--- a/source/Xcp_Std.c
+++ b/source/Xcp_Std.c
@@ -1284,8 +1284,30 @@ uint8 Xcp_DTOCmdStdGetId(boolean *responseExpected, const PduInfoType *pPduInfo)
         const void *identification = NULL_PTR;
         uint8 extension = 0x00u;
         uint32 identification_length = 0x00000000u;
+        boolean served = FALSE;
 
-        if (identification_type == XCP_GET_ID_TYPE_ASCII)
+        if (Xcp_Ptr->general->getIdentificationFunction != NULL_PTR)
+        {
+            /* Consulted for every defined type including 0, so an integrator who needs a
+             * runtime-varying type 0 can override the configured string. Declining it falls back
+             * to that string below, which is what makes a NULL_PTR callback and a callback that
+             * returns E_NOT_OK for type 0 behave identically. DD110. */
+            if (Xcp_Ptr->general->getIdentificationFunction(identification_type,
+                                                            &identification,
+                                                            &extension,
+                                                            &identification_length) == E_OK)
+            {
+                served = TRUE;
+            }
+            else
+            {
+                identification = NULL_PTR;
+                extension = 0x00u;
+                identification_length = 0x00000000u;
+            }
+        }
+
+        if ((served == FALSE) && (identification_type == XCP_GET_ID_TYPE_ASCII))
         {
             identification = (const void *)Xcp_Ptr->general->identification;
             /* DD75 (docs/superpowers/specs/2026-09-07-xcp-shared-state-defects-design.md). XCP part 2
@@ -1332,10 +1354,13 @@ uint8 Xcp_DTOCmdStdGetId(boolean *responseExpected, const PduInfoType *pPduInfo)
             }
         }
 
-        /* DD113: a declined type nulls the MTA rather than leaving an earlier SET_MTA's pointer
-         * standing for an UPLOAD that ignores Length = 0. (NULL_PTR, 0) is this module's own
-         * vocabulary for "nothing meaningful on this pair" -- Xcp_Init and Xcp_CTOCmdStdConnect
-         * both pair exactly that. */
+        /* Points the MTA at whatever identification/extension now hold, for the UPLOAD that
+         * follows this response: a served type's own address and extension (the callback's, DD109
+         * included, or the static string's with extension 0), or -- DD113 -- (NULL_PTR, 0) when
+         * nothing served this request, so a declined type nulls the MTA rather than leaving an
+         * earlier SET_MTA's pointer standing for an UPLOAD that ignores Length = 0. (NULL_PTR, 0) is
+         * this module's own vocabulary for "nothing meaningful on this pair" -- Xcp_Init and
+         * Xcp_CTOCmdStdConnect both pair exactly that. */
         Xcp_Internal.memory_transfer.address = (void *)identification;
         Xcp_Internal.memory_transfer.extension = extension;
 

--- a/source/Xcp_Std.c
+++ b/source/Xcp_Std.c
@@ -1317,6 +1317,9 @@ uint8 Xcp_DTOCmdStdGetId(boolean *responseExpected, const PduInfoType *pPduInfo)
         Xcp_Internal.memory_transfer.extension = 0x00u;
 
         Xcp_Internal.cto_response.pdu_info.SduDataPtr[0x00u] = XCP_PID_RESPONSE;
+
+        /* Mode (1.1/1.6.1.2.2): TRANSFER_MODE and COMPRESSED_ENCRYPTED both clear. See DD111 and
+         * the masks' own note in source/Xcp_Internal.h for why neither is ever set here. */
         Xcp_Internal.cto_response.pdu_info.SduDataPtr[0x01u] = 0x00u;
         Xcp_Internal.cto_response.pdu_info.SduDataPtr[0x02u] = 0x00u;
         Xcp_Internal.cto_response.pdu_info.SduDataPtr[0x03u] = 0x00u;

--- a/source/Xcp_Std.c
+++ b/source/Xcp_Std.c
@@ -1399,7 +1399,9 @@ uint8 Xcp_DTOCmdStdGetId(boolean *responseExpected, const PduInfoType *pPduInfo)
         Xcp_Internal.memory_transfer.extension = extension;
 
         Xcp_Internal.cto_response.pdu_info.SduDataPtr[0x00u] = XCP_PID_RESPONSE;
-        /* Mode (1.1/1.6.1.2.2): TRANSFER_MODE and COMPRESSED_ENCRYPTED both clear. DD111. */
+        /* Mode (1.1/1.6.1.2.2): XCP_GET_ID_MODE_TRANSFER_MODE and
+         * XCP_GET_ID_MODE_COMPRESSED_ENCRYPTED (source/Xcp_Internal.h) both clear -- the slave
+         * points the MTA and compresses nothing. DD111. */
         Xcp_Internal.cto_response.pdu_info.SduDataPtr[0x01u] = 0x00u;
         Xcp_Internal.cto_response.pdu_info.SduDataPtr[0x02u] = 0x00u;
         Xcp_Internal.cto_response.pdu_info.SduDataPtr[0x03u] = 0x00u;

--- a/source/Xcp_Std.c
+++ b/source/Xcp_Std.c
@@ -1301,8 +1301,10 @@ uint8 Xcp_DTOCmdStdGetId(boolean *responseExpected, const PduInfoType *pPduInfo)
             }
             else
             {
-                identification = NULL_PTR;
-                extension = 0x00u;
+                /* E_NOT_OK promises nothing about the out-parameters, and a callback may have
+                 * written them before declining. Discarding its length is what sends a type with
+                 * no static fallback to Length = 0 below, and through Length = 0 the MTA to
+                 * (NULL_PTR, 0x00u), DD113. Type 0's fallback overwrites all three. */
                 identification_length = 0x00000000u;
             }
         }
@@ -1354,13 +1356,11 @@ uint8 Xcp_DTOCmdStdGetId(boolean *responseExpected, const PduInfoType *pPduInfo)
             }
         }
 
-        /* Deliberately after the static-fallback block above, not immediately after the callback
-         * block: served is set back to FALSE below on a non-conforming length, and served == FALSE
-         * together with identification_type == XCP_GET_ID_TYPE_ASCII is exactly what triggers that
-         * fallback. Checking here instead keeps a type-0 callback that answered E_OK from having
-         * its rejected length silently replaced by the configured string -- a callback that
-         * answered E_OK has claimed the type, and substituting different data would hide the
-         * defect Det is about to report. DD112. */
+        /* Only a callback's length is checked here; the configured string's is checked at
+         * generation time (script/source_cfg.c.jinja2). A type-0 callback that answered E_OK has
+         * claimed the type, so a length refused here is answered Length = 0 and is never replaced
+         * by the configured string -- substituting different data would hide the defect Det is
+         * about to report. DD112. */
         if (served == TRUE)
         {
             const uint8 element_size =
@@ -1369,24 +1369,32 @@ uint8 Xcp_DTOCmdStdGetId(boolean *responseExpected, const PduInfoType *pPduInfo)
             if ((identification_length % (uint32)element_size) != 0x00000000u)
             {
                 /* 1.1/1.6.1.2.2: "Length mod AG = 0". The module cannot emit a non-conforming
-                 * Length, so the type is reported unavailable and the integrator hears about it
-                 * through Det -- the master has no channel for this distinction. DD112. */
+                 * Length, so the type is reported unavailable -- Length = 0, which also nulls the
+                 * MTA below, DD113 -- and the integrator hears about it through Det; the master
+                 * has no channel for this distinction. DD112. */
                 Xcp_ReportError(0x00u, XCP_CAN_IF_RX_INDICATION_API_ID,
                                 XCP_E_IDENTIFICATION_NOT_GRANULAR);
-                identification = NULL_PTR;
-                extension = 0x00u;
                 identification_length = 0x00000000u;
-                served = FALSE;
             }
         }
 
-        /* Points the MTA at whatever identification/extension now hold, for the UPLOAD that
-         * follows this response: a served type's own address and extension (the callback's, DD109
-         * included, or the static string's with extension 0), or -- DD113 -- (NULL_PTR, 0) when
-         * nothing served this request, so a declined type nulls the MTA rather than leaving an
-         * earlier SET_MTA's pointer standing for an UPLOAD that ignores Length = 0. (NULL_PTR, 0) is
-         * this module's own vocabulary for "nothing meaningful on this pair" -- Xcp_Init and
-         * Xcp_CTOCmdStdConnect both pair exactly that. */
+        if (identification_length == 0x00000000u)
+        {
+            /* DD113: a response whose Length is 0 points the MTA at (NULL_PTR, 0x00u). Decided here,
+             * on the Length alone, so that no route to Length = 0 can skip it: a callback answering
+             * E_OK with a length of 0 and an empty configured string for type 0 both arrive with a
+             * live address, and the declined and refused callback routes above reset only the
+             * length, keeping whatever the callback wrote. A master that ignores Length = 0 and
+             * uploads anyway then reads through a pointer the slave deliberately nulled.
+             * (NULL_PTR, 0x00u) is this module's own vocabulary for "nothing meaningful on this
+             * pair" -- Xcp_Init and Xcp_CTOCmdStdConnect both pair exactly that. */
+            identification = NULL_PTR;
+            extension = 0x00u;
+        }
+
+        /* Points the MTA for the UPLOAD that follows this response: a served type's own address
+         * and extension -- the callback's, DD109 included, or the static string's with extension
+         * 0 -- or (NULL_PTR, 0x00u) whenever the Length is 0, as set just above. */
         Xcp_Internal.memory_transfer.address = (void *)identification;
         Xcp_Internal.memory_transfer.extension = extension;
 

--- a/source/Xcp_Std.c
+++ b/source/Xcp_Std.c
@@ -1354,6 +1354,32 @@ uint8 Xcp_DTOCmdStdGetId(boolean *responseExpected, const PduInfoType *pPduInfo)
             }
         }
 
+        /* Deliberately after the static-fallback block above, not immediately after the callback
+         * block: served is set back to FALSE below on a non-conforming length, and served == FALSE
+         * together with identification_type == XCP_GET_ID_TYPE_ASCII is exactly what triggers that
+         * fallback. Checking here instead keeps a type-0 callback that answered E_OK from having
+         * its rejected length silently replaced by the configured string -- a callback that
+         * answered E_OK has claimed the type, and substituting different data would hide the
+         * defect Det is about to report. DD112. */
+        if (served == TRUE)
+        {
+            const uint8 element_size =
+                Xcp_ElementSizeForAddressGranularity(Xcp_Ptr->general->addressGranularity);
+
+            if ((identification_length % (uint32)element_size) != 0x00000000u)
+            {
+                /* 1.1/1.6.1.2.2: "Length mod AG = 0". The module cannot emit a non-conforming
+                 * Length, so the type is reported unavailable and the integrator hears about it
+                 * through Det -- the master has no channel for this distinction. DD112. */
+                Xcp_ReportError(0x00u, XCP_MAIN_FUNCTION_API_ID,
+                                XCP_E_IDENTIFICATION_NOT_GRANULAR);
+                identification = NULL_PTR;
+                extension = 0x00u;
+                identification_length = 0x00000000u;
+                served = FALSE;
+            }
+        }
+
         /* Points the MTA at whatever identification/extension now hold, for the UPLOAD that
          * follows this response: a served type's own address and extension (the callback's, DD109
          * included, or the static string's with extension 0), or -- DD113 -- (NULL_PTR, 0) when

--- a/source/Xcp_Std.c
+++ b/source/Xcp_Std.c
@@ -1371,7 +1371,7 @@ uint8 Xcp_DTOCmdStdGetId(boolean *responseExpected, const PduInfoType *pPduInfo)
                 /* 1.1/1.6.1.2.2: "Length mod AG = 0". The module cannot emit a non-conforming
                  * Length, so the type is reported unavailable and the integrator hears about it
                  * through Det -- the master has no channel for this distinction. DD112. */
-                Xcp_ReportError(0x00u, XCP_MAIN_FUNCTION_API_ID,
+                Xcp_ReportError(0x00u, XCP_CAN_IF_RX_INDICATION_API_ID,
                                 XCP_E_IDENTIFICATION_NOT_GRANULAR);
                 identification = NULL_PTR;
                 extension = 0x00u;

--- a/test.sh
+++ b/test.sh
@@ -11,11 +11,20 @@
 # Measured, 600 template compilations per run, this tree, this host:
 #   alpine image, 8 MB stack   -- failed 2 of 3 runs
 #   alpine image, 64 MB stack  -- 7 of 7 clean
+#   alpine image, 256 MB stack -- failed 1 of 2 runs
 #   debian/glibc, 8 MB stack   -- 4 of 4 clean
 #
 # glibc survives the same depth at the same limit, which is why this only ever bit locally and in
 # this image. The hard limit here is unlimited, so an unprivileged user can raise the soft limit;
 # doing it here rather than at the `docker run` keeps every caller -- CI and local -- on one rule.
+#
+# The 256 MB run that failed hit the identical class of symptom listed above, this time "...unknown
+# to the frame ('loop')" in jinja2/idtracking.py while compiling source_cfg.c.jinja2. A 4x increase
+# over the 64 MB setting measured clean not shifting the failure mode is evidence against stack
+# headroom being the binding constraint at this scale, whatever was true at 8 MB. The limit stays
+# at 65536; re-run remains the workaround, not a larger ulimit. Prompted by one branch that grew
+# source_cfg.c.jinja2 measuring 1 clean run in 9 attempts of the standard command, against a
+# clean-first-try control on the unmodified parent commit.
 ulimit -s 65536
 
 result=0

--- a/test/asam_error_matrix_test.py
+++ b/test/asam_error_matrix_test.py
@@ -202,8 +202,15 @@ class TestGetIdErrorHandling:
         handle.lib.Xcp_MainFunction()
         assert tuple(handle.can_if_transmit.call_args[0][1].SduDataPtr[0:2]) == (0xFE, 0x21)
 
-    @pytest.mark.parametrize('requested_identification_type', range(0x01, 0xFF))
+    @pytest.mark.parametrize('requested_identification_type', range(0x05, 0x80))
     def test_returns_err_out_of_range(self, requested_identification_type):
+        """1.1/1.6.1.2.2 defines identification types 0-4 and 128-255. Only 5-127 are out of range;
+        a defined type this slave does not serve answers a positive response with Length = 0 instead
+        (test/get_id_test.py::test_get_id_reports_length_zero_for_a_defined_type_it_does_not_serve),
+        which is what 1.1/1.6.1.2.2 defines Length = 0 to mean. DD110.
+
+        This previously ranged over range(0x01, 0xFF) -- every type but 0, and stopping short of 255.
+        """
         handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001))
         handle.lib.Xcp_CanIfRxIndication(0x0001, handle.get_pdu_info((0xFF, 0x00)))
         handle.lib.Xcp_MainFunction()

--- a/test/configuration_schema_test.py
+++ b/test/configuration_schema_test.py
@@ -79,6 +79,40 @@ def test_every_identification_field_type_is_valid(schema, identification_field_t
     validate(DefaultConfig(identification=identification_field_type), schema)
 
 
+@pytest.mark.parametrize('identification', (
+    pytest.param('/path/to/xcp.a2\u00e9', id='non-ASCII'),
+    pytest.param('/path/to\txcp.a2l', id='control character'),
+    pytest.param('/path/to/xcp.a2l\n', id='trailing line feed'),
+))
+def test_an_identification_that_is_not_printable_ascii_is_rejected(schema, identification):
+    """The identification's pattern, shown to run rather than assumed to: jsonschema silently
+    ignores a keyword it does not recognise, a misspelt one included, so a constraint written into
+    this schema is not by itself evidence that anything enforces it. XCP part 2 - Protocol Layer
+    Specification 1.1/1.6.1.2.2 calls the identification "a byte stream of plain ASCII text", and
+    script/source_cfg.c.jinja2 refuses the same characters as the backstop for configurations that
+    never pass through this schema.
+
+    The trailing line feed is the row a pattern ending in $ would let through: jsonschema matches
+    patterns with Python's re, whose $ also matches just before a final line feed."""
+    with pytest.raises(jsonschema.ValidationError):
+        validate(DefaultConfig(identification=identification), schema)
+
+
+@pytest.mark.parametrize('identification', (
+    pytest.param('c:\\database\\test.a2l', id='backslash'),
+    pytest.param('/path/to/"x".a2l', id='double quote'),
+    pytest.param('', id='empty'),
+))
+def test_an_identification_with_a_backslash_a_quote_or_nothing_at_all_is_valid(schema,
+                                                                               identification):
+    """The pattern's other edge. Backslash and double quote are printable ASCII and stay allowed:
+    c:\\database\\test.a2l is 1.1/1.6.1.2.2's own second example, and the generator escapes both
+    characters into the C literal rather than refusing them. The empty string stays allowed, as it
+    was before the pattern existed: it answers Length = 0 for type 0, which 1.1/1.6.1.2.2 defines
+    as not available, and the generator accepts it."""
+    validate(DefaultConfig(identification=identification), schema)
+
+
 def test_the_repository_configuration_is_valid(schema):
     """config/xcp.json is what generated/CMakeLists.txt actually validates; a failure here is a
     broken integrator build, not just a harness inconsistency."""

--- a/test/configuration_schema_test.py
+++ b/test/configuration_schema_test.py
@@ -76,7 +76,7 @@ def test_every_address_granularity_is_valid(schema, address_granularity):
 
 @pytest.mark.parametrize('identification_field_type', identification_field_types)
 def test_every_identification_field_type_is_valid(schema, identification_field_type):
-    validate(DefaultConfig(identification=identification_field_type), schema)
+    validate(DefaultConfig(identification_field_type=identification_field_type), schema)
 
 
 @pytest.mark.parametrize('identification', (

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -600,6 +600,11 @@ class XcpTest(object):
                 self._guarded_callback('Xcp_UserDefinedChecksumFunction',
                                        self.xcp_user_defined_checksum_function))
         self.xcp_user_defined_checksum_function.return_value = 0
+        self.xcp_get_identification_function = MagicMock()
+        self.config.ffi.def_extern('Xcp_GetIdentificationFunction')(
+                self._guarded_callback('Xcp_GetIdentificationFunction',
+                                       self.xcp_get_identification_function))
+        self.xcp_get_identification_function.return_value = self.define('E_NOT_OK')
         for func in self.code.mocked:
             self.ffi.def_extern(func)(self._guarded_callback(func, getattr(self, convert(func))))
         self.can_if_transmit.return_value = self.define('E_OK')

--- a/test/daq_configuration_test.py
+++ b/test/daq_configuration_test.py
@@ -1006,3 +1006,26 @@ def test_generation_accepts_the_default_identification_under_every_granularity(
 
     assert handle.ffi.string(handle.config.lib.Xcp[0].general.identification) == \
         b'/path/to/xcp.a2l'
+
+
+@pytest.mark.parametrize('identification', (
+    pytest.param('/path/to/xcp.a2\u00e9', id='non-ASCII'),   # 16 characters, 17 UTF-8 bytes
+    pytest.param('/path/to\txcp.a2l', id='control character'),    # 16 characters, one a real tab
+))
+def test_generation_refuses_an_identification_that_is_not_printable_ascii(identification):
+    """XCP part 2 - Protocol Layer Specification 1.1/1.6.1.2.2 defines the identification as "a byte
+    stream of plain ASCII text", and the generator's Length mod AG = 0 guard counts characters --
+    one byte each only for printable ASCII, 0x20-0x7E. U+00E9 is one character and two UTF-8 bytes,
+    so the first row passes a count of 16 and would compile to 17. Control characters are refused
+    as a class: a raw line feed would split the generated C literal, and a NUL would end the string
+    Xcp_DTOCmdStdGetId measures by scanning for one. The tab stands for the class.
+
+    BYTE granularity, so the length guard cannot be what refuses either row: every length is a
+    multiple of 1. Both rows are 16 characters, a multiple of 4 as well, so neither would trip that
+    guard under any granularity. config/xcp.schema.json refuses the same characters
+    (test/configuration_schema_test.py), but the harness drives BSWCodeGen without the schema, so
+    this is the check every configuration meets. Asserts only that generation fails, for the reason
+    given above test_generation_fails_when_a_configured_pid_contradicts_the_derived_first_pid.
+    """
+    with pytest.raises(UndefinedError):
+        XcpTest(DefaultConfig(address_granularity='BYTE', identification=identification))

--- a/test/daq_configuration_test.py
+++ b/test/daq_configuration_test.py
@@ -971,6 +971,7 @@ def test_odt_entry_size_stim_is_reported_for_a_stim_capable_build():
     ('WORD', '/path/to/database.a2l'),    # 21 bytes: 21 mod 2 == 1
     ('DWORD', '/path/to/database.a2l'),   # 21 bytes: 21 mod 4 == 1
     ('DWORD', '/path/to/xcp.a2ll'),       # 17 bytes: 17 mod 4 == 1
+    ('DWORD', '/path/to/xcp12.a2l'),      # 18 bytes: 18 mod 4 == 2, yet 18 mod 2 == 0 -- see below
 ))
 def test_generation_refuses_an_identification_that_is_not_a_multiple_of_the_granularity(
         address_granularity, identification):
@@ -1006,6 +1007,18 @@ def test_generation_accepts_the_default_identification_under_every_granularity(
 
     assert handle.ffi.string(handle.config.lib.Xcp[0].general.identification) == \
         b'/path/to/xcp.a2l'
+
+
+def test_generation_accepts_an_18_byte_identification_under_word():
+    """The row that tells WORD from DWORD. '/path/to/xcp12.a2l' is 18 bytes: 18 mod 2 == 0, so WORD
+    accepts it, and 18 mod 4 == 2, so DWORD refuses it (the last refusal row above). Every other
+    row on either side is a length the two granularities agree on -- 21 and 17 are odd, 16 is a
+    multiple of 4 -- so exchanging their element sizes in the guard's own table would pass them
+    all. This test and that DWORD row each fail under the exchange."""
+    handle = XcpTest(DefaultConfig(address_granularity='WORD', identification='/path/to/xcp12.a2l'))
+
+    assert handle.ffi.string(handle.config.lib.Xcp[0].general.identification) == \
+        b'/path/to/xcp12.a2l'
 
 
 @pytest.mark.parametrize('identification', (

--- a/test/daq_configuration_test.py
+++ b/test/daq_configuration_test.py
@@ -965,3 +965,44 @@ def test_odt_entry_size_stim_is_reported_for_a_stim_capable_build():
     assert handle.config.lib.Xcp[0].general.odtEntrySizeStim == \
         handle.config.lib.Xcp[0].general.odtEntrySizeDaq
     assert handle.config.lib.Xcp[0].general.odtEntrySizeStim != 0
+
+
+@pytest.mark.parametrize('address_granularity, identification', (
+    ('WORD', '/path/to/database.a2l'),    # 21 bytes: 21 mod 2 == 1
+    ('DWORD', '/path/to/database.a2l'),   # 21 bytes: 21 mod 4 == 1
+    ('DWORD', '/path/to/xcp.a2ll'),       # 17 bytes: 17 mod 4 == 1
+))
+def test_generation_refuses_an_identification_that_is_not_a_multiple_of_the_granularity(
+        address_granularity, identification):
+    """XCP part 2 - Protocol Layer Specification 1.1/1.6.1.2.2 adds a rule 1.0/1.6.1.2.2 does not
+    have: "The following rule applies: Length mod AG = 0". It protects the UPLOAD that follows,
+    whose element count 1.1 defines as (Length GET_ID [BYTE]) / AG -- an inexact division leaves
+    the master unable to ask for the right number of elements. DD112.
+
+    The guard message is documentation, not output: raise() is not a registered Jinja global in
+    bsw_code_gen, so referencing it aborts rendering with UndefinedError and the string never
+    reaches the caller. This asserts that generation fails, never that a message matches.
+    """
+    with pytest.raises(UndefinedError):
+        XcpTest(DefaultConfig(address_granularity=address_granularity,
+                              identification=identification))
+
+
+@pytest.mark.parametrize('address_granularity', ('BYTE', 'WORD', 'DWORD'))
+def test_generation_accepts_the_default_identification_under_every_granularity(
+        address_granularity):
+    """The boundary above from the accepting side, and the reason the shipped default changed from
+    /path/to/database.a2l (21 bytes) to /path/to/xcp.a2l (16): without it the guard would reject
+    the module's own default configuration under WORD and DWORD.
+
+    Asserts on the generated identification string rather than on addressGranularity itself:
+    Xcp_AddressGranularityType's enumerators (interface/Xcp_Types.h) are the bare names BYTE,
+    WORD, DWORD with no XCP_ADDRESS_GRANULARITY_ prefix, and that prefixed spelling is not a
+    preprocessor #define anywhere in the generated header either, so handle.define(...) would
+    raise KeyError before the comparison ever ran. The point of this test is only that generation
+    succeeds at all under every granularity, which the identification round-trip already shows.
+    """
+    handle = XcpTest(DefaultConfig(address_granularity=address_granularity))
+
+    assert handle.ffi.string(handle.config.lib.Xcp[0].general.identification) == \
+        b'/path/to/xcp.a2l'

--- a/test/get_id_test.py
+++ b/test/get_id_test.py
@@ -80,3 +80,118 @@ def test_get_id_sets_all_remaining_bytes_to_trailing_value(trailing_value, max_c
     handle.lib.Xcp_MainFunction()
     remaining_zeros = tuple(trailing_value for _ in range(max_cto - 0x08))
     assert tuple(handle.can_if_transmit.call_args[0][1].SduDataPtr[0x08:max_cto]) == remaining_zeros
+
+
+def _connect(handle):
+    handle.lib.Xcp_CanIfRxIndication(0x0001, handle.get_pdu_info((0xFF, 0x00)))
+    handle.lib.Xcp_MainFunction()
+    handle.lib.Xcp_CanIfTxConfirmation(0x0001, handle.define('E_OK'))
+
+
+def _get_id(handle, identification_type):
+    """Issue GET_ID and return the response bytes, read immediately after the transmit call."""
+    handle.lib.Xcp_CanIfRxIndication(0x0001, handle.get_pdu_info((0xFA, identification_type)))
+    handle.lib.Xcp_MainFunction()
+    raw = tuple(handle.can_if_transmit.call_args[0][1].SduDataPtr[0:8])
+    handle.lib.Xcp_CanIfTxConfirmation(0x0001, handle.define('E_OK'))
+    return raw
+
+
+@pytest.mark.parametrize('byte_order', byte_orders)
+@pytest.mark.parametrize('identification_type', (0x01, 0x02, 0x03, 0x04, 0x80, 0xFF))
+def test_get_id_reports_length_zero_for_a_defined_type_it_does_not_serve(byte_order,
+                                                                        identification_type):
+    """XCP part 2 - Protocol Layer Specification 1.1/1.6.1.2.2 (1.0/1.6.1.2.2, identical wording):
+    "If length is 0, the requested identification type is not available." That is GET_ID's own
+    in-band way of declining, and it exists so a master can enumerate what a slave supports without
+    provoking errors. Types 1-4 and 128-255 are all types 1.1 defines as requestable, so naming one
+    is a valid parameter even on a slave with nothing to return for it -- DD110.
+
+    Type 255 is covered here deliberately: the ERR_OUT_OF_RANGE test this replaces ranged over
+    range(0x01, 0xFF), which stops at 254, so the top of the user-defined range was never exercised.
+    """
+    handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001, byte_order=byte_order))
+    _connect(handle)
+
+    raw_data = _get_id(handle, identification_type)
+
+    assert raw_data[0] == 0xFF, 'a declined type is still a positive response, not an error packet'
+    assert raw_data[1] == 0x00, 'Mode: TRANSFER_MODE and COMPRESSED_ENCRYPTED both clear'
+    assert u32_from_array(bytearray(raw_data[4:8]), byte_order) == 0, 'Length must be 0'
+
+
+@pytest.mark.parametrize('identification_type', (0x05, 0x40, 0x7F))
+def test_get_id_rejects_a_type_the_specification_does_not_define(identification_type):
+    """1.1/1.6.1.2.2 lists exactly 0, 1, 2, 3, 4 and 128..255 as the types that "may be requested".
+    5..127 name no identification type at all, so a master sending one has supplied an out-of-range
+    parameter -- which is what keeps 1.1/1.7.3.2.1's GET_ID ERR_OUT_OF_RANGE row reachable, given
+    that the identification type is GET_ID's only parameter. DD110."""
+    handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001))
+    _connect(handle)
+
+    raw_data = _get_id(handle, identification_type)
+
+    assert raw_data[0:2] == (0xFE, 0x22), 'expected ERR_OUT_OF_RANGE'
+
+
+def _set_mta(handle, address_bytes, extension=0x00):
+    """SET_MTA. Copy the exact framing from test/session_teardown_test.py, which already issues a
+    SET_MTA(0xDEADBEEF) for the neighbouring DD75 case -- do not reconstruct the byte order here."""
+    handle.lib.Xcp_CanIfRxIndication(0x0001, handle.get_pdu_info(
+        (0xF6, 0x00, 0x00, extension) + address_bytes))
+    handle.lib.Xcp_MainFunction()
+    handle.lib.Xcp_CanIfTxConfirmation(0x0001, handle.define('E_OK'))
+
+
+def _upload_addresses(handle, element_count):
+    """Issue UPLOAD and return the raw pointers Xcp_ReadSlaveMemory was asked to read.
+
+    Returns cdata pointers, not integers: the harness idiom for "is this pointer null" is a direct
+    comparison against handle.ffi.NULL (test/clear_daq_list_test.py:40), which needs no cast to an
+    integer type the cdef may not carry.
+    """
+    addresses = []
+    handle.xcp_read_slave_memory_u8.side_effect = \
+        lambda p_address, _extension, _p_buffer: addresses.append(p_address)
+    handle.lib.Xcp_CanIfRxIndication(0x0001, handle.get_pdu_info((0xF5, element_count)))
+    handle.lib.Xcp_MainFunction()
+    return addresses
+
+
+def test_a_length_zero_get_id_does_not_leave_an_earlier_set_mta_standing():
+    """DD113. A declined GET_ID must not leave an earlier SET_MTA's pointer in place: a master that
+    ignores Length = 0 and uploads anyway would then read through a pointer the slave never set for
+    this purpose -- the defect DD75 fixed for the extension half of the same pair, arriving the
+    other way round.
+
+    Paired with its own positive control below. "This address was never read" is vacuous alone: such
+    a test passes just as happily if UPLOAD read nothing at all, or if SET_MTA never worked. The
+    control shows the same SET_MTA address IS reached when no GET_ID intervenes, so the difference
+    here is caused by GET_ID and by nothing else. test/session_teardown_test.py uses the same
+    pairing for the neighbouring DD75 case.
+    """
+    handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001))
+    _connect(handle)
+    _set_mta(handle, (0xEF, 0xBE, 0xAD, 0xDE))
+
+    _get_id(handle, 0x03)   # a type 1.1/1.6.1.2.2 defines but this slave does not serve
+
+    addresses = _upload_addresses(handle, 0x01)
+
+    assert addresses, 'UPLOAD read no memory at all -- see the note below before changing this'
+    assert addresses[0] == handle.ffi.NULL, \
+        'a Length = 0 GET_ID left the earlier SET_MTA standing for the following UPLOAD'
+
+
+def test_an_upload_with_no_intervening_get_id_still_reads_the_set_mta_address():
+    """The positive control for the test above: same SET_MTA, same UPLOAD, no GET_ID between them.
+    If this ever fails, the absence the test above asserts proves nothing."""
+    handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001))
+    _connect(handle)
+    _set_mta(handle, (0xEF, 0xBE, 0xAD, 0xDE))
+
+    addresses = _upload_addresses(handle, 0x01)
+
+    assert addresses, 'setup: UPLOAD must read memory'
+    assert addresses[0] != handle.ffi.NULL, \
+        'setup: UPLOAD must reach the address SET_MTA just set, or the paired test is vacuous'

--- a/test/get_id_test.py
+++ b/test/get_id_test.py
@@ -145,65 +145,134 @@ def _set_mta(handle, address_bytes, extension=0x00):
 
 
 def _upload_addresses(handle, element_count):
-    """Issue UPLOAD and return the raw pointers Xcp_ReadSlaveMemory was asked to read.
+    """Issue UPLOAD and return the MTA pairs Xcp_ReadSlaveMemory* was asked to read through, as
+    (address, extension) integers.
 
-    Returns cdata pointers, not integers: the harness idiom for "is this pointer null" is a direct
-    comparison against handle.ffi.NULL (test/clear_daq_list_test.py:40), which needs no cast to an
-    integer type the cdef may not carry.
+    A pair, not an address alone: 1.1/1.6.1.2.6 defines the MTA as "32Bit address + 8Bit
+    extension", and an address can be right while its extension is stale -- DD75's defect. The
+    address is cast to uintptr_t, as test_get_id_points_the_mta_at_the_callbacks_address_and_
+    extension does, and never dereferenced: callers here point the MTA at SET_MTA's fabricated
+    0xDEADBEEF, or expect NULL. All three widths are hooked because UPLOAD reads through
+    Xcp_ReadSlaveMemoryTable[addressGranularity] (source/Xcp.c), so a WORD or DWORD configuration
+    never reaches the u8 double.
     """
-    addresses = []
-    handle.xcp_read_slave_memory_u8.side_effect = \
-        lambda p_address, _extension, _p_buffer: addresses.append(p_address)
+    reads = []
+
+    def read_slave_memory(p_address, extension, _p_buffer):
+        reads.append((int(handle.ffi.cast('uintptr_t', p_address)), extension))
+
+    handle.xcp_read_slave_memory_u8.side_effect = read_slave_memory
+    handle.xcp_read_slave_memory_u16.side_effect = read_slave_memory
+    handle.xcp_read_slave_memory_u32.side_effect = read_slave_memory
     handle.lib.Xcp_CanIfRxIndication(0x0001, handle.get_pdu_info((0xF5, element_count)))
     handle.lib.Xcp_MainFunction()
-    return addresses
-
-
-def test_a_length_zero_get_id_does_not_leave_an_earlier_set_mta_standing():
-    """DD113. A declined GET_ID must not leave an earlier SET_MTA's pointer in place: a master that
-    ignores Length = 0 and uploads anyway would then read through a pointer the slave never set for
-    this purpose -- the defect DD75 fixed for the extension half of the same pair, arriving the
-    other way round.
-
-    Paired with its own positive control below. "This address was never read" is vacuous alone: such
-    a test passes just as happily if UPLOAD read nothing at all, or if SET_MTA never worked. The
-    control shows the same SET_MTA address IS reached when no GET_ID intervenes, so the difference
-    here is caused by GET_ID and by nothing else. test/session_teardown_test.py uses the same
-    pairing for the neighbouring DD75 case.
-    """
-    handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001))
-    _connect(handle)
-    _set_mta(handle, (0xEF, 0xBE, 0xAD, 0xDE))
-
-    _get_id(handle, 0x03)   # a type 1.1/1.6.1.2.2 defines but this slave does not serve
-
-    addresses = _upload_addresses(handle, 0x01)
-
-    assert addresses, 'UPLOAD read no memory at all -- see the note below before changing this'
-    assert addresses[0] == handle.ffi.NULL, \
-        'a Length = 0 GET_ID left the earlier SET_MTA standing for the following UPLOAD'
-
-
-def test_an_upload_with_no_intervening_get_id_still_reads_the_set_mta_address():
-    """The positive control for the test above: same SET_MTA, same UPLOAD, no GET_ID between them.
-    If this ever fails, the absence the test above asserts proves nothing."""
-    handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001))
-    _connect(handle)
-    _set_mta(handle, (0xEF, 0xBE, 0xAD, 0xDE))
-
-    addresses = _upload_addresses(handle, 0x01)
-
-    assert addresses, 'setup: UPLOAD must read memory'
-    assert addresses[0] != handle.ffi.NULL, \
-        'setup: UPLOAD must reach the address SET_MTA just set, or the paired test is vacuous'
+    return reads
 
 
 _CALLBACK_CONFIG = dict(channel_rx_pdu_ref=0x0001,
                         get_id_function='Xcp_GetIdentificationFunction')
 
+# Distinct from the extension every SET_MTA below sets (7), so a pair that leaks names its source.
+_CALLBACK_EXTENSION = 0x05
 
-def _serve(handle, payload, extension=0x00):
+
+def _no_callback(_handle):
+    pass
+
+
+def _declines_after_writing(handle):
+    _serve(handle, b'abcd', extension=_CALLBACK_EXTENSION, result='E_NOT_OK')
+
+
+def _serves_a_length_the_granularity_refuses(handle):
+    _serve(handle, b'abc', extension=_CALLBACK_EXTENSION)   # 3 is not a multiple of WORD's 2
+
+
+def _serves_length_zero(handle):
+    _serve(handle, b'', extension=_CALLBACK_EXTENSION)
+
+
+# Every route by which GET_ID answers Length = 0 -- (configuration, callback behaviour, type).
+_LENGTH_ZERO_ROUTES = (
+    pytest.param(dict(channel_rx_pdu_ref=0x0001), _no_callback, 0x03,
+                 id='(i) no callback, a defined type it does not serve'),
+    pytest.param(_CALLBACK_CONFIG, _declines_after_writing, 0x01,
+                 id='(ii) callback writes its out-parameters, then E_NOT_OK'),
+    pytest.param(dict(address_granularity='WORD', **_CALLBACK_CONFIG),
+                 _serves_a_length_the_granularity_refuses, 0x01,
+                 id='(iii) callback length 3 under WORD'),
+    pytest.param(_CALLBACK_CONFIG, _serves_length_zero, 0x01,
+                 id='(iv) callback answers E_OK with length 0'),
+    pytest.param(dict(channel_rx_pdu_ref=0x0001, identification=''), _no_callback, 0x00,
+                 id='(v) empty configured identification, type 0'),
+)
+
+
+@pytest.mark.parametrize('config, callback_behaviour, identification_type', _LENGTH_ZERO_ROUTES)
+def test_a_length_zero_get_id_does_not_leave_an_earlier_set_mta_standing(config,
+                                                                        callback_behaviour,
+                                                                        identification_type):
+    """DD113. Every GET_ID that answers Length = 0 points the MTA at (NULL_PTR, 0x00u). A master
+    that ignores Length = 0 and uploads anyway then reads through a pointer the slave deliberately
+    nulled -- not an earlier SET_MTA's, which is the defect DD75 fixed for the extension half of
+    the same pair, arriving the other way round, and not whatever the route itself was holding.
+
+    One row per route to Length = 0, because they reach it differently: (i) nothing serves a
+    defined type, so nothing is assigned; (ii) the callback writes all three out-parameters and
+    then declines; (iii) the callback's length is refused as not a multiple of the granularity;
+    (iv) the callback answers E_OK with a length of 0; (v) the configured string is empty. Routes
+    (ii) to (v) all reach Length = 0 holding a live address -- the callback's own, or the empty
+    string's -- which is what (i), the only route this test used to take, could never show.
+
+    SET_MTA sets extension 7 first, and the callback writes extension 5, so a pair that leaks names
+    its source. Paired with a positive control per route below: "UPLOAD read (NULL, 0)" is vacuous
+    alone, because CONNECT itself leaves the MTA at exactly that pair, so a SET_MTA that silently
+    failed would pass every row. test/session_teardown_test.py uses the same pairing for the
+    neighbouring DD75 case.
+    """
+    handle = XcpTest(DefaultConfig(**config))
+    _connect(handle)
+    callback_behaviour(handle)
+    _set_mta(handle, (0xEF, 0xBE, 0xAD, 0xDE), extension=0x07)
+
+    raw_data = _get_id(handle, identification_type)
+
+    assert raw_data[0] == 0xFF, 'a Length = 0 answer is still a positive response'
+    assert u32_from_array(bytearray(raw_data[4:8]), 'LITTLE_ENDIAN') == 0, \
+        'every row here is a route to Length = 0'
+
+    reads = _upload_addresses(handle, 0x01)
+
+    assert reads, 'UPLOAD read no memory at all -- see the docstring before changing this'
+    assert reads[0] == (0, 0x00), \
+        'UPLOAD read through (0x{:X}, {}) after a Length = 0 GET_ID -- expected (NULL, 0)'.format(
+            *reads[0])
+
+
+@pytest.mark.parametrize('config', [pytest.param(route.values[0], id=route.id)
+                                    for route in _LENGTH_ZERO_ROUTES])
+def test_an_upload_with_no_intervening_get_id_still_reads_the_set_mta_address(config):
+    """The positive control for the test above, one row per route's configuration: the same SET_MTA
+    and the same UPLOAD, with no GET_ID between them. If a row here fails, the (NULL, 0) its route
+    asserts above proves nothing. Per route rather than once, because the configurations differ
+    where it matters: route (iii)'s WORD granularity reads through a different
+    Xcp_ReadSlaveMemory* function than the others."""
+    handle = XcpTest(DefaultConfig(**config))
+    _connect(handle)
+    _set_mta(handle, (0xEF, 0xBE, 0xAD, 0xDE), extension=0x07)
+
+    reads = _upload_addresses(handle, 0x01)
+
+    assert reads, 'setup: UPLOAD must read memory'
+    assert reads[0][0] != 0, \
+        'setup: UPLOAD must reach the address SET_MTA just set, or the paired test is vacuous'
+
+
+def _serve(handle, payload, extension=0x00, result='E_OK'):
     """Make the configured callback answer `payload` for every type, and keep the buffer alive.
+
+    `result` is what the callback returns after writing all three out-parameters. E_NOT_OK after
+    writing them is how a test shows the module takes nothing from a declined call.
 
     Allocated and cast through handle.config.ffi, not the bare handle.ffi (== handle.code.ffi):
     Xcp_GetIdentificationFunction's own extern is declared and registered on handle.config.ffi
@@ -220,7 +289,7 @@ def _serve(handle, payload, extension=0x00):
         p_identification[0] = handle.config.ffi.cast('void *', buffer)
         p_extension[0] = extension
         p_length[0] = len(payload)
-        return handle.define('E_OK')
+        return handle.define(result)
 
     handle.xcp_get_identification_function.side_effect = get_identification
     return buffer
@@ -284,6 +353,40 @@ def test_get_id_falls_back_to_the_static_identification_when_the_callback_declin
 
     assert raw_data[0] == 0xFF
     assert u32_from_array(bytearray(raw_data[4:8]), 'LITTLE_ENDIAN') == len('/path/to/xcp.a2l')
+
+
+def test_get_id_takes_nothing_a_declining_callback_wrote_into_the_static_fallback():
+    """DD110 and DD75 together. E_NOT_OK promises nothing about the out-parameters, and this
+    callback writes all three before declining type 0 -- its own buffer, extension 5 and length 4.
+    The configured string is the fallback, and the response and the MTA must both be entirely its
+    own: its length, its address, and extension 0, DD75's value for plain slave-owned descriptive
+    data. Nothing the declining callback wrote may survive into either.
+
+    The decline path resets only the length (DD113), so for type 0 the fallback's own assignments
+    are all that stand between the callback's pair and the MTA. The address and the length are
+    assigned there unconditionally; this is the test that notices if the extension assignment goes.
+    SET_MTA sets extension 7 first, so a leak names its source: 5 is the callback's, 7 the earlier
+    SET_MTA's.
+    """
+    handle = XcpTest(DefaultConfig(**_CALLBACK_CONFIG))
+    _connect(handle)
+    _serve(handle, b'abcd', extension=_CALLBACK_EXTENSION, result='E_NOT_OK')
+    _set_mta(handle, (0xEF, 0xBE, 0xAD, 0xDE), extension=0x07)
+
+    raw_data = _get_id(handle, 0x00)
+
+    assert raw_data[0] == 0xFF
+    assert u32_from_array(bytearray(raw_data[4:8]), 'LITTLE_ENDIAN') == len('/path/to/xcp.a2l'), \
+        "the configured string's length, not the 4 the declining callback wrote"
+
+    reads = _upload_addresses(handle, 0x01)
+
+    identification = int(handle.ffi.cast('uintptr_t',
+                                         handle.config.lib.Xcp[0].general.identification))
+    assert reads, 'UPLOAD read no memory at all'
+    assert reads[0] == (identification, 0x00), \
+        'UPLOAD read through (0x{:X}, {}) -- expected the configured string at 0x{:X}, ' \
+        'extension 0'.format(reads[0][0], reads[0][1], identification)
 
 
 @pytest.mark.parametrize('identification_type', (0x01, 0x04, 0x80, 0xFF))
@@ -376,14 +479,14 @@ def test_get_id_accepts_a_callback_length_that_is_a_multiple_of_the_granularity(
 
 
 def test_get_id_does_not_fall_back_to_the_static_identification_when_type_zeros_callback_length_is_not_granular():
-    """The ordering hazard the runtime check above must not fall into. `served` starts TRUE for a
-    type-0 callback that answers E_OK, and the granularity check sets it back to FALSE on a
-    non-conforming length. If that check ran BEFORE the static-fallback block instead of after it,
-    the now-FALSE `served` together with identification_type == XCP_GET_ID_TYPE_ASCII is exactly
-    the condition that triggers the fallback -- so the response would silently carry the configured
-    string (a conforming, non-zero length) instead of the Length = 0 DET just reported. A callback
-    that answered E_OK has claimed type 0, and substituting different data for a length it got
-    wrong would hide the very defect DET is reporting.
+    """A type-0 callback that answered E_OK has claimed the type, so when its length is refused the
+    response is Length = 0 -- never the configured string. The hazard this pins is ordering and
+    state together: `served` is TRUE for such a callback, and served == FALSE together with
+    identification_type == XCP_GET_ID_TYPE_ASCII is exactly the static fallback's condition. A
+    granularity check that marked the refused request unserved and ran before the fallback block
+    would hand type 0 to the configured string, and the response would silently carry its
+    conforming, non-zero length instead of the Length = 0 DET just reported -- hiding the very
+    defect DET is reporting.
 
     The default configured string ('/path/to/xcp.a2l', 16 bytes) is itself WORD/DWORD-conforming,
     so if this test ever starts observing that length instead of 0, the cause is the fallback firing,

--- a/test/get_id_test.py
+++ b/test/get_id_test.py
@@ -44,8 +44,10 @@ def test_get_id_returns_identification_through_mta_when_mode_is_0(byte_order,
     # makes this byte a bit mask -- TRANSFER_MODE at bit 0, COMPRESSED_ENCRYPTED at bit 1, bits 2-7
     # don't-care. 1.0/1.6.1.2.2 has the same byte and leaves it unnamed, which is why this was
     # previously read as an echo of the request's Requested Identification Type. It is not one:
-    # request byte 1 and response byte 1 are different fields that both happen to be 0 here, so the
-    # old `assert raw_data[1] == mode` passed under every possible implementation.
+    # request byte 1 and response byte 1 are different fields that both happen to be 0 here. The
+    # old `assert raw_data[1] == mode` pinned the right value only because this test's parametrize
+    # list has one row at zero; it would demand a wrong thing -- that the response echo the
+    # request -- as soon as a second identification type is covered.
     # Both bits clear: the slave transfers through the MTA and does not compress (DD111).
     assert raw_data[1] & 0x01 == 0x00, 'TRANSFER_MODE must be clear: this slave points the MTA'
     assert raw_data[1] & 0x02 == 0x00, 'COMPRESSED_ENCRYPTED must be clear: nothing is compressed'

--- a/test/get_id_test.py
+++ b/test/get_id_test.py
@@ -136,8 +136,11 @@ def test_get_id_rejects_a_type_the_specification_does_not_define(identification_
 
 
 def _set_mta(handle, address_bytes, extension=0x00):
-    """SET_MTA. Copy the exact framing from test/session_teardown_test.py, which already issues a
-    SET_MTA(0xDEADBEEF) for the neighbouring DD75 case -- do not reconstruct the byte order here."""
+    """Issue SET_MTA (0xF6), process it, and confirm the response frame's transmission. The frame
+    is two reserved bytes, the address extension, then the four address bytes exactly as given --
+    already in the configured byte order, so (0xEF, 0xBE, 0xAD, 0xDE) is 0xDEADBEEF under
+    DefaultConfig's LITTLE_ENDIAN default. The same framing as set_mta_with_extension in
+    test/session_teardown_test.py."""
     handle.lib.Xcp_CanIfRxIndication(0x0001, handle.get_pdu_info(
         (0xF6, 0x00, 0x00, extension) + address_bytes))
     handle.lib.Xcp_MainFunction()
@@ -256,7 +259,8 @@ def test_an_upload_with_no_intervening_get_id_still_reads_the_set_mta_address(co
     and the same UPLOAD, with no GET_ID between them. If a row here fails, the (NULL, 0) its route
     asserts above proves nothing. Per route rather than once, because the configurations differ
     where it matters: route (iii)'s WORD granularity reads through a different
-    Xcp_ReadSlaveMemory* function than the others."""
+    Xcp_ReadSlaveMemory* function than the others. Exact, not merely non-NULL: the pair UPLOAD
+    reads must be the one SET_MTA just set, address and extension alike."""
     handle = XcpTest(DefaultConfig(**config))
     _connect(handle)
     _set_mta(handle, (0xEF, 0xBE, 0xAD, 0xDE), extension=0x07)
@@ -264,8 +268,9 @@ def test_an_upload_with_no_intervening_get_id_still_reads_the_set_mta_address(co
     reads = _upload_addresses(handle, 0x01)
 
     assert reads, 'setup: UPLOAD must read memory'
-    assert reads[0][0] != 0, \
-        'setup: UPLOAD must reach the address SET_MTA just set, or the paired test is vacuous'
+    assert reads[0] == (0xDEADBEEF, 0x07), \
+        'setup: UPLOAD read through (0x{:X}, {}), not the (0xDEADBEEF, 7) SET_MTA just set -- ' \
+        'without that pair the paired test is vacuous'.format(*reads[0])
 
 
 def _serve(handle, payload, extension=0x00, result='E_OK'):
@@ -419,7 +424,12 @@ def test_get_id_does_not_consult_the_callback_for_an_undefined_type(identificati
     handle.xcp_get_identification_function.assert_not_called()
 
 
-@pytest.mark.parametrize('address_granularity, length', (('WORD', 3), ('DWORD', 5), ('DWORD', 7)))
+@pytest.mark.parametrize('address_granularity, length', (
+    ('WORD', 3),
+    ('DWORD', 5),
+    ('DWORD', 6),   # even, yet not a multiple of 4: WORD accepts this same length, below
+    ('DWORD', 7),
+))
 def test_get_id_refuses_a_callback_length_that_is_not_a_multiple_of_the_granularity(
         address_granularity, length):
     """DD112's runtime half. XCP part 2 1.1/1.6.1.2.2's "Length mod AG = 0" protects the UPLOAD that
@@ -462,7 +472,12 @@ def test_get_id_refuses_a_callback_length_that_is_not_a_multiple_of_the_granular
         'a non-conforming length must be reported as unavailable, not emitted'
 
 
-@pytest.mark.parametrize('address_granularity, length', (('BYTE', 3), ('WORD', 4), ('DWORD', 8)))
+@pytest.mark.parametrize('address_granularity, length', (
+    ('BYTE', 3),
+    ('WORD', 4),
+    ('WORD', 6),    # the WORD/DWORD boundary: DWORD refuses this same length, above
+    ('DWORD', 8),
+))
 def test_get_id_accepts_a_callback_length_that_is_a_multiple_of_the_granularity(
         address_granularity, length):
     """The boundary above from the accepting side, including BYTE, where the rule is vacuous:

--- a/test/get_id_test.py
+++ b/test/get_id_test.py
@@ -412,3 +412,37 @@ def test_get_id_does_not_fall_back_to_the_static_identification_when_type_zeros_
     assert raw_data[0] == 0xFF
     assert u32_from_array(bytearray(raw_data[4:8]), 'LITTLE_ENDIAN') == 0, \
         'a callback that claimed type 0 with a bad length must not fall back to the configured string'
+
+
+@pytest.mark.parametrize('identification', (
+    pytest.param('D:\\temp\\new1.a2l', id='backslashes C reads as escapes'),   # 16 characters
+    pytest.param('c:\\database\\test.a2l', id='1.1 example 2'),               # 20 characters
+    pytest.param('/path/to/"x".a2l', id='double quotes'),                      # 16 characters
+))
+def test_get_id_reports_a_configured_identification_needing_c_escapes_at_its_own_length(
+        identification):
+    """DD112's generation half counts the configured string's characters; GET_ID reports the
+    compiled C string's bytes. This is where the two are shown to agree. The generator pastes the
+    identification into a C string literal, so a backslash or double quote in it must be escaped
+    there. Unescaped, C reads D:\\temp\\new1.a2l's \\t and \\n as a tab and a line feed and
+    compiles its 16 characters to 14 bytes -- a Length that violates the Length mod AG = 0 the
+    generator had just accepted, with no DET, because the run-time check covers only callback
+    lengths. c:\\database\\test.a2l is XCP part 2 1.1/1.6.1.2.2's own second example.
+
+    DWORD, the strictest granularity: every row is a multiple of 4 characters, so the generator
+    accepts each one, and the Length on the wire must be that same number. The generated string's
+    content is checked as well, so an escape that doubled a character instead of preserving it
+    fails here too.
+    """
+    handle = XcpTest(DefaultConfig(channel_rx_pdu_ref=0x0001,
+                                   address_granularity='DWORD',
+                                   identification=identification))
+    _connect(handle)
+
+    raw_data = _get_id(handle, 0x00)
+
+    assert raw_data[0] == 0xFF
+    assert u32_from_array(bytearray(raw_data[4:8]), 'LITTLE_ENDIAN') == len(identification), \
+        'GET_ID must report the configured identification at the length the generator checked'
+    assert handle.ffi.string(handle.config.lib.Xcp[0].general.identification) == \
+        identification.encode('ascii'), 'the generated C literal must compile to the configured string'

--- a/test/get_id_test.py
+++ b/test/get_id_test.py
@@ -40,8 +40,16 @@ def test_get_id_returns_identification_through_mta_when_mode_is_0(byte_order,
     # check packet ID.
     assert raw_data[0] == 0xFF
 
-    # check Mode.
-    assert raw_data[1] == mode
+    # check the response Mode bit mask. XCP part 2 - Protocol Layer Specification 1.1/1.6.1.2.2
+    # makes this byte a bit mask -- TRANSFER_MODE at bit 0, COMPRESSED_ENCRYPTED at bit 1, bits 2-7
+    # don't-care. 1.0/1.6.1.2.2 has the same byte and leaves it unnamed, which is why this was
+    # previously read as an echo of the request's Requested Identification Type. It is not one:
+    # request byte 1 and response byte 1 are different fields that both happen to be 0 here, so the
+    # old `assert raw_data[1] == mode` passed under every possible implementation.
+    # Both bits clear: the slave transfers through the MTA and does not compress (DD111).
+    assert raw_data[1] & 0x01 == 0x00, 'TRANSFER_MODE must be clear: this slave points the MTA'
+    assert raw_data[1] & 0x02 == 0x00, 'COMPRESSED_ENCRYPTED must be clear: nothing is compressed'
+    assert raw_data[1] == 0x00, 'no reserved bit of the Mode mask may be set'
 
     # check reserved bytes.
     assert raw_data[2] == 0x00

--- a/test/get_id_test.py
+++ b/test/get_id_test.py
@@ -195,3 +195,121 @@ def test_an_upload_with_no_intervening_get_id_still_reads_the_set_mta_address():
     assert addresses, 'setup: UPLOAD must read memory'
     assert addresses[0] != handle.ffi.NULL, \
         'setup: UPLOAD must reach the address SET_MTA just set, or the paired test is vacuous'
+
+
+_CALLBACK_CONFIG = dict(channel_rx_pdu_ref=0x0001,
+                        get_id_function='Xcp_GetIdentificationFunction')
+
+
+def _serve(handle, payload, extension=0x00):
+    """Make the configured callback answer `payload` for every type, and keep the buffer alive.
+
+    Allocated and cast through handle.config.ffi, not the bare handle.ffi (== handle.code.ffi):
+    Xcp_GetIdentificationFunction's own extern is declared and registered on handle.config.ffi
+    (Xcp_Cfg.c is what takes &Xcp_GetIdentificationFunction, the same reason
+    Xcp_UserCmdFunction/Xcp_UserDefinedChecksumFunction are registered there rather than through
+    the generic self.code.mocked loop), so the pointer and cast that flow through its
+    const void ** out-parameter are kept on that same ffi rather than relying on code.ffi and
+    config.ffi's independently-registered types happening to agree.
+    """
+    buffer = handle.config.ffi.new('char[]', payload)
+    handle._pdu_info_keepalive.append(buffer)
+
+    def get_identification(_type, p_identification, p_extension, p_length):
+        p_identification[0] = handle.config.ffi.cast('void *', buffer)
+        p_extension[0] = extension
+        p_length[0] = len(payload)
+        return handle.define('E_OK')
+
+    handle.xcp_get_identification_function.side_effect = get_identification
+    return buffer
+
+
+@pytest.mark.parametrize('byte_order', byte_orders)
+@pytest.mark.parametrize('identification_type', (0x00, 0x01, 0x02, 0x03, 0x04, 0x80, 0xFF))
+def test_get_id_serves_every_defined_type_from_the_callback(byte_order, identification_type):
+    """DD108. Types 1-3 are strings an integrator could put in xcp.json, but type 4 is
+    "ASAM-MC2 file to upload" (1.1/1.6.1.2.2) -- a whole A2L file whose contents are not known when
+    the configuration is generated -- and 128..255 is an open user-defined range a fixed table
+    cannot enumerate. So identification data comes from a callback."""
+    handle = XcpTest(DefaultConfig(byte_order=byte_order, **_CALLBACK_CONFIG))
+    _connect(handle)
+    _serve(handle, b'abcd')
+
+    raw_data = _get_id(handle, identification_type)
+
+    assert raw_data[0] == 0xFF
+    assert u32_from_array(bytearray(raw_data[4:8]), byte_order) == 4
+    assert handle.xcp_get_identification_function.call_args[0][0] == identification_type, \
+        'the callback must be told which type was requested'
+
+
+def test_get_id_points_the_mta_at_the_callbacks_address_and_extension():
+    """DD109. DD75 fixed extension = 0 for the *static* identification, on the ground that it is
+    "plain, slave-owned descriptive data that lives entirely outside the page-switching model" --
+    an argument about Xcp_Ptr->general->identification that does not transfer to arbitrary
+    integrator data. Type 4 is the case that breaks it: an A2L file plausibly lives in memory the
+    integrator's Xcp_ReadSlaveMemory* reaches through a non-zero extension. Fixing the extension at
+    0 would advertise type 4 while only being able to serve it from extension-0 memory."""
+    handle = XcpTest(DefaultConfig(**_CALLBACK_CONFIG))
+    _connect(handle)
+    buffer = _serve(handle, b'wxyz', extension=0x07)
+
+    _get_id(handle, 0x04)
+
+    reads = []
+    handle.xcp_read_slave_memory_u8.side_effect = lambda p_address, extension, _p_buffer: \
+        reads.append((int(handle.ffi.cast('uintptr_t', p_address)), extension))
+
+    handle.lib.Xcp_CanIfRxIndication(0x0001, handle.get_pdu_info((0xF5, 0x04)))
+    handle.lib.Xcp_MainFunction()
+
+    assert reads, 'UPLOAD did not read any memory'
+    assert reads[0] == (int(handle.ffi.cast('uintptr_t', buffer)), 0x07), \
+        'UPLOAD read {} -- expected the callback\'s own address and extension 7'.format(reads[0])
+
+
+def test_get_id_falls_back_to_the_static_identification_when_the_callback_declines_type_zero():
+    """DD110. The callback is consulted for every defined type including 0, and E_NOT_OK means
+    "I do not serve that type" rather than an error. For type 0 the configured string is the
+    fallback, so an integrator who only wants types 1-4 returns E_NOT_OK for 0 and still gets the
+    behaviour that shipped before this phase."""
+    handle = XcpTest(DefaultConfig(identification='/path/to/xcp.a2l', **_CALLBACK_CONFIG))
+    _connect(handle)
+    handle.xcp_get_identification_function.side_effect = None
+    handle.xcp_get_identification_function.return_value = handle.define('E_NOT_OK')
+
+    raw_data = _get_id(handle, 0x00)
+
+    assert raw_data[0] == 0xFF
+    assert u32_from_array(bytearray(raw_data[4:8]), 'LITTLE_ENDIAN') == len('/path/to/xcp.a2l')
+
+
+@pytest.mark.parametrize('identification_type', (0x01, 0x04, 0x80, 0xFF))
+def test_get_id_reports_length_zero_when_the_callback_declines_a_non_ascii_type(
+        identification_type):
+    """The other half of the fallback: only type 0 has a static string behind it, so a declined
+    type 1-4 or 128-255 is simply not available -- Length = 0, per 1.1/1.6.1.2.2. DD110."""
+    handle = XcpTest(DefaultConfig(**_CALLBACK_CONFIG))
+    _connect(handle)
+    handle.xcp_get_identification_function.side_effect = None
+    handle.xcp_get_identification_function.return_value = handle.define('E_NOT_OK')
+
+    raw_data = _get_id(handle, identification_type)
+
+    assert raw_data[0] == 0xFF
+    assert u32_from_array(bytearray(raw_data[4:8]), 'LITTLE_ENDIAN') == 0
+
+
+@pytest.mark.parametrize('identification_type', (0x05, 0x7F))
+def test_get_id_does_not_consult_the_callback_for_an_undefined_type(identification_type):
+    """5..127 are refused before the callback is reached: they name no identification type at all,
+    so there is nothing for an integrator to be asked about. DD110."""
+    handle = XcpTest(DefaultConfig(**_CALLBACK_CONFIG))
+    _connect(handle)
+    _serve(handle, b'abcd')
+
+    raw_data = _get_id(handle, identification_type)
+
+    assert raw_data[0:2] == (0xFE, 0x22)
+    handle.xcp_get_identification_function.assert_not_called()

--- a/test/get_id_test.py
+++ b/test/get_id_test.py
@@ -225,7 +225,7 @@ def test_a_length_zero_get_id_does_not_leave_an_earlier_set_mta_standing(config,
     then declines; (iii) the callback's length is refused as not a multiple of the granularity;
     (iv) the callback answers E_OK with a length of 0; (v) the configured string is empty. Routes
     (ii) to (v) all reach Length = 0 holding a live address -- the callback's own, or the empty
-    string's -- which is what (i), the only route this test used to take, could never show.
+    string's -- which route (i), holding none, cannot show on its own.
 
     SET_MTA sets extension 7 first, and the callback writes extension 5, so a pair that leaks names
     its source. Paired with a positive control per route below: "UPLOAD read (NULL, 0)" is vacuous

--- a/test/get_id_test.py
+++ b/test/get_id_test.py
@@ -336,15 +336,27 @@ def test_get_id_refuses_a_callback_length_that_is_not_a_multiple_of_the_granular
     # the wrong one -- passing or failing for a reason that has nothing to do with GET_ID.
     handle.det_report_error.reset_mock()
 
-    raw_data = _get_id(handle, 0x01)
+    # Delivered inline, not through _get_id: the command table's one dispatch site
+    # (source/Xcp.c:2161, `Xcp_PIDTable[pid](...)`) is reached only from Xcp_CanIfRxIndication, so
+    # Xcp_DTOCmdStdGetId -- and the DET it raises -- runs during this call, never during
+    # Xcp_MainFunction. Asserting that here, before Xcp_MainFunction runs at all, grounds the
+    # expected API id in the test's own action instead of in a constant copied from the
+    # implementation: the error fires during the call just made, so it must name that call. This is
+    # what lets this assertion catch a wrong API id, which asserting only after Xcp_MainFunction (as
+    # before) never could.
+    handle.lib.Xcp_CanIfRxIndication(0x0001, handle.get_pdu_info((0xFA, 0x01)))
+    handle.det_report_error.assert_called_once_with(
+        ANY, ANY,
+        handle.define('XCP_CAN_IF_RX_INDICATION_API_ID'),
+        handle.define('XCP_E_IDENTIFICATION_NOT_GRANULAR'))
+
+    handle.lib.Xcp_MainFunction()
+    raw_data = tuple(handle.can_if_transmit.call_args[0][1].SduDataPtr[0:8])
+    handle.lib.Xcp_CanIfTxConfirmation(0x0001, handle.define('E_OK'))
 
     assert raw_data[0] == 0xFF, 'still a positive response'
     assert u32_from_array(bytearray(raw_data[4:8]), 'LITTLE_ENDIAN') == 0, \
         'a non-conforming length must be reported as unavailable, not emitted'
-    handle.det_report_error.assert_called_once_with(
-        ANY, ANY,
-        handle.define('XCP_MAIN_FUNCTION_API_ID'),
-        handle.define('XCP_E_IDENTIFICATION_NOT_GRANULAR'))
 
 
 @pytest.mark.parametrize('address_granularity, length', (('BYTE', 3), ('WORD', 4), ('DWORD', 8)))
@@ -382,12 +394,21 @@ def test_get_id_does_not_fall_back_to_the_static_identification_when_type_zeros_
     _serve(handle, b'x' * 3)   # 3 is not a multiple of WORD's 2-byte element size
     handle.det_report_error.reset_mock()
 
-    raw_data = _get_id(handle, 0x00)   # XCP_GET_ID_TYPE_ASCII -- the only type with a static fallback
+    # Same ordering argument as the refusing-a-non-granular-length test above: Xcp_DTOCmdStdGetId,
+    # and the DET it raises, run inside Xcp_CanIfRxIndication, never inside Xcp_MainFunction, so
+    # this is checked before Xcp_MainFunction runs -- grounding the expected API id in this test's
+    # own action rather than in a constant copied from the plan.
+    # XCP_GET_ID_TYPE_ASCII -- the only type with a static fallback.
+    handle.lib.Xcp_CanIfRxIndication(0x0001, handle.get_pdu_info((0xFA, 0x00)))
+    handle.det_report_error.assert_called_once_with(
+        ANY, ANY,
+        handle.define('XCP_CAN_IF_RX_INDICATION_API_ID'),
+        handle.define('XCP_E_IDENTIFICATION_NOT_GRANULAR'))
+
+    handle.lib.Xcp_MainFunction()
+    raw_data = tuple(handle.can_if_transmit.call_args[0][1].SduDataPtr[0:8])
+    handle.lib.Xcp_CanIfTxConfirmation(0x0001, handle.define('E_OK'))
 
     assert raw_data[0] == 0xFF
     assert u32_from_array(bytearray(raw_data[4:8]), 'LITTLE_ENDIAN') == 0, \
         'a callback that claimed type 0 with a bad length must not fall back to the configured string'
-    handle.det_report_error.assert_called_once_with(
-        ANY, ANY,
-        handle.define('XCP_MAIN_FUNCTION_API_ID'),
-        handle.define('XCP_E_IDENTIFICATION_NOT_GRANULAR'))

--- a/test/get_id_test.py
+++ b/test/get_id_test.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import math
+from unittest.mock import ANY
 
 from .parameter import *
 from .conftest import XcpTest
@@ -313,3 +314,80 @@ def test_get_id_does_not_consult_the_callback_for_an_undefined_type(identificati
 
     assert raw_data[0:2] == (0xFE, 0x22)
     handle.xcp_get_identification_function.assert_not_called()
+
+
+@pytest.mark.parametrize('address_granularity, length', (('WORD', 3), ('DWORD', 5), ('DWORD', 7)))
+def test_get_id_refuses_a_callback_length_that_is_not_a_multiple_of_the_granularity(
+        address_granularity, length):
+    """DD112's runtime half. XCP part 2 1.1/1.6.1.2.2's "Length mod AG = 0" protects the UPLOAD that
+    follows, whose element count 1.1 defines as (Length GET_ID [BYTE]) / AG. The configured string
+    is checked at generation time; a callback's length is not knowable then.
+
+    The module cannot emit a non-conforming Length, and reporting the type unavailable is the honest
+    alternative to truncating the data or padding it with the NULs 1.1 explicitly says the string
+    does not carry. The integrator hears about it through DET, which is the only channel available:
+    the master is simply told the type is not there.
+    """
+    handle = XcpTest(DefaultConfig(address_granularity=address_granularity, **_CALLBACK_CONFIG))
+    _connect(handle)
+    _serve(handle, b'x' * length)
+    # Everything asserted below is about GET_ID alone. Without this, a DET raised by CONNECT or by
+    # construction would be the call assert_called_once_with inspects, and the test would report on
+    # the wrong one -- passing or failing for a reason that has nothing to do with GET_ID.
+    handle.det_report_error.reset_mock()
+
+    raw_data = _get_id(handle, 0x01)
+
+    assert raw_data[0] == 0xFF, 'still a positive response'
+    assert u32_from_array(bytearray(raw_data[4:8]), 'LITTLE_ENDIAN') == 0, \
+        'a non-conforming length must be reported as unavailable, not emitted'
+    handle.det_report_error.assert_called_once_with(
+        ANY, ANY,
+        handle.define('XCP_MAIN_FUNCTION_API_ID'),
+        handle.define('XCP_E_IDENTIFICATION_NOT_GRANULAR'))
+
+
+@pytest.mark.parametrize('address_granularity, length', (('BYTE', 3), ('WORD', 4), ('DWORD', 8)))
+def test_get_id_accepts_a_callback_length_that_is_a_multiple_of_the_granularity(
+        address_granularity, length):
+    """The boundary above from the accepting side, including BYTE, where the rule is vacuous:
+    every length is a multiple of 1, so no conforming configuration is ever refused by it."""
+    handle = XcpTest(DefaultConfig(address_granularity=address_granularity, **_CALLBACK_CONFIG))
+    _connect(handle)
+    _serve(handle, b'x' * length)
+    handle.det_report_error.reset_mock()   # same reason as the test above
+
+    raw_data = _get_id(handle, 0x01)
+
+    assert u32_from_array(bytearray(raw_data[4:8]), 'LITTLE_ENDIAN') == length
+    handle.det_report_error.assert_not_called()
+
+
+def test_get_id_does_not_fall_back_to_the_static_identification_when_type_zeros_callback_length_is_not_granular():
+    """The ordering hazard the runtime check above must not fall into. `served` starts TRUE for a
+    type-0 callback that answers E_OK, and the granularity check sets it back to FALSE on a
+    non-conforming length. If that check ran BEFORE the static-fallback block instead of after it,
+    the now-FALSE `served` together with identification_type == XCP_GET_ID_TYPE_ASCII is exactly
+    the condition that triggers the fallback -- so the response would silently carry the configured
+    string (a conforming, non-zero length) instead of the Length = 0 DET just reported. A callback
+    that answered E_OK has claimed type 0, and substituting different data for a length it got
+    wrong would hide the very defect DET is reporting.
+
+    The default configured string ('/path/to/xcp.a2l', 16 bytes) is itself WORD/DWORD-conforming,
+    so if this test ever starts observing that length instead of 0, the cause is the fallback firing,
+    not a coincidental failure of the static string's own generation-time check. DD112.
+    """
+    handle = XcpTest(DefaultConfig(address_granularity='WORD', **_CALLBACK_CONFIG))
+    _connect(handle)
+    _serve(handle, b'x' * 3)   # 3 is not a multiple of WORD's 2-byte element size
+    handle.det_report_error.reset_mock()
+
+    raw_data = _get_id(handle, 0x00)   # XCP_GET_ID_TYPE_ASCII -- the only type with a static fallback
+
+    assert raw_data[0] == 0xFF
+    assert u32_from_array(bytearray(raw_data[4:8]), 'LITTLE_ENDIAN') == 0, \
+        'a callback that claimed type 0 with a bad length must not fall back to the configured string'
+    handle.det_report_error.assert_called_once_with(
+        ANY, ANY,
+        handle.define('XCP_MAIN_FUNCTION_API_ID'),
+        handle.define('XCP_E_IDENTIFICATION_NOT_GRANULAR'))

--- a/test/parameter.py
+++ b/test/parameter.py
@@ -391,6 +391,7 @@ class DefaultConfig(dict):
                  checksum_type='XCP_CRC_32',
                  user_defined_checksum_function='Xcp_UserDefinedChecksumFunction',
                  user_cmd_function='Xcp_UserCmdFunction',
+                 get_id_function=None,
                  trailing_value=0,
                  identification='/path/to/xcp.a2l',
                  timestamp=None):
@@ -417,6 +418,7 @@ class DefaultConfig(dict):
             "checksum_type": checksum_type,
             "user_defined_checksum_function": user_defined_checksum_function,
             "user_cmd_function": user_cmd_function,
+            "get_id_function": get_id_function,
             "trailing_value": trailing_value,
             'identification': identification,
             "daq_config_type": daq_config_type

--- a/test/parameter.py
+++ b/test/parameter.py
@@ -392,7 +392,7 @@ class DefaultConfig(dict):
                  user_defined_checksum_function='Xcp_UserDefinedChecksumFunction',
                  user_cmd_function='Xcp_UserCmdFunction',
                  trailing_value=0,
-                 identification='/path/to/database.a2l',
+                 identification='/path/to/xcp.a2l',
                  timestamp=None):
         self._channel_rx_pdu = channel_rx_pdu_ref
         self._channel_tx_pdu = channel_tx_pdu_ref

--- a/test/stub/Xcp_GetId.h
+++ b/test/stub/Xcp_GetId.h
@@ -1,0 +1,40 @@
+/**
+* @file Xcp_GetId.h
+* @author Guillaume Sottas
+* @date 11/09/2026
+*/
+
+#ifndef XCP_GET_ID_H
+#define XCP_GET_ID_H
+
+#ifdef __cplusplus
+
+extern "C" {
+
+#endif /* #ifdef __cplusplus */
+
+#include "Std_Types.h"
+
+/**
+ * @brief supplies GET_ID identification data for any identification type.
+ * @param identificationType the Requested Identification Type from the GET_ID request: 0..4 or
+ * 128..255 (XCP part 2 - Protocol Layer Specification 1.1/1.6.1.2.2). 5..127 are refused before
+ * this is called.
+ * @param pIdentification set to the address the master will UPLOAD the identification from.
+ * @param pExtension set to the MTA address extension that address is reached through.
+ * @param pLength set to the identification's length in bytes.
+ * @retval E_OK : all three out-parameters are set; the requested type is served.
+ * @retval E_NOT_OK : this slave does not serve the requested type. Not an error: it answers
+ * Length = 0.
+ */
+extern Std_ReturnType Xcp_GetIdentificationFunction(uint8 identificationType,
+                                                    const void **pIdentification,
+                                                    uint8 *pExtension,
+                                                    uint32 *pLength);
+
+#ifdef __cplusplus
+}
+
+#endif /* #ifdef __cplusplus */
+
+#endif /* #ifndef XCP_GET_ID_H */


### PR DESCRIPTION
**`GET_ID` now serves every identification type XCP 1.1 defines, 0–4 plus the user-defined 128–255,
through an optional integrator callback.** This completes the last small, well-defined item on SP5's
residue list.

**Design:** `docs/superpowers/specs/2026-09-11-xcp-get-id-types-design.md` (DD108–DD113).
**Plan:** `docs/superpowers/plans/2026-09-11-xcp-get-id-types.md`.

## What 1.1 changes that 1.0 didn't, read from the PDF rather than its OCR

1.0 leaves response byte 1 as an unnamed "Mode". 1.1 makes it a bit mask: `TRANSFER_MODE` is bit 0
and `COMPRESSED_ENCRYPTED`, new in 1.1, is bit 1. It is the same 1.0-to-1.1 mode-byte pattern that
cost three PRs on `SET_REQUEST`. 1.1 also adds `Length mod AG = 0`, and it defines the first UPLOAD's
element count as `Length / AG`.

The bit positions come from the 1.1 PDF's own text layer. The OCR sidecar misaligns table columns, so
it could not be trusted for them. The text layer is glyph-substituted; I recovered the substitution
from known-plaintext pairs, and the decoded prose and the table's column geometry agree
independently. The method is in §0 of the design doc.

## The shape

```c
Std_ReturnType (*const getIdentificationFunction)(uint8 identificationType,
                                                  const void **pIdentification,
                                                  uint8 *pExtension,
                                                  uint32 *pLength);
```

The callback is consulted for every defined type, type 0 included, and the configured
`identification` string is type 0's fallback. So with no callback configured, **type 0 is answered
exactly as before**. It also returns the MTA extension (DD109), because type 4 is a whole A2L file,
which may live in memory reached through a non-zero extension.

| Requested type | Answer |
|---|---|
| 5–127 | `ERR_OUT_OF_RANGE`. These are not identification types, and this keeps GET_ID's row in 1.1/§1.7.3.2.1 reachable (DD110). |
| 0–4, 128–255, served | Positive response: the MTA points at the data, and `Length` is its size. |
| 0–4, 128–255, not served | Positive response with `Length = 0`, 1.1's own way of saying "not available" (DD110). |

- **Every `Length = 0` response points the MTA at `(NULL_PTR, 0)` (DD113).** A master that uploads
  anyway reads through a pointer the slave deliberately nulled, not one left over from an unrelated
  `SET_MTA`.
- **`Length mod AG = 0` is enforced wherever each half of it can be checked (DD112).** Generation
  refuses a configured string that breaks the rule. A callback length that breaks it raises DET
  `XCP_E_IDENTIFICATION_NOT_GRANULAR` (`0x09`, reported under `XCP_CAN_IF_RX_INDICATION_API_ID`)
  and answers `Length = 0`.
- **`TRANSFER_MODE` stays 0 (DD111).** The request is two bytes, so the master has no way to ask for
  inline transfer. The slave chooses, and mode 0 is a complete answer.

## Defects found and fixed on the way

- **A test comparing two different fields.** `test_get_id_returns_identification_through_mta_when_mode_is_0`
  asserted `raw_data[1] == mode`: the response's Mode bit mask against the request's identification
  type. It pinned the right value only because its parametrize list held a single row, at mode 0.
- **A `Length mod AG = 0` violation already shipping.** The default identification was 21 bytes,
  an odd number, so every WORD or DWORD configuration reported a non-conforming Length. It is now
  `/path/to/xcp.a2l`, 16 bytes.
- **The generator counted characters where GET_ID reports bytes.** The whole-branch review found
  this one. The configured string was pasted raw into a C literal, so `D:\temp\new1.a2l` is 16
  characters but 14 bytes (`\t` and `\n` are escapes), and `/path/to/xcp.a2é` is 16 characters
  but 17 bytes. The string is now restricted to printable ASCII by both a schema pattern and a
  generator guard; the guard is needed because the test harness bypasses the schema. `\` and `"`
  are C-escaped, so every character is one byte. They are escaped rather than refused because type 0
  is "plain ASCII text", and refusing printable characters would narrow it below the specification.
- **A DET reported under the wrong API, with a test that could not catch it because it copied the
  same wrong constant.** Command handlers run inside `Xcp_CanIfRxIndication` (`source/Xcp.c:2161`),
  not `Xcp_MainFunction`. The tests now assert that the DET fires during the
  `Xcp_CanIfRxIndication` call itself.
- **`test/configuration_schema_test.py:79` never varied `identification_field_type`.** It passed
  the value to `identification=`. This one predates the branch and is fixed in its own commit.

## For integrators: what changes

- `protocol_layer.get_id_function` is a new **required** key. Add `"get_id_function": null` to
  existing `xcp.json` files, or the build's schema validation fails.
- `interface/Xcp.h` now includes `Xcp_GetId.h`. Supply it, as you already do `Xcp_UserCmd.h`.
- The default `identification` is now `/path/to/xcp.a2l`, and the configured string must be
  printable ASCII.
- A master probing a type the slave does not serve now gets `Length = 0` instead of
  `ERR_OUT_OF_RANGE`. Types 5–127 still get the error.
- There is a new DET error, `XCP_E_IDENTIFICATION_NOT_GRANULAR` (`0x09`).

## Deliberately not built

- **`TRANSFER_MODE = 1` (inline transfer).** The slave chooses the mode and is never obliged to use
  this one, and it is impossible anyway at `max_cto` 8. The bit positions are recorded for whoever
  builds it.
- **`COMPRESSED_ENCRYPTED`.** Its algorithm interface is defined in XCP Part 4, which is not in
  `docs/external`.

## Known residuals: flagged, not fixed

The final re-review found these. All are comment or documentation only, and none affects behaviour.

- **Four places give the wrong reason for escaping backslashes.** They cite 1.1's
  `c:\database\test.a2l` example, but that example illustrates *type 2*, which the callback serves
  and the template never emits. The true reason is the one given above. The four places are the
  comment at the identification initialiser, `config/xcp.schema.json`'s `identification`
  description, `test/configuration_schema_test.py:106` and `test/get_id_test.py:537`.
- `test/get_id_test.py:157`: `_upload_addresses`'s docstring is wrong about its third caller.
- `test/configuration_schema_test.py:111`: a time-bound phrase.
- `source/Xcp_Std.c:1384` says "live address", but an `E_OK` callback reporting length 0 may write
  NULL.
- The identification's schema pattern uses a lookahead, which RE2-based validators (Go, Rust) reject.
  `"not": {"pattern": "[^\\x20-\\x7E]"}` is equivalent and portable. This build validates with
  Python `jsonschema` and is unaffected.
- The printable-ASCII-plus-escaping decision is not yet recorded as a DD.
- Correction notes in the design doc and plan cite report files kept outside the repository. They
  would be better citing commits.

## Pre-existing issues surfaced, tracked separately

- **Trigraphs.** Strict ISO C before C23 replaces trigraph sequences, so `"/path/to/??=.a2l"` is 16
  bytes under gnu11 but 14 under `-std=c99`. This affects every string the templates emit.
- **Event names can carry a trailing newline.** The `events[].name` schema pattern ends in `$`, which
  under Python `re` also matches before a trailing newline. `jsonschema` therefore accepts `"name\n"`,
  and the newline lands inside a generated C literal.
- **`"OneOf"` is ignored.** Three schema entries use `"OneOf"` where JSON Schema's keyword is
  `oneOf`, so their allowed-name lists are never enforced. This branch's new entry copied the
  casing.
- **The module id may be wrong.** `XCP_MODULE_ID` is `0xFF`. AUTOSAR's BSW Module List would say
  whether it should be 212; this is unverified.
- **The test suite is flaky.** It fails intermittently with corrupted jinja2 or cffi internals on
  unrelated tests. Raising `ulimit -s` to 256 MB did not help, as recorded in `test.sh`.
  **If CI fails that way, re-run it.**

## Verification

- `12907 passed, 29 skipped` at HEAD, both ctest targets green, on the first attempt. The count
  started at 12962: narrowing `ERR_OUT_OF_RANGE` to types 5–127 removed 131 tests, and 76 new tests
  were added.
- Every behavioural claim was mutation-verified: the code was changed so that the test should fail,
  and the failure was observed.
- Each of the six tasks passed a task-scoped review. The branch then passed a whole-branch review
  and one scoped re-review of its fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
